### PR TITLE
feat: implement START transition (idle -> focusing)

### DIFF
--- a/packages/core/src/timer/index.ts
+++ b/packages/core/src/timer/index.ts
@@ -9,3 +9,4 @@ export type {
 } from './types.js';
 export { createInitialState, isRunning, getTimeRemaining } from './utils.js';
 export { isLongBreak, isReflectionEnabled } from './guards.js';
+export { transition } from './transition.js';

--- a/packages/core/src/timer/transition.test.ts
+++ b/packages/core/src/timer/transition.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { transition } from './transition.js';
+import { TIMER_STATUS, TIMER_EVENT_TYPE } from './types.js';
+import type { TimerConfig, TimerState } from './types.js';
+
+const defaultConfig: TimerConfig = {
+  focusDuration: 1500,
+  shortBreakDuration: 300,
+  longBreakDuration: 900,
+  sessionsBeforeLongBreak: 4,
+  reflectionEnabled: true,
+};
+
+describe('transition — START event', () => {
+  it('transitions from idle to focusing with correct fields', () => {
+    const idle: TimerState = { status: TIMER_STATUS.IDLE, config: defaultConfig };
+    const now = 1000;
+    const result = transition(idle, { type: TIMER_EVENT_TYPE.START }, now);
+    expect(result).toEqual({
+      status: 'focusing',
+      timeRemaining: defaultConfig.focusDuration,
+      startedAt: now,
+      sessionNumber: 1,
+      config: defaultConfig,
+    });
+  });
+
+  it('uses custom focusDuration from config', () => {
+    const customConfig: TimerConfig = {
+      ...defaultConfig,
+      focusDuration: 3000,
+    };
+    const idle: TimerState = { status: TIMER_STATUS.IDLE, config: customConfig };
+    const now = 5000;
+    const result = transition(idle, { type: TIMER_EVENT_TYPE.START }, now);
+    expect(result).toEqual({
+      status: 'focusing',
+      timeRemaining: 3000,
+      startedAt: now,
+      sessionNumber: 1,
+      config: customConfig,
+    });
+  });
+
+  it('returns state unchanged when START from focusing', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.FOCUSING,
+      timeRemaining: 1200,
+      startedAt: 1000,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.START }, 2000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when START from paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.PAUSED,
+      timeRemaining: 900,
+      pausedAt: 1600,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.START }, 2000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when START from short_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 300,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.START }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when START from long_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 900,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.START }, 4000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when START from break_paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 200,
+      pausedAt: 2700,
+      breakType: 'short',
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.START }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when START from reflection', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.START }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when START from completed', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.COMPLETED,
+      sessionNumber: 1,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.START }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when START from abandoned', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.ABANDONED,
+      sessionNumber: 1,
+      abandonedAt: 5000,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.START }, 6000);
+    expect(result).toBe(state);
+  });
+});
+
+describe('transition — unhandled events return state unchanged', () => {
+  it('returns idle state unchanged for non-START events', () => {
+    const idle: TimerState = { status: TIMER_STATUS.IDLE, config: defaultConfig };
+    const now = 1000;
+    expect(transition(idle, { type: TIMER_EVENT_TYPE.PAUSE }, now)).toBe(idle);
+    expect(transition(idle, { type: TIMER_EVENT_TYPE.RESUME }, now)).toBe(idle);
+    expect(transition(idle, { type: TIMER_EVENT_TYPE.TICK }, now)).toBe(idle);
+    expect(transition(idle, { type: TIMER_EVENT_TYPE.TIMER_DONE }, now)).toBe(idle);
+    expect(transition(idle, { type: TIMER_EVENT_TYPE.SKIP }, now)).toBe(idle);
+    expect(
+      transition(
+        idle,
+        { type: TIMER_EVENT_TYPE.SUBMIT, data: { focusQuality: 'locked_in' } },
+        now,
+      ),
+    ).toBe(idle);
+    expect(transition(idle, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, now)).toBe(idle);
+    expect(transition(idle, { type: TIMER_EVENT_TYPE.ABANDON }, now)).toBe(idle);
+    expect(transition(idle, { type: TIMER_EVENT_TYPE.RESET }, now)).toBe(idle);
+  });
+});

--- a/packages/core/src/timer/transition.ts
+++ b/packages/core/src/timer/transition.ts
@@ -1,0 +1,45 @@
+import { TIMER_STATUS, TIMER_EVENT_TYPE } from './types.js';
+import type { TimerState, TimerEvent } from './types.js';
+
+export function transition(state: TimerState, event: TimerEvent, now: number): TimerState {
+  switch (state.status) {
+    case TIMER_STATUS.IDLE:
+      switch (event.type) {
+        case TIMER_EVENT_TYPE.START:
+          return {
+            status: TIMER_STATUS.FOCUSING,
+            timeRemaining: state.config.focusDuration,
+            startedAt: now,
+            sessionNumber: 1,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.PAUSE:
+        case TIMER_EVENT_TYPE.RESUME:
+        case TIMER_EVENT_TYPE.TICK:
+        case TIMER_EVENT_TYPE.TIMER_DONE:
+        case TIMER_EVENT_TYPE.SKIP:
+        case TIMER_EVENT_TYPE.SUBMIT:
+        case TIMER_EVENT_TYPE.SKIP_BREAK:
+        case TIMER_EVENT_TYPE.ABANDON:
+        case TIMER_EVENT_TYPE.RESET:
+          return state;
+        default: {
+          const _exhaustive: never = event;
+          return _exhaustive;
+        }
+      }
+    case TIMER_STATUS.FOCUSING:
+    case TIMER_STATUS.PAUSED:
+    case TIMER_STATUS.SHORT_BREAK:
+    case TIMER_STATUS.LONG_BREAK:
+    case TIMER_STATUS.BREAK_PAUSED:
+    case TIMER_STATUS.REFLECTION:
+    case TIMER_STATUS.COMPLETED:
+    case TIMER_STATUS.ABANDONED:
+      return state;
+    default: {
+      const _exhaustive: never = state;
+      return _exhaustive;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Implements the `transition()` function for the timer state machine, handling the START event from idle state to produce a focusing state with correct `timeRemaining`, `startedAt`, and `sessionNumber: 1`
- START from any non-idle state returns the state unchanged (no-op)
- All unhandled events for idle state return the state unchanged
- Exhaustive `switch` on both `state.status` and `event.type` with `never` defaults (U-008)

Closes #95

## Test plan

- [x] `transition(idleState, { type: 'START' }, now)` returns focusing state with correct fields
- [x] Custom `focusDuration` from config is respected
- [x] START from all 8 non-idle states returns state unchanged (identity)
- [x] All non-START events from idle return state unchanged
- [x] `pnpm nx test @pomofocus/core` passes
- [x] `pnpm nx type-check @pomofocus/core` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)