### PR TITLE
test: add example test in packages/core to validate pipeline

### DIFF
--- a/packages/core/src/example.test.ts
+++ b/packages/core/src/example.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import type { Session, FocusQuality } from '@pomofocus/types';
+
+describe('test pipeline validation', () => {
+  it('resolves @pomofocus/types cross-package import', () => {
+    const quality: FocusQuality = 'locked_in';
+    expect(quality).toBe('locked_in');
+  });
+
+  it('uses Session type from @pomofocus/types', () => {
+    const partial: Pick<Session, 'id' | 'completed'> = {
+      id: 'test-uuid',
+      completed: false,
+    };
+    expect(partial.id).toBe('test-uuid');
+    expect(partial.completed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a minimal test file (`packages/core/src/example.test.ts`) that validates the Vitest test pipeline works end-to-end
- Verifies cross-package `@pomofocus/types` imports resolve correctly (imports `Session` and `FocusQuality` types)
- Proves the full chain: Vitest workspace -> per-package config -> TypeScript compilation -> test execution -> result reporting

Closes #48

## Test plan
- [x] `pnpm nx test @pomofocus/core --run` passes
- [x] Test file co-located per TST-006 (`example.test.ts` next to source)
- [x] Cross-package type imports work (`@pomofocus/types`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)