### PR TITLE
feat: implement createInitialState and utility functions

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 // Pure domain logic: timer, goals, sessions, sync protocol.
 // No IO, no React, no Supabase imports.
 export type { StreakResult, GoalProgress } from './goals/index.js';
-export { TIMER_STATUS, TIMER_EVENT_TYPE } from './timer/index.js';
+export { TIMER_STATUS, TIMER_EVENT_TYPE, createInitialState, isRunning, getTimeRemaining } from './timer/index.js';
 export type {
   TimerStatus,
   TimerEventType,

--- a/packages/core/src/timer/index.ts
+++ b/packages/core/src/timer/index.ts
@@ -7,3 +7,4 @@ export type {
   TimerState,
   TimerEvent,
 } from './types.js';
+export { createInitialState, isRunning, getTimeRemaining } from './utils.js';

--- a/packages/core/src/timer/utils.test.ts
+++ b/packages/core/src/timer/utils.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import { createInitialState, isRunning, getTimeRemaining } from './utils.js';
+import { TIMER_STATUS } from './types.js';
+import type { TimerConfig, TimerState } from './types.js';
+
+const defaultConfig: TimerConfig = {
+  focusDuration: 1500,
+  shortBreakDuration: 300,
+  longBreakDuration: 900,
+  sessionsBeforeLongBreak: 4,
+  reflectionEnabled: true,
+};
+
+describe('createInitialState', () => {
+  it('returns idle state with the provided config', () => {
+    const state = createInitialState(defaultConfig);
+    expect(state).toEqual({ status: 'idle', config: defaultConfig });
+  });
+
+  it('preserves custom config values', () => {
+    const customConfig: TimerConfig = {
+      focusDuration: 3000,
+      shortBreakDuration: 600,
+      longBreakDuration: 1800,
+      sessionsBeforeLongBreak: 2,
+      reflectionEnabled: false,
+    };
+    const state = createInitialState(customConfig);
+    expect(state).toEqual({ status: 'idle', config: customConfig });
+  });
+});
+
+describe('isRunning', () => {
+  it('returns false for idle', () => {
+    const state: TimerState = { status: TIMER_STATUS.IDLE, config: defaultConfig };
+    expect(isRunning(state)).toBe(false);
+  });
+
+  it('returns true for focusing', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.FOCUSING,
+      timeRemaining: 1500,
+      startedAt: 1000,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    expect(isRunning(state)).toBe(true);
+  });
+
+  it('returns false for paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.PAUSED,
+      timeRemaining: 900,
+      pausedAt: 1600,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    expect(isRunning(state)).toBe(false);
+  });
+
+  it('returns true for short_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 300,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    expect(isRunning(state)).toBe(true);
+  });
+
+  it('returns true for long_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 900,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    expect(isRunning(state)).toBe(true);
+  });
+
+  it('returns false for break_paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 200,
+      pausedAt: 2700,
+      breakType: 'short',
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    expect(isRunning(state)).toBe(false);
+  });
+
+  it('returns false for reflection', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    expect(isRunning(state)).toBe(false);
+  });
+
+  it('returns false for completed', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.COMPLETED,
+      sessionNumber: 1,
+    };
+    expect(isRunning(state)).toBe(false);
+  });
+
+  it('returns false for abandoned', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.ABANDONED,
+      sessionNumber: 1,
+      abandonedAt: 5000,
+    };
+    expect(isRunning(state)).toBe(false);
+  });
+});
+
+describe('getTimeRemaining', () => {
+  it('returns 0 for idle', () => {
+    const state: TimerState = { status: TIMER_STATUS.IDLE, config: defaultConfig };
+    expect(getTimeRemaining(state)).toBe(0);
+  });
+
+  it('returns timeRemaining for focusing', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.FOCUSING,
+      timeRemaining: 1234,
+      startedAt: 1000,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    expect(getTimeRemaining(state)).toBe(1234);
+  });
+
+  it('returns timeRemaining for paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.PAUSED,
+      timeRemaining: 567,
+      pausedAt: 1600,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    expect(getTimeRemaining(state)).toBe(567);
+  });
+
+  it('returns timeRemaining for short_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 250,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    expect(getTimeRemaining(state)).toBe(250);
+  });
+
+  it('returns timeRemaining for long_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 800,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    expect(getTimeRemaining(state)).toBe(800);
+  });
+
+  it('returns timeRemaining for break_paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 150,
+      pausedAt: 2700,
+      breakType: 'long',
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    expect(getTimeRemaining(state)).toBe(150);
+  });
+
+  it('returns 0 for reflection', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    expect(getTimeRemaining(state)).toBe(0);
+  });
+
+  it('returns 0 for completed', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.COMPLETED,
+      sessionNumber: 1,
+    };
+    expect(getTimeRemaining(state)).toBe(0);
+  });
+
+  it('returns 0 for abandoned', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.ABANDONED,
+      sessionNumber: 1,
+      abandonedAt: 5000,
+    };
+    expect(getTimeRemaining(state)).toBe(0);
+  });
+});

--- a/packages/core/src/timer/utils.ts
+++ b/packages/core/src/timer/utils.ts
@@ -1,0 +1,49 @@
+import { TIMER_STATUS } from './types.js';
+import type { TimerConfig, TimerState } from './types.js';
+
+/** Returns an idle timer state with the given configuration. */
+export function createInitialState(config: TimerConfig): TimerState {
+  return { status: TIMER_STATUS.IDLE, config };
+}
+
+/** Returns true when the timer is actively counting down (focusing or on a break). */
+export function isRunning(state: TimerState): boolean {
+  switch (state.status) {
+    case TIMER_STATUS.FOCUSING:
+    case TIMER_STATUS.SHORT_BREAK:
+    case TIMER_STATUS.LONG_BREAK:
+      return true;
+    case TIMER_STATUS.IDLE:
+    case TIMER_STATUS.PAUSED:
+    case TIMER_STATUS.BREAK_PAUSED:
+    case TIMER_STATUS.REFLECTION:
+    case TIMER_STATUS.COMPLETED:
+    case TIMER_STATUS.ABANDONED:
+      return false;
+    default: {
+      const _exhaustive: never = state;
+      return _exhaustive;
+    }
+  }
+}
+
+/** Returns the seconds remaining for timed states, or 0 for states without a countdown. */
+export function getTimeRemaining(state: TimerState): number {
+  switch (state.status) {
+    case TIMER_STATUS.FOCUSING:
+    case TIMER_STATUS.PAUSED:
+    case TIMER_STATUS.SHORT_BREAK:
+    case TIMER_STATUS.LONG_BREAK:
+    case TIMER_STATUS.BREAK_PAUSED:
+      return state.timeRemaining;
+    case TIMER_STATUS.IDLE:
+    case TIMER_STATUS.REFLECTION:
+    case TIMER_STATUS.COMPLETED:
+    case TIMER_STATUS.ABANDONED:
+      return 0;
+    default: {
+      const _exhaustive: never = state;
+      return _exhaustive;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Implement `createInitialState(config)`, `isRunning(state)`, and `getTimeRemaining(state)` utility functions for the timer state machine in `packages/core/src/timer/utils.ts`
- Add comprehensive tests covering all 9 timer states for each utility function
- Re-export utility functions from `packages/core/src/timer/index.ts` and `packages/core/src/index.ts`

Closes #90

## Test plan

- [ ] `pnpm nx test @pomofocus/core` passes with no failures
- [ ] `pnpm nx type-check @pomofocus/core` exits clean
- [ ] All 9 timer states covered for `isRunning` and `getTimeRemaining`
- [ ] Exhaustive switch with `default: never` pattern used (U-008)
- [ ] No `any` or `as` assertions (U-001, U-009)

🤖 Generated with [Claude Code](https://claude.com/claude-code)