### PR TITLE
feat: scaffold packages/core/src/session/ with placeholder types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,4 +3,4 @@
 export type { StreakResult, GoalProgress } from './goals/index.js';
 export type { TimerConfig, ReflectionData, TimerState, TimerEvent } from './timer/index.js';
 export type { QueueItemState, SyncEvent, RetryPolicy, SyncableEntityType } from './sync/index.js';
-export type { SessionData } from './session/index.js';
+export type { SessionData, SessionReflection } from './session/index.js';

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -1,1 +1,1 @@
-export type { SessionData, ReflectionData } from './types.js';
+export type { SessionData, SessionReflection } from './types.js';

--- a/packages/core/src/session/types.ts
+++ b/packages/core/src/session/types.ts
@@ -17,8 +17,8 @@ export type SessionData = {
   readonly deviceId: string | null;
 };
 
-/** Post-session reflection data. */
-export type ReflectionData = {
+/** Persisted reflection fields on a session record. */
+export type SessionReflection = {
   readonly focusQuality: FocusQuality | null;
   readonly distractionType: DistractionType | null;
   readonly notes: string | null;


### PR DESCRIPTION
## Summary
- Adds `SessionData` (pre-persistence shape with client-generated `id` per ADR-006) and `SessionReflection` (persisted reflection fields: focus quality, distraction type, notes) placeholder types in `packages/core/src/session/`
- Barrel exports from `@pomofocus/core` so `import type { SessionData } from '@pomofocus/core'` resolves
- Renamed from `ReflectionData` to `SessionReflection` to avoid collision with timer module's `ReflectionData` export
- Phase 0 scaffolding (sub-item 0.7)

Closes #63

## Test plan
- [x] `pnpm nx type-check @pomofocus/core` passes
- [x] `pnpm nx lint @pomofocus/core` passes
- [x] `pnpm nx run-many --target=type-check --all` — all 10 projects pass
- [x] Rebased onto current main (includes goals, timer, ESLint, tsconfig PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)