### PR TITLE
Add product brief v0.5 from discovery session

### DIFF
--- a/product-brief.md
+++ b/product-brief.md
@@ -758,6 +758,7 @@ No fixed calendar deadline — but a fixed *scope*. The shape below is the ceili
 | **VS Code extension** | Post-v1. |
 | **Claude Code MCP server** | Post-v1. |
 | **Data export** | Post-v1. |
+| **Accessibility / i18n** | v1 is English-only; accessibility follows iOS/web platform defaults. |
 | **Haptic/audio feedback on device** | Device v1 is visual only (display + buttons). Buzzer for timer end is a maybe. |
 | **E-ink display** | Start with OLED (LILYGO T-Display S3). E-ink adds complexity for v1 prototype. |
 
@@ -802,6 +803,8 @@ v1 is done when 10-20 testers can:
 ## 13. Research Threads — Findings
 
 These threads were flagged during discovery as needing verification before finalizing the solution design. Findings below, with direct PomoFocus implications.
+
+**v1 relevance:** Threads 1 (commitment devices) and 7 (guilt-productivity cycle) directly validate the core thesis and should inform v1 design decisions. Threads 2 (goal salience) and 3 (environmental design) support the widget and device rationale. Threads 4 (habit timelines), 5 (screen time intervention), and 6 (Pomodoro efficacy) are useful background but won't change what gets built for v1.
 
 ---
 


### PR DESCRIPTION
## Summary

Full 4-phase product discovery session (`/discover` skill) producing a 1,000+ line `product-brief.md` (v0.6) that defines PomoFocus's product vision:

- **Phase 1 (Problem):** Intention-action gap + phone-as-dopamine-trap. Target user = "structure seekers." Core insight: portable structure, not a timer
- **Phase 2 (Solution Shape):** Device architecture (ESP32 + e-ink, BLE sync). Software is a complete standalone product; physical device is the premium layer. Three-tier experience model
- **Phase 3 (Opportunity Mapping):** Guilt spiral as primary intervention point. 3-layer goal model, session flow, onboarding (60s to first session), social features (accountability without comparison — no leaderboards ever), analytics/insights tiers, pricing (free local + paid cloud sync)
- **Phase 4 (Shaping):** v1 scope fixed to iOS + web + ESP32 device + social. Explicit no-go list (Android, Mac widget, VS Code, MCP, payments, a11y/i18n). 7 rabbit holes, 9-step de-risking build order, 6 success criteria
- **Research (post-discovery):** All 7 research threads filled with citations (Ariely, Gollwitzer, Ward, Lally, Sirois/Pychyl, Biwer, etc.) and "→ PomoFocus implication" lines. Findings propagated back into Sections 3, 6, 10, 11 as Research Note callouts. Competitive landscape expanded from 6 to 14 competitors across 5 categories plus design inspirations table
- Minor cleanup: removed code-reviewer agent, trimmed watchOS references from agents/templates, updated stack recommendations

## Files changed

- `product-brief.md` — **new** (1,000+ lines, the main deliverable)
- `.claude/agents/` — removed code-reviewer.md, updated ios-developer.md scope
- `.github/ISSUE_TEMPLATE/` — minor template cleanup
- `AGENTS.md`, `CLAUDE.md`, `GitHub-Agents.md` — minor reference updates
- `research/` — updated stack recommendations and README

## Test plan

- [ ] Read through `product-brief.md` and confirm it matches discovery session decisions
- [ ] Verify research threads have citations and implication lines
- [ ] Verify competitive landscape covers all major categories
- [ ] Confirm no unintended deletions in agent files or templates
- [ ] Check research README index still links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)