### PR TITLE
feat(core): scaffold sync module with placeholder types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,4 @@
 // No IO, no React, no Supabase imports.
 export type { StreakResult, GoalProgress } from './goals/index.js';
 export type { TimerConfig, ReflectionData, TimerState, TimerEvent } from './timer/index.js';
+export type { QueueItemState, SyncEvent, RetryPolicy, SyncableEntityType } from './sync/index.js';

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -1,0 +1,1 @@
+export type { QueueItemState, SyncEvent, RetryPolicy, SyncableEntityType } from './types.js';

--- a/packages/core/src/sync/types.ts
+++ b/packages/core/src/sync/types.ts
@@ -1,0 +1,42 @@
+// Placeholder types for the outbox queue state machine (ADR-006).
+// Implementation comes in Phase 2 — these are type definitions only.
+
+// ── Syncable Entities ──
+
+/** Tables that participate in outbox sync (ADR-005). */
+export type SyncableEntityType =
+  | 'sessions'
+  | 'breaks'
+  | 'encouragement_taps'
+  | 'user_preferences'
+  | 'long_term_goals'
+  | 'process_goals';
+
+// ── Queue Item States ──
+
+/** Discriminated union for the state of a single outbox entry. */
+export type QueueItemState =
+  | { readonly type: 'pending' }
+  | { readonly type: 'uploading' }
+  | { readonly type: 'confirmed' }
+  | { readonly type: 'failed'; readonly errorMessage: string };
+
+// ── Sync Events ──
+
+/** Discriminated union for outbox queue state machine events. */
+export type SyncEvent =
+  | { readonly type: 'ENQUEUE'; readonly entryId: string; readonly entityType: SyncableEntityType; readonly entityId: string }
+  | { readonly type: 'UPLOAD_START'; readonly entryId: string }
+  | { readonly type: 'UPLOAD_SUCCESS'; readonly entryId: string }
+  | { readonly type: 'UPLOAD_FAILURE'; readonly entryId: string; readonly errorMessage: string }
+  | { readonly type: 'RETRY'; readonly entryId: string }
+  | { readonly type: 'NETWORK_AVAILABLE' };
+
+// ── Retry Policy ──
+
+/** Configuration for exponential backoff with jitter. */
+export type RetryPolicy = {
+  readonly maxRetries: number;
+  readonly baseDelayMs: number;
+  readonly jitterMs: number;
+};


### PR DESCRIPTION
## Summary

- Add `packages/core/src/sync/` directory with placeholder types for the outbox queue state machine (ADR-006)
- Define `QueueItemState` discriminated union (pending, uploading, confirmed, failed), `SyncEvent` union (6 events), `RetryPolicy` config type, and `SyncableEntityType` string union
- Re-export all sync types from `@pomofocus/core` barrel

Closes #62

## Test plan

- [x] `pnpm nx type-check @pomofocus/core` passes
- [x] `pnpm nx lint @pomofocus/core` passes
- [x] `pnpm nx affected -t type-check,lint --base=main` — all 4 affected projects pass
- [x] `import type { QueueItemState } from '@pomofocus/core'` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)