### PR TITLE
feat: scaffold packages/core/src/goals/ module with placeholder types

### DIFF
--- a/packages/core/src/goals/index.ts
+++ b/packages/core/src/goals/index.ts
@@ -1,0 +1,1 @@
+export type { StreakResult, GoalProgress } from './types.js';

--- a/packages/core/src/goals/types.ts
+++ b/packages/core/src/goals/types.ts
@@ -1,0 +1,11 @@
+export type StreakResult = {
+  readonly currentStreak: number;
+  readonly longestStreak: number;
+  readonly gracePeriodActive: boolean;
+};
+
+export type GoalProgress = {
+  readonly goalId: string;
+  readonly completedToday: number;
+  readonly target: number;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,3 @@
 // Pure domain logic: timer, goals, sessions, sync protocol.
 // No IO, no React, no Supabase imports.
-export {};
+export type { StreakResult, GoalProgress } from './goals/index.js';


### PR DESCRIPTION
## Summary
- Adds `packages/core/src/goals/` module with `StreakResult` and `GoalProgress` placeholder types
- Re-exports from `packages/core/src/index.ts` so `import type { StreakResult } from '@pomofocus/core'` works
- No implementation logic — streak calculation and goal CRUD deferred to Phase 2

Closes #61

## Test plan
- [x] `pnpm nx type-check @pomofocus/core` passes
- [x] `pnpm nx lint @pomofocus/core` passes
- [x] Downstream package (`@pomofocus/analytics`) type-check unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)