### PR TITLE
Enable all strict TypeScript compiler options in tsconfig.base.json

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,14 +1,15 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "esnext",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": ["esnext"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "verbatimModuleSyntax": true,
+    "noPropertyAccessFromIndexSignature": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Enables all strict TypeScript compiler options (`noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `verbatimModuleSyntax`, `noPropertyAccessFromIndexSignature`) in `tsconfig.base.json`
- Updates `target` and `lib` from `ES2022` to `esnext` per coding standards spec
- All packages inherit these strict settings, catching more bugs at compile time

Closes #55

## Changes

- `tsconfig.base.json`: Added `noPropertyAccessFromIndexSignature: true`, updated `target` and `lib` to `esnext`

## Test Plan

- [ ] Verify `tsconfig.base.json` contains all required strict options
- [ ] `pnpm nx run-many --target=type-check` passes on all packages
- [ ] Existing packages continue to compile without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)