### PR TITLE
feat: add ADR-012 Security & Data Privacy — lean GDPR approach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,14 @@ See [ADR-009](./research/decisions/009-ci-cd-pipeline-design.md) for full ration
 
 ---
 
+## Security & Privacy
+
+IMPORTANT: Rely on platform-provided security — no application-level encryption. Supabase handles AES-256 at rest and TLS in transit. RLS on every table (ADR-005) + API gateway (ADR-007) provides access control. GDPR compliance is built in: `DELETE /v1/me` (cascade delete all user data) and `GET /v1/me/export` (JSON download). Store minimum OAuth data: provider `sub`, email, display name. No tracking, no ads, no third-party analytics — no cookie banner needed. BLE uses LE Secure Connections with Passkey Entry + Bonding. Token storage is platform-secure per app (HttpOnly cookie for web, `expo-secure-store` for mobile, Keychain for macOS, `SecretStorage` for VS Code).
+
+See [ADR-012](./research/decisions/012-security-data-privacy.md) for full rationale.
+
+---
+
 ## Observability
 
 IMPORTANT: Use platform built-in dashboards (Supabase, Cloudflare Workers, Vercel) for infrastructure monitoring. Add Sentry free tier for client-side error tracking when each platform first deploys to staging — not before. Sentry SDK init belongs in app entry points (`apps/` and `native/`), never in shared packages (`packages/`). Defer Langfuse and all other observability tools until a concrete pain point arises.

--- a/research/decisions/002-auth-architecture.md
+++ b/research/decisions/002-auth-architecture.md
@@ -102,3 +102,4 @@ Supabase Auth is the sole long-term auth provider. Better Auth was evaluated as 
 - Database: Supabase (Postgres + RLS + Realtime) — accepted, see `research/04-stack-recommendations.md`
 - Testing frameworks — accepted, see `research/08-testing-frameworks.md`
 - [ADR-007: API Architecture](./007-api-architecture.md) — auth flow routes through the Hono API on CF Workers. API validates user's Supabase JWT and forwards to Supabase — RLS and `get_user_id()` work unchanged. Clients manage JWT refresh via shared auth interceptors.
+- [ADR-012: Security & Data Privacy](./012-security-data-privacy.md) — OAuth data minimization (store only provider `sub`, email, display name). GDPR endpoints for data export and account deletion. Token storage per platform.

--- a/research/decisions/010-physical-device-hardware-platform.md
+++ b/research/decisions/010-physical-device-hardware-platform.md
@@ -132,3 +132,4 @@ Chosen option: **"nRF52840 (Seeed XIAO)"**, because it is the most power-efficie
 - [ADR-004: Timer State Machine](./004-timer-state-machine.md) — the pure `transition(state, event) → newState` model translates to C++ `enum class` on the device; device runs its own timer driver using `millis()`
 - [ADR-005: Database Schema & Data Model](./005-database-schema-data-model.md) — `devices` and `device_sync_log` tables support BLE device registration and incremental sync; UUID-based idempotent inserts deduplicate retries
 - [ADR-006: Offline-First Sync Architecture](./006-offline-first-sync-architecture.md) — device implements the outbox sync pattern: buffer sessions locally, upload when BLE reconnects, server deduplicates via `ON CONFLICT (id) DO NOTHING`
+- [ADR-012: Security & Data Privacy](./012-security-data-privacy.md) — BLE uses LE Secure Connections with Passkey Entry + Bonding; advanced BLE hardening (SCO mode, GATT-level encryption) explicitly deferred

--- a/research/decisions/012-security-data-privacy.md
+++ b/research/decisions/012-security-data-privacy.md
@@ -1,0 +1,145 @@
+# ADR-012: Security & Data Privacy
+
+**Status:** Accepted
+**Date:** 2026-03-09
+**Decision-makers:** Project lead
+**Zoom level:** Level 1-2 (system-level, affects schema, API, auth, BLE)
+**Platforms:** All (iOS app, iOS widget, Apple Watch, macOS menu bar, Android, web, VS Code extension, Claude Code MCP, BLE device)
+
+## Context and Problem Statement
+
+PomoFocus collects low-to-moderate sensitivity productivity data: timer sessions, goals with user-written titles, self-reported focus quality, friendship connections, and reflection notes. The app targets a global audience (EU users expected from launch), handles OAuth sign-in via Apple and Google, and includes a BLE device that syncs through the phone. The question is: what security and privacy measures does a consumer productivity app actually need — balancing real-world risk against development effort on a $0/month budget?
+
+## Decision Drivers
+
+- **GDPR compliance** — EU users from launch; must comply with data minimization, right to erasure, and right to data portability from day one
+- **$0/month budget** — rely on platform-provided security, no additional services
+- **Low-to-moderate data sensitivity** — timer durations and goal titles, not health/financial data
+- **Multi-platform** — security model must work across web, mobile, BLE device, native Apple, VS Code, and MCP
+- **Existing architecture** — Supabase (AES-256 at rest, TLS in transit), API gateway (ADR-007), RLS on every table (ADR-005)
+
+## Considered Options
+
+1. Lean GDPR — Supabase defaults + RLS + API gateway + GDPR endpoints + BLE passkey pairing
+2. Defense in Depth — Option 1 + application-level encryption for sensitive fields (goals, reflections)
+3. Maximum BLE Security — Option 1 + Secure Connections Only mode + GATT-level encryption + MAC rotation
+
+## Decision Outcome
+
+Chosen option: **"Lean GDPR"**, because the data PomoFocus handles does not justify application-level encryption complexity or advanced BLE hardening. Supabase's built-in encryption (AES-256 at rest, TLS 1.2+ in transit) combined with RLS on every table and the API gateway (ADR-007) provides sufficient protection for productivity data. The incremental effort is limited to two API endpoints (data export, account deletion), a privacy policy, and BLE passkey pairing configuration.
+
+### Consequences
+
+- **Good:** Near-zero additional development effort. GDPR compliance from day one. No third-party security SDKs to vet or maintain. Aligns with existing architecture (ADR-005 hard deletes, ADR-007 API gateway).
+- **Bad:** Goal titles and reflection notes stored as plaintext in Supabase (behind AES-256 at-rest encryption). A Supabase admin breach would expose this data. BLE passkey (6 digits) is brute-forceable if initial pairing exchange is captured.
+- **Neutral:** The decision is partially revisable — application-level encryption for specific fields could be added later without changing the overall architecture, though it would break queries on those fields.
+
+## The Security Model
+
+### Encryption
+
+| Layer | Mechanism | Responsibility |
+|-------|-----------|----------------|
+| In transit | TLS 1.2+ (HTTPS) | Supabase, Cloudflare Workers, Vercel (automatic) |
+| At rest | AES-256 | Supabase (automatic, no configuration needed) |
+| Application-level | None | Not required for low-to-moderate sensitivity data |
+
+No additional encryption is needed. Supabase's shared responsibility model covers encryption at rest and in transit. Application-level encryption (e.g., `pgcrypto`) is not warranted because: (1) the data is not health, financial, or credential data; (2) encrypted fields cannot be queried, breaking analytics; (3) key management adds significant complexity for marginal security gain.
+
+### Access Control
+
+| Layer | Mechanism | Reference |
+|-------|-----------|-----------|
+| API gateway | Hono on CF Workers — clients never access Supabase directly | ADR-007 |
+| Row-level security | RLS on every table via `get_user_id()` helper | ADR-005 |
+| JWT validation | Server-side validation of Supabase JWT in API middleware | ADR-007 |
+| Social visibility | Scoped functions (`is_friend_focusing`, `did_friend_focus_today`) — friends never see raw session data | ADR-005 |
+
+### GDPR Compliance
+
+| Requirement | Implementation |
+|-------------|----------------|
+| Right to erasure (Art. 17) | `DELETE /v1/me` — cascade deletes all user data (sessions, goals, friendships, devices, preferences). Hard deletes (ADR-005). |
+| Right to data portability (Art. 20) | `GET /v1/me/export` — returns all user data as JSON download |
+| Privacy policy | Static page at `/privacy` — describes data collected, purposes, retention, and rights |
+| Consent | Acknowledgment at sign-up (link to privacy policy). No cookie banner needed — no tracking, no ads, no third-party analytics. |
+| Data minimization | Store only what's needed: provider user ID, email (account recovery), display name (social features). No profile pictures unless user uploads. |
+| Data retention | 30 days post-deletion for backup safety, then hard purge via scheduled CF Worker cron job |
+
+### OAuth Data Minimization
+
+| Provider | Scopes Requested | Data Stored |
+|----------|-----------------|-------------|
+| Apple Sign-In | `name`, `email` | Provider `sub` (user ID), email (real or private relay), display name (cached on first login — Apple only returns it once) |
+| Google | `openid`, `email`, `profile` | Provider `sub`, email, display name |
+| Email/password | N/A | Email, hashed password (Supabase Auth handles hashing) |
+
+Supabase Auth manages all OAuth tokens, refresh cycles, and session management. `packages/data-access/` wraps Supabase Auth; `packages/core/` never handles auth data — it receives `userId: string` per ADR-002.
+
+### BLE Security
+
+| Measure | Implementation |
+|---------|----------------|
+| Pairing | LE Secure Connections with Passkey Entry — 6-digit code displayed on e-ink screen, entered on phone |
+| Bonding | Persist Long Term Key (LTK) after initial pairing — re-pairing not needed for subsequent sessions |
+| Link encryption | AES-CCM 128-bit (standard for LE Secure Connections) |
+| Accepted risk | Timer/goal data is low-stakes — brute-forcing a 6-digit passkey to intercept "user focused 25 minutes" is not a credible threat |
+
+Advanced BLE hardening (Secure Connections Only mode, GATT-level encryption, MAC rotation) is deferred — the threat model does not justify the firmware complexity and OS compatibility issues.
+
+### Platform Security Notes
+
+| Platform | Security Considerations |
+|----------|----------------------|
+| Web (Next.js) | HTTPS via Vercel. HttpOnly cookies for session. CSP headers. No localStorage for tokens. |
+| Mobile (Expo) | Secure storage via `expo-secure-store` for tokens. Certificate pinning deferred. |
+| iOS Widget | Data via App Group (on-device transfer, not network). No additional concern. |
+| watchOS | Data via WatchConnectivity (on-device transfer). No additional concern. |
+| macOS menu bar | CoreBluetooth for BLE fallback. Keychain for token storage. |
+| VS Code | `SecretStorage` API for tokens. Extension sandbox provides isolation. |
+| MCP Server | Token stored via Claude Code's credential management. No browser context. |
+| BLE Device | LE Secure Connections + bonding. Session data in internal flash (not network-accessible). |
+
+## Pros and Cons of the Options
+
+### Option 1: Lean GDPR (Chosen)
+
+- Good, because near-zero additional effort — Supabase handles encryption, existing ADRs cover access control
+- Good, because GDPR compliance adds only 2 API endpoints and a privacy policy
+- Good, because no third-party security SDKs or services ($0/month)
+- Good, because hard deletes (ADR-005) naturally align with right to erasure
+- Bad, because goal titles and reflections are plaintext in Supabase (mitigated by AES-256 at rest)
+- Bad, because BLE passkey is only 6 digits of entropy (mitigated by bonding + low-value data)
+
+### Option 2: Defense in Depth
+
+- Good, because application-level encryption protects goals/reflections even against Supabase admin breach
+- Bad, because key management adds significant complexity (rotation, recovery, per-user keys)
+- Bad, because encrypted fields cannot be queried by SQL — breaks analytics and search ([Supabase encryption docs](https://supabase.com/docs/guides/database/secure-data))
+- Bad, because over-engineered for productivity data — no regulatory requirement demands field-level encryption
+
+### Option 3: Maximum BLE Security
+
+- Good, because Secure Connections Only mode blocks BLE downgrade attacks ([USENIX Security 2020](https://www.usenix.org/conference/usenixsecurity20/presentation/zhang-yue))
+- Good, because MAC rotation prevents device fingerprinting/tracking
+- Bad, because SCO mode has inconsistent OS support across Android, iOS, and macOS
+- Bad, because GATT-level encryption adds firmware complexity and battery drain
+- Bad, because threat model is weak — intercepting timer data has negligible value
+
+## Research Sources
+
+- [Supabase Security](https://supabase.com/security) — AES-256 at rest, TLS in transit, shared responsibility model
+- [Supabase Securing Your Data](https://supabase.com/docs/guides/database/secure-data) — RLS best practices, encryption guidance
+- [Supabase Shared Responsibility Model](https://supabase.com/docs/guides/deployment/shared-responsibility-model) — what Supabase handles vs what developers handle
+- [Auth0 GDPR Data Minimization](https://auth0.com/docs/secure/data-privacy-and-compliance/gdpr/gdpr-data-minimization) — OAuth data minimization guidance
+- [Curity: Privacy and GDPR Using OAuth](https://curity.io/resources/learn/privacy-and-gdpr/) — OAuth GDPR compliance patterns
+- [Apple Developer: Sign in with Apple](https://developer.apple.com/sign-in-with-apple/) — data returned, private relay email, name only on first login
+- [Google OAuth 2.0 Scopes](https://developers.google.com/identity/protocols/oauth2/scopes) — minimum scopes for authentication
+
+## Related Decisions
+
+- [ADR-002: Auth Architecture](./002-auth-architecture.md) — Supabase Auth as sole provider, auth confined to `data-access/`
+- [ADR-005: Database Schema](./005-database-schema-data-model.md) — RLS on every table, hard deletes, `get_user_id()` helper
+- [ADR-007: API Architecture](./007-api-architecture.md) — Hono API gateway hides Supabase, JWT forwarding
+- [ADR-010: Physical Device Hardware](./010-physical-device-hardware-platform.md) — BLE 5.0, passkey pairing, phone-as-hub
+- [ADR-011: Monitoring & Observability](./011-monitoring-observability.md) — Sentry for client-side error tracking (no PII in error reports)

--- a/research/designs/security-data-privacy.md
+++ b/research/designs/security-data-privacy.md
@@ -1,0 +1,161 @@
+# Design: Security & Data Privacy
+
+**Date:** 2026-03-09
+**Status:** Accepted
+**Related ADR:** [ADR-012](../decisions/012-security-data-privacy.md)
+**Platforms:** All (iOS app, iOS widget, Apple Watch, macOS menu bar, Android, web, VS Code extension, Claude Code MCP, BLE device)
+
+## Context & Scope
+
+PomoFocus is a multi-platform Pomodoro productivity app that collects timer sessions, user-written goals, self-reported focus quality, and friendship connections. The data is low-to-moderate sensitivity — not health, financial, or credential data, but users may write personal aspirations in goal titles and reflections. The app targets a global audience (EU users from day one), uses OAuth sign-in (Apple + Google + email), and includes a BLE device that syncs through the phone. Existing architecture decisions already provide a strong security foundation: Supabase with RLS (ADR-005), an API gateway that hides Supabase from clients (ADR-007), and auth confined to `data-access/` (ADR-002).
+
+## Goals & Non-Goals
+
+**Goals:**
+- GDPR compliance from launch (right to erasure, data portability, data minimization, consent)
+- Leverage existing platform security (Supabase encryption, RLS, CF Workers TLS) rather than building custom solutions
+- Secure BLE pairing between phone and physical device
+- Store minimum OAuth data needed for the app to function
+
+**Non-Goals:**
+- Application-level field encryption (not warranted for productivity data)
+- Advanced BLE hardening (SCO mode, GATT-level encryption, MAC rotation)
+- SOC 2 or HIPAA compliance (not a health or enterprise app)
+- Cookie consent banners (no tracking, no ads, no third-party analytics)
+- Certificate pinning on mobile (defer until post-v1)
+- WAF or DDoS protection beyond what Cloudflare provides by default
+
+## The Design
+
+### Security Architecture Overview
+
+```
+User Device                         Cloud
+┌─────────────────┐               ┌──────────────────────┐
+│  App / Browser   │──── TLS ────▶│  Cloudflare Workers   │
+│                  │               │  (Hono API Gateway)   │
+│  Token stored in │               │                       │
+│  platform-secure │               │  - JWT validation     │
+│  storage         │               │  - Rate limiting      │
+│                  │               │  - Route auth check   │
+└─────────────────┘               └──────────┬───────────┘
+                                              │ JWT forwarded
+                                              ▼
+                                   ┌──────────────────────┐
+                                   │  Supabase             │
+                                   │  - AES-256 at rest    │
+                                   │  - TLS in transit     │
+                                   │  - RLS on every table │
+                                   │  - get_user_id()      │
+                                   └──────────────────────┘
+```
+
+```
+Phone                              BLE Device
+┌─────────────────┐               ┌──────────────────────┐
+│  Expo App        │◄── BLE ─────▶│  nRF52840 (EN04)     │
+│                  │   Encrypted   │                       │
+│  react-native-   │   AES-CCM    │  - Passkey displayed  │
+│  ble-plx         │   128-bit    │    on e-ink screen    │
+│                  │              │  - LTK bonded after   │
+│  Syncs to cloud  │              │    initial pairing    │
+│  via API gateway │              │  - Sessions in flash  │
+└─────────────────┘              └──────────────────────┘
+```
+
+### GDPR Endpoints
+
+Two new routes in the Hono API (`apps/api/`):
+
+#### `DELETE /v1/me` — Account Deletion
+
+1. Validate JWT, extract `userId`
+2. Cascade delete all user data: `profiles`, `user_preferences`, `long_term_goals`, `process_goals`, `sessions`, `breaks`, `devices`, `device_sync_log`, `friend_requests`, `friendships`, `encouragement_taps`
+3. Delete Supabase Auth user via `auth.admin.deleteUser(userId)` (service_role key, server-side only)
+4. Return `204 No Content`
+5. Data retained in Supabase backups for 30 days (Supabase default), then purged
+
+Implementation note: For power users with thousands of sessions, this cascade could be slow. If latency becomes an issue post-launch, migrate to async deletion via CF Workers queue (accept request immediately, process in background, confirm via email).
+
+#### `GET /v1/me/export` — Data Export
+
+1. Validate JWT, extract `userId`
+2. Query all user data across all tables
+3. Return as JSON with `Content-Disposition: attachment; filename="pomofocus-data-export.json"`
+4. Format: flat structure with one key per table (`{ "profile": {...}, "goals": [...], "sessions": [...], ... }`)
+5. No rate limit needed — users rarely export data
+
+### OAuth Data Storage
+
+Supabase Auth manages all OAuth complexity (tokens, refresh, sessions). PomoFocus stores only:
+
+| Field | Table | Purpose | Legal Basis (GDPR) |
+|-------|-------|---------|-------------------|
+| `auth_id` (provider `sub`) | `auth.users` (Supabase-managed) | Unique identity | Contractual necessity |
+| `email` | `auth.users` | Account recovery, notifications | Contractual necessity |
+| `display_name` | `profiles` | Social features (Quiet Feed, Library Mode) | Legitimate interest |
+
+**Apple Sign-In special handling:** Apple returns `given_name` and `family_name` only on the first authorization. The API must cache the display name in `profiles` immediately on first sign-in — it will not be available again.
+
+### Token Storage per Platform
+
+| Platform | Storage Mechanism | Notes |
+|----------|-------------------|-------|
+| Web (Next.js) | HttpOnly cookie (set by API) | Not accessible to JavaScript — XSS-safe |
+| Mobile (Expo) | `expo-secure-store` | Encrypted keychain (iOS) / keystore (Android) |
+| iOS Widget | App Group `UserDefaults` | Shared with Expo app via native module |
+| watchOS | WatchConnectivity transfer | Received from paired iPhone |
+| macOS menu bar | Keychain Services | Standard macOS credential storage |
+| VS Code | `SecretStorage` API | Extension-scoped encrypted storage |
+| MCP Server | Claude Code credential management | Managed by Claude Code runtime |
+| BLE Device | N/A | No auth tokens — syncs through phone |
+
+### BLE Pairing Flow
+
+1. User initiates pairing from phone app
+2. Device enters pairing mode, generates 6-digit passkey
+3. Passkey displayed on e-ink screen
+4. User enters passkey on phone
+5. LE Secure Connections handshake with AES-CCM 128-bit encryption
+6. Long Term Key (LTK) exchanged and bonded
+7. Subsequent connections auto-authenticate via bonded LTK
+8. If user wants to pair a different phone, they reset the device (long-press 10s), which clears the bond
+
+### Privacy Policy Requirements
+
+The privacy policy (static page at `/privacy`) must include:
+- What data is collected (sessions, goals, focus quality, friendships)
+- Why it's collected (core app functionality, social features)
+- How it's stored (Supabase, encrypted at rest and in transit)
+- Who has access (only the user; friends see limited presence/activity via scoped functions)
+- Data retention (active account: indefinite; deleted account: 30 days in backups)
+- User rights (export, deletion, correction)
+- Contact information for data requests
+- No third-party data sharing, no ads, no tracking
+
+## Alternatives Considered
+
+### Application-Level Encryption (Rejected)
+
+Encrypting goal titles and reflection notes before storing in Supabase would protect against a Supabase admin breach. Rejected because: (1) key management (per-user keys, rotation, recovery) adds significant complexity; (2) encrypted fields cannot be queried via SQL, breaking analytics and search; (3) Supabase's AES-256 at-rest encryption already protects against physical storage theft; (4) the data is not sensitive enough to justify the trade-offs.
+
+### Advanced BLE Security (Rejected)
+
+Secure Connections Only mode, GATT-level encryption, and MAC rotation would harden the BLE link against sophisticated attacks. Rejected because: (1) SCO mode has inconsistent OS support across Android, iOS, and macOS; (2) GATT-level encryption adds firmware complexity and battery drain; (3) the threat model is weak — intercepting timer/goal data has negligible value to an attacker.
+
+### Self-Hosted Supabase (Not Considered for v1)
+
+Self-hosting would eliminate the risk of Supabase employees accessing data. Not considered because: (1) solo developer with $0 budget; (2) Supabase's shared responsibility model is appropriate for non-sensitive data; (3) self-hosting introduces infrastructure management burden.
+
+## Cross-Cutting Concerns
+
+- **Security:** The main attack surface is the Hono API on CF Workers. JWT validation must be strict — verify signature against Supabase's JWKS endpoint, check expiration, and reject malformed tokens. RLS provides defense-in-depth even if the API has a bug.
+- **Cost:** $0/month. All security is provided by platform defaults (Supabase encryption, CF Workers TLS, Vercel HTTPS). GDPR endpoints are standard Hono routes.
+- **Observability:** Failed auth attempts and data deletion events should be logged (CF Workers dashboard). Sentry (ADR-011) captures client-side errors but must not include PII in error reports — strip user data from Sentry breadcrumbs.
+- **Migration path:** If application-level encryption becomes necessary later (e.g., regulatory change, enterprise customers), it can be added to specific fields without changing the overall architecture. Existing data would need a one-time migration to encrypt in place.
+
+## Open Questions
+
+- **Rate limiting specifics:** How aggressive should rate limiting be on auth endpoints? (Cloudflare's default DDoS protection may be sufficient for v1.)
+- **Token refresh strategy:** How does the web app handle token refresh for long sessions? (Supabase Auth handles this automatically, but the HttpOnly cookie approach needs careful design.)
+- **GDPR DPA:** Does Supabase's Data Processing Agreement (DPA) need to be signed before launch? (Yes — available at supabase.com/legal/dpa, self-service.)

--- a/technical-design-decisions.md
+++ b/technical-design-decisions.md
@@ -337,13 +337,22 @@ Architecture: outbox queue (client -> server) + polling pull (server -> client, 
 
 ### Security & Data Privacy
 
-> **Status:** Needs /tech-design
-> **Product brief ref:** Sections 7 (paid subscription = user data), 9 (social features = shared data), 5 (BLE pairing)
-> **What I need to learn:** What security measures a consumer app handling focus/productivity data actually needs. GDPR requirements for EU users. How BLE pairing security works (can someone sniff my session data?). OAuth provider deep dive — what data do we get and store from each provider.
-> **Key questions:**
-> - What data do we encrypt at rest vs in transit vs not at all?
-> - What GDPR obligations apply — data export, deletion, consent?
-> - How secure is BLE pairing, and what are the actual risks of someone intercepting timer/goal data?
+> **Date:** 2026-03-09
+> **Status:** Accepted
+> **ADR:** [research/decisions/012-security-data-privacy.md](./research/decisions/012-security-data-privacy.md)
+> **Design doc:** [research/designs/security-data-privacy.md](./research/designs/security-data-privacy.md)
+
+| Layer | Choice | Key Principle |
+|-------|--------|---------------|
+| Encryption (transit) | **TLS 1.2+** (Supabase, CF Workers, Vercel — automatic) | Platform-provided, zero configuration |
+| Encryption (at rest) | **AES-256** (Supabase — automatic) | No application-level encryption needed for productivity data |
+| Access control | **RLS + API gateway + JWT validation** | ADR-005 + ADR-007 defense-in-depth |
+| GDPR | **Two endpoints** (`DELETE /v1/me`, `GET /v1/me/export`) + privacy policy + consent at sign-up | Right to erasure, data portability, data minimization from day one |
+| OAuth data | **Minimum storage** — provider `sub`, email, display name only | Apple private relay supported. Apple name cached on first login. |
+| BLE security | **LE Secure Connections + Passkey Entry + Bonding** | 6-digit passkey on e-ink, LTK bonded, AES-CCM 128-bit link encryption |
+| Token storage | **Platform-secure per app** — HttpOnly cookie (web), expo-secure-store (mobile), Keychain (macOS), SecretStorage (VS Code) | No localStorage tokens |
+
+Hard deletes (ADR-005) align with GDPR. No third-party security SDKs. $0/month. Application-level encryption and advanced BLE hardening explicitly deferred — data sensitivity does not justify the complexity.
 
 ---
 


### PR DESCRIPTION
Decide security strategy: rely on Supabase built-in encryption (AES-256
at rest, TLS in transit) + RLS + API gateway. Add two GDPR endpoints
(data export, account deletion). BLE uses LE Secure Connections with
Passkey Entry. No application-level encryption — data sensitivity does
not justify the complexity. OAuth stores minimum data (provider sub,
email, display name).

New files:
- research/decisions/012-security-data-privacy.md (ADR)
- research/designs/security-data-privacy.md (design doc)

Updated files:
- CLAUDE.md — added Security & Privacy section
- technical-design-decisions.md — Security entry: Needs → Accepted
- ADR-002 — added ADR-012 cross-reference
- ADR-010 — added ADR-012 cross-reference

https://claude.ai/code/session_013hQFY98k9NtsKeaJvFaA7L