### PR TITLE
Add Nx test targets to all apps (api, mobile, web)

### DIFF
--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -11,6 +11,12 @@
         "cwd": "apps/api"
       }
     },
+    "test": {
+      "command": "vitest run --config vitest.config.ts",
+      "options": {
+        "cwd": "apps/api"
+      }
+    },
     "type-check": {
       "command": "tsc -p tsconfig.lib.json --noEmit",
       "options": {

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+import rootConfig from '../../vitest.config';
+
+const appRoot = import.meta.dirname;
+const workspaceRoot = resolve(appRoot, '../..');
+
+export default mergeConfig(
+  rootConfig,
+  defineConfig({
+    test: {
+      environment: 'node',
+      include: ['src/**/*.test.ts'],
+    },
+    resolve: {
+      alias: {
+        '@pomofocus/types': resolve(workspaceRoot, 'packages/types/src/index.ts'),
+        '@pomofocus/core': resolve(workspaceRoot, 'packages/core/src/index.ts'),
+        '@pomofocus/analytics': resolve(workspaceRoot, 'packages/analytics/src/index.ts'),
+        '@pomofocus/data-access': resolve(workspaceRoot, 'packages/data-access/src/index.ts'),
+      },
+    },
+  }),
+);

--- a/apps/mobile/project.json
+++ b/apps/mobile/project.json
@@ -11,6 +11,12 @@
         "cwd": "apps/mobile"
       }
     },
+    "test": {
+      "command": "vitest run --config vitest.config.ts",
+      "options": {
+        "cwd": "apps/mobile"
+      }
+    },
     "type-check": {
       "command": "tsc -p tsconfig.json --noEmit",
       "options": {

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+import rootConfig from '../../vitest.config';
+
+const appRoot = import.meta.dirname;
+const workspaceRoot = resolve(appRoot, '../..');
+
+export default mergeConfig(
+  rootConfig,
+  defineConfig({
+    test: {
+      environment: 'node',
+      include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'app/**/*.test.ts', 'app/**/*.test.tsx'],
+    },
+    resolve: {
+      alias: {
+        '@pomofocus/types': resolve(workspaceRoot, 'packages/types/src/index.ts'),
+        '@pomofocus/core': resolve(workspaceRoot, 'packages/core/src/index.ts'),
+        '@pomofocus/state': resolve(workspaceRoot, 'packages/state/src/index.ts'),
+        '@pomofocus/ui': resolve(workspaceRoot, 'packages/ui/src/index.ts'),
+      },
+    },
+  }),
+);

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -11,6 +11,12 @@
         "cwd": "apps/web"
       }
     },
+    "test": {
+      "command": "vitest run --config vitest.config.ts",
+      "options": {
+        "cwd": "apps/web"
+      }
+    },
     "type-check": {
       "command": "tsc -p tsconfig.json --noEmit",
       "options": {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+import rootConfig from '../../vitest.config';
+
+const appRoot = import.meta.dirname;
+const workspaceRoot = resolve(appRoot, '../..');
+
+export default mergeConfig(
+  rootConfig,
+  defineConfig({
+    test: {
+      environment: 'jsdom',
+      include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'app/**/*.test.ts', 'app/**/*.test.tsx'],
+    },
+    resolve: {
+      alias: {
+        '@pomofocus/types': resolve(workspaceRoot, 'packages/types/src/index.ts'),
+        '@pomofocus/core': resolve(workspaceRoot, 'packages/core/src/index.ts'),
+        '@pomofocus/state': resolve(workspaceRoot, 'packages/state/src/index.ts'),
+        '@pomofocus/ui': resolve(workspaceRoot, 'packages/ui/src/index.ts'),
+      },
+    },
+  }),
+);


### PR DESCRIPTION
Add vitest test targets to apps/api, apps/mobile, and apps/web
project.json files, and create per-app vitest.config.ts files that
extend the root config. All packages already had test targets from
issue #47. This enables `pnpm nx run-many --target=test --all` and
`pnpm nx affected --target=test` across the full monorepo.

https://claude.ai/code/session_017VjQCK5SnE4gXkzDmyx7mv