### PR TITLE
refactor(skills): rename /fix-issue to /ship-issue

### DIFF
--- a/.claude/docs/agent-ready-issues.md
+++ b/.claude/docs/agent-ready-issues.md
@@ -242,7 +242,7 @@ This doc builds on `research/02-github-for-agents.md` which defines:
 - Issue template YAML files (feature-agent.yml, bug-agent.yml)
 - 8 writing rules for agent-ready tickets
 - Label strategy (agent-ready, needs-human, effort:small/large, etc.)
-- `/fix-issue` and `/decompose-issue` skill specs
+- `/ship-issue` and `/decompose-issue` skill specs
 - Platform subagent configurations
 
 What this doc adds:

--- a/.claude/docs/clarification-protocol.md
+++ b/.claude/docs/clarification-protocol.md
@@ -88,7 +88,7 @@ Writes a spec to `.claude/specs/YYYY-MM-DD-<goal>.md`, asks for user confirmatio
 Specs are persisted in `.claude/specs/` and committed to git. They serve as:
 - Implementation contracts for agent sessions
 - Audit trail for what was intended vs. what was built
-- Input for future `/fix-issue` skill sessions
+- Input for future `/ship-issue` skill sessions
 
 ---
 

--- a/.claude/docs/claude-code-advanced.md
+++ b/.claude/docs/claude-code-advanced.md
@@ -371,7 +371,7 @@ claude --permission-mode plan
 
 ### Pattern 4: Skills as Team Workflows
 ```bash
-/fix-issue 123       # Fix a GitHub issue by number
+/ship-issue 123       # Fix a GitHub issue by number
 /deploy production   # Deploy with all checks
 /pr-review           # Review and suggest improvements
 ```

--- a/.claude/skills/decompose-issue/SKILL.md
+++ b/.claude/skills/decompose-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: decompose-issue
-description: Break a large GitHub issue (labeled effort:large) into 3-5 smaller, agent-ready sub-issues using the data→logic→UI split pattern. Called automatically by /fix-issue when effort:large is detected, or invoked directly. Creates each sub-issue with full agent-ready fields, comments a tracking task list on the parent, and relabels the parent as decomposed.
+description: Break a large GitHub issue (labeled effort:large) into 3-5 smaller, agent-ready sub-issues using the data→logic→UI split pattern. Called automatically by /ship-issue when effort:large is detected, or invoked directly. Creates each sub-issue with full agent-ready fields, comments a tracking task list on the parent, and relabels the parent as decomposed.
 user-invocable: true
 allowed-tools: Bash(gh *), Bash(git *), Bash(pnpm *), Read, Grep, Glob
 argument-hint: "[issue number]"
@@ -103,7 +103,7 @@ This issue has been broken into smaller, agent-ready pieces:
 
 **Implementation order:** #[sub1] → #[sub2] → #[sub3]
 
-Each sub-issue is labeled \`agent-ready\` and can be picked up with \`/fix-issue N\`.
+Each sub-issue is labeled \`agent-ready\` and can be picked up with \`/ship-issue N\`.
 This issue will be closed manually when all sub-issues are merged.
 EOF
 )"

--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: fix-issue
+name: ship-issue
 description: Pick up a GitHub issue by number. If effort:large, decomposes it into sub-issues instead of implementing. If needs-human, comments a blocker and stops. Otherwise: creates a branch, reads affected files, implements, and runs tests until all pass. Calls /finalize when done — does not manage the PR or labels directly.
 user-invocable: true
 context: fork

--- a/.github/ISSUE_TEMPLATE/feature-agent.yml
+++ b/.github/ISSUE_TEMPLATE/feature-agent.yml
@@ -98,7 +98,7 @@ body:
     id: effort
     attributes:
       label: Effort Estimate
-      description: "effort:large issues will be auto-decomposed into sub-issues by /fix-issue."
+      description: "effort:large issues will be auto-decomposed into sub-issues by /ship-issue."
       options:
         - "effort:small (< 1 hour, < 10 files, implement directly)"
         - "effort:large (decompose into sub-issues first)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ pomofocus/
 │   └── workflows/            # CI/CD (Nx affected + platform-specific)
 ├── .claude/
 │   ├── agents/               # Platform subagent definitions
-│   ├── skills/               # /fix-issue, /decompose-issue, /clarify
+│   ├── skills/               # /ship-issue, /decompose-issue, /clarify
 │   ├── hooks/                # UserPromptSubmit ambiguity check
 │   └── specs/                # Written specs from /clarify sessions
 ├── AGENTS.md                 # This file — cross-agent context
@@ -180,7 +180,7 @@ PR body must include: Closes #42
 
 ## Workflow Summary
 
-1. Pick up a GitHub Issue labeled `agent-ready` (or run `/fix-issue N`)
+1. Pick up a GitHub Issue labeled `agent-ready` (or run `/ship-issue N`)
 2. If labeled `effort:large` → run `/decompose-issue N` instead, stop
 3. Create branch: `feature/issue-N-<slug>`
 4. Read all files in the issue's "Affected Files" section

--- a/GitHub-Agents.md
+++ b/GitHub-Agents.md
@@ -31,7 +31,7 @@
 ```
 GitHub Issue (labeled "agent-ready")
          ↓
-/fix-issue N  (Claude Code session)
+/ship-issue N  (Claude Code session)
          ↓
 Read issue → check effort:large → if yes: /decompose-issue N, stop
          ↓ (issue is effort:small or unlabeled)
@@ -57,7 +57,7 @@ Human reviews and merges
 
 ```bash
 # Pick up an issue
-/fix-issue 42
+/ship-issue 42
 
 # Decompose a large issue into sub-issues
 /decompose-issue 42
@@ -209,7 +209,7 @@ Do NOT change the TimerState interface in `packages/core/src/types.ts`.
 iOS only
 ```
 
-This ticket can be executed with `/fix-issue 42` without a single follow-up question.
+This ticket can be executed with `/ship-issue 42` without a single follow-up question.
 
 ---
 
@@ -241,7 +241,7 @@ Created (draft)
 Backlog (project column)
     ↓ [verify agent-ready criteria met]
 Agent-Ready (column + label)
-    ↓ [/fix-issue N or agent pickup]
+    ↓ [/ship-issue N or agent pickup]
 In Progress (column + label)
     ↓ [PR opened]
 In Review (column + label)
@@ -308,15 +308,15 @@ gh api graphql -f query='...' -F projectId=PVT_xxx -F itemId=PVTI_xxx ...
 
 ## 4. Skills Reference
 
-### `/fix-issue [number]`
+### `/ship-issue [number]`
 
-**File:** `.claude/skills/fix-issue/SKILL.md`
+**File:** `.claude/skills/ship-issue/SKILL.md`
 
 **What it does:** Picks up a GitHub issue by number. Checks for `effort:large` label; if found, delegates to `/decompose-issue` and stops. Otherwise: creates branch, reads affected files, implements, runs tests, opens PR, updates labels.
 
 **Usage:**
 ```
-/fix-issue 42
+/ship-issue 42
 ```
 
 **Key behaviors:**

--- a/research/02-github-for-agents.md
+++ b/research/02-github-for-agents.md
@@ -235,13 +235,13 @@ When picking up a GitHub Issue:
 6. Update the issue label from "in-progress" to "in-review"
 ```
 
-### 3. Add a `fix-issue` Skill for One-Command Ticket Pickup
+### 3. Add a `ship-issue` Skill for One-Command Ticket Pickup
 
-Create `.claude/skills/fix-issue/SKILL.md` — this becomes `/fix-issue 42` in any Claude Code session:
+Create `.claude/skills/ship-issue/SKILL.md` — this becomes `/ship-issue 42` in any Claude Code session:
 
 ```yaml
 ---
-name: fix-issue
+name: ship-issue
 description: Pick up a GitHub issue by number. If effort:large, decomposes it into sub-issues instead of implementing. Otherwise creates a branch, implements, runs tests, and opens a PR.
 user-invocable: true
 context: fork
@@ -291,7 +291,7 @@ If tests fail, fix them before proceeding.
 Report a summary of what was changed and the PR URL.
 ```
 
-**Usage:** In any Claude Code session, type `/fix-issue 42` and Claude handles the rest. If the issue is labeled `effort:large`, it decomposes automatically — you review the new sub-issues and move them to "Agent-Ready" when ready.
+**Usage:** In any Claude Code session, type `/ship-issue 42` and Claude handles the rest. If the issue is labeled `effort:large`, it decomposes automatically — you review the new sub-issues and move them to "Agent-Ready" when ready.
 
 ### 4. Add a `decompose-issue` Skill for Large Ticket Breakdown
 
@@ -300,7 +300,7 @@ When an issue is too large to implement in one session, the agent should break i
 ```yaml
 ---
 name: decompose-issue
-description: Break a large GitHub issue into 3-5 smaller, agent-ready sub-issues. Called automatically by fix-issue when effort:large is detected, or invoked directly.
+description: Break a large GitHub issue into 3-5 smaller, agent-ready sub-issues. Called automatically by ship-issue when effort:large is detected, or invoked directly.
 user-invocable: true
 allowed-tools: Bash(gh *), Read, Grep, Glob
 argument-hint: "[issue number]"
@@ -388,7 +388,7 @@ Output a summary:
 - Recommended order of implementation
 ```
 
-**Usage:** `/decompose-issue 42` — or triggered automatically by `/fix-issue 42` when `effort:large` is detected.
+**Usage:** `/decompose-issue 42` — or triggered automatically by `/ship-issue 42` when `effort:large` is detected.
 
 **What "too large" means in practice:**
 - The issue requires changes to more than ~10 files
@@ -646,7 +646,7 @@ iOS only
 `main`
 ```
 
-This ticket can be handed to Claude Code with `/fix-issue 42` and executed without a single follow-up question.
+This ticket can be handed to Claude Code with `/ship-issue 42` and executed without a single follow-up question.
 
 ---
 
@@ -891,7 +891,7 @@ From practitioner reports and filed issues:
 - [ ] Write a shell script wrapping the Projects v2 GraphQL mutation for status updates
 
 ### Skills & Agents
-- [ ] Create `.claude/skills/fix-issue/SKILL.md`
+- [ ] Create `.claude/skills/ship-issue/SKILL.md`
 - [ ] Create `.claude/skills/decompose-issue/SKILL.md`
 - [ ] Create `.claude/agents/ios-developer.md`
 - [ ] Create `.claude/agents/android-developer.md`

--- a/research/07-design-decision-frameworks.md
+++ b/research/07-design-decision-frameworks.md
@@ -217,7 +217,7 @@ The iterative questioning approach is the core interaction pattern: don't let th
         ↓
 ADR key points added to CLAUDE.md
         ↓
-Future /fix-issue sessions read CLAUDE.md
+Future /ship-issue sessions read CLAUDE.md
         ↓
 Agents automatically respect the decision
 ```
@@ -277,7 +277,7 @@ Phase 5: Integration
      ↓
 /clarify → "What's the exact scope of this implementation task?"
      ↓
-/fix-issue → "Implement it."
+/ship-issue → "Implement it."
 ```
 
 ---

--- a/research/README.md
+++ b/research/README.md
@@ -11,7 +11,7 @@
 | File | Title | TL;DR |
 |------|-------|-------|
 | [01-agent-workflow-experts.md](./01-agent-workflow-experts.md) | AI-Assisted Development: Expert Synthesis | Five universal patterns from Boris Cherny, Karpathy, Simon Willison, swyx, and others. CLAUDE.md is the single highest-leverage investment. Tests are the agent's feedback loop. |
-| [02-github-for-agents.md](./02-github-for-agents.md) | GitHub Issues & Projects for AI Agent Workflows | How to write tickets that agents can execute without hand-holding. GitHub MCP server, Projects v2 API, issue templates, `fix-issue` skill, and label strategy. **Updated Mar 2026:** AGENTS.md convention, GitHub Agentic Workflows, WRAP framework, Claude Code Action v1.0 GA, Copilot coding agent updates, Playwright MCP, failure patterns. |
+| [02-github-for-agents.md](./02-github-for-agents.md) | GitHub Issues & Projects for AI Agent Workflows | How to write tickets that agents can execute without hand-holding. GitHub MCP server, Projects v2 API, issue templates, `ship-issue` skill, and label strategy. **Updated Mar 2026:** AGENTS.md convention, GitHub Agentic Workflows, WRAP framework, Claude Code Action v1.0 GA, Copilot coding agent updates, Playwright MCP, failure patterns. |
 | [03-github-actions-ci-cd.md](./03-github-actions-ci-cd.md) | GitHub Actions CI/CD for Multi-Platform Apps | Full delivery surface (web, iOS, iOS widget, watchOS, Android, VS Code, Mac widget) from one monorepo. Claude Code Action for AI-assisted auto-fix loops. Cloudflare, App Store, and Play Store pipelines. |
 | [04-stack-recommendations.md](./04-stack-recommendations.md) | Tech Stack Recommendations 2025-2026 | Supabase + CF Durable Objects + Supabase Auth (MVP→Better Auth) + Expo + SwiftUI widget + Nx + Vercel + MCP server. MVP cost: $0/month. |
 | [05-startups-and-oss-solving-this.md](./05-startups-and-oss-solving-this.md) | Startups & OSS Solving Agent Dev Workflows | Landscape of tools for "agent picks up Issue and ships PR." Aider + Sweep AI + OpenHands are the install-today picks. Devin is powerful but $500/month. Height is shut down. |
@@ -45,7 +45,7 @@
 
 ```
 GitHub Issues (labeled "agent-ready")
-         ↓ (webhook or manual /fix-issue N)
+         ↓ (webhook or manual /ship-issue N)
 Claude Code reads issue via GitHub MCP server
          ↓
 Creates feature branch, enters plan mode
@@ -96,7 +96,7 @@ Create separate agent configurations (`.claude/agents/`) for iOS, Android, share
 1. **Write `CLAUDE.md`** at repo root — this is the briefing document for every agent session
 2. **Create GitHub Issue templates** (`.github/ISSUE_TEMPLATE/feature-agent.yml`) so every ticket is agent-ready by default
 3. **Set up GitHub Projects v2** with 5 columns: Backlog → Agent-Ready → In Progress → In Review → Done
-4. **Create the `/fix-issue` skill** (`.claude/skills/fix-issue/SKILL.md`) for one-command issue pickup
+4. **Create the `/ship-issue` skill** (`.claude/skills/ship-issue/SKILL.md`) for one-command issue pickup
 5. **Install GitHub MCP server** in `.claude/settings.json`
 6. **Add Sweep AI** as a GitHub App for automatic issue → PR on labeled tickets
 7. **Set up GitHub Actions** for CI (lint + test + deploy to preview per platform)


### PR DESCRIPTION
## Summary
- Renames `.claude/skills/fix-issue/` → `.claude/skills/ship-issue/`
- Updates all 11 references across docs, skills, issue templates, and agent configs
- `/ship-issue` better reflects the skill's purpose: full end-to-end delivery (plan → implement → test → PR), not just bug fixing

## Files changed
- `.claude/skills/ship-issue/SKILL.md` (renamed)
- `.claude/skills/decompose-issue/SKILL.md`
- `.claude/docs/clarification-protocol.md`, `claude-code-advanced.md`, `agent-ready-issues.md`
- `research/README.md`, `research/02-github-for-agents.md`, `research/07-design-decision-frameworks.md`
- `GitHub-Agents.md`, `AGENTS.md`
- `.github/ISSUE_TEMPLATE/feature-agent.yml`

## Test plan
- [ ] `.claude/skills/ship-issue/SKILL.md` exists and `fix-issue` directory is gone
- [ ] No remaining references to `fix-issue` in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)