### PR TITLE
feat: configure CORS middleware with per-environment origins

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,9 @@
 import { Hono } from 'hono';
+import { corsMiddleware } from './middleware/cors.js';
 
 const app = new Hono();
+
+app.use('*', corsMiddleware);
 
 app.get('/health', (c) => {
   return c.json({ status: 'ok' });

--- a/apps/api/src/middleware/cors.test.ts
+++ b/apps/api/src/middleware/cors.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { createCorsMiddleware, parseOrigins } from './cors.js';
+
+/**
+ * Creates a test app with CORS middleware and a simple route.
+ */
+function createTestApp(allowedOrigins?: string): Hono {
+  const app = new Hono();
+  app.use('*', createCorsMiddleware(allowedOrigins));
+  app.get('/health', (c) => c.json({ status: 'ok' }));
+  return app;
+}
+
+describe('parseOrigins', () => {
+  it('parses comma-separated origins', () => {
+    expect(parseOrigins('https://app.pomofocus.dev,https://pomofocus.dev')).toEqual([
+      'https://app.pomofocus.dev',
+      'https://pomofocus.dev',
+    ]);
+  });
+
+  it('trims whitespace around origins', () => {
+    expect(parseOrigins('  https://a.com , https://b.com  ')).toEqual([
+      'https://a.com',
+      'https://b.com',
+    ]);
+  });
+
+  it('filters out empty strings from trailing commas', () => {
+    expect(parseOrigins('https://a.com,,https://b.com,')).toEqual([
+      'https://a.com',
+      'https://b.com',
+    ]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parseOrigins('')).toEqual([]);
+  });
+});
+
+describe('createCorsMiddleware', () => {
+  describe('preflight requests', () => {
+    it('returns 204 for OPTIONS preflight', async () => {
+      const app = createTestApp();
+      const res = await app.request('/health', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'http://localhost:3000',
+          'Access-Control-Request-Method': 'GET',
+        },
+      });
+
+      expect(res.status).toBe(204);
+    });
+
+    it('includes CORS headers on preflight response', async () => {
+      const app = createTestApp();
+      const res = await app.request('/health', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'http://localhost:3000',
+          'Access-Control-Request-Method': 'GET',
+        },
+      });
+
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3000');
+      expect(res.headers.get('Access-Control-Allow-Methods')).toContain('GET');
+      expect(res.headers.get('Access-Control-Allow-Headers')).toContain('Content-Type');
+      expect(res.headers.get('Access-Control-Allow-Headers')).toContain('Authorization');
+    });
+  });
+
+  describe('default dev origins', () => {
+    it('allows localhost:3000 when no ALLOWED_ORIGINS set', async () => {
+      const app = createTestApp(undefined);
+      const res = await app.request('/health', {
+        headers: { Origin: 'http://localhost:3000' },
+      });
+
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3000');
+    });
+
+    it('allows localhost:5173 when no ALLOWED_ORIGINS set', async () => {
+      const app = createTestApp(undefined);
+      const res = await app.request('/health', {
+        headers: { Origin: 'http://localhost:5173' },
+      });
+
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:5173');
+    });
+
+    it('rejects unknown origins when no ALLOWED_ORIGINS set', async () => {
+      const app = createTestApp(undefined);
+      const res = await app.request('/health', {
+        headers: { Origin: 'https://evil.com' },
+      });
+
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    });
+  });
+
+  describe('configured origins', () => {
+    it('allows configured production origin', async () => {
+      const app = createTestApp('https://app.pomofocus.dev,https://pomofocus.dev');
+      const res = await app.request('/health', {
+        headers: { Origin: 'https://app.pomofocus.dev' },
+      });
+
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://app.pomofocus.dev');
+    });
+
+    it('rejects origins not in the configured list', async () => {
+      const app = createTestApp('https://app.pomofocus.dev');
+      const res = await app.request('/health', {
+        headers: { Origin: 'https://evil.com' },
+      });
+
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    });
+  });
+
+  describe('CORS headers on regular responses', () => {
+    it('includes CORS headers on GET response', async () => {
+      const app = createTestApp();
+      const res = await app.request('/health', {
+        headers: { Origin: 'http://localhost:3000' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3000');
+    });
+
+    it('includes credentials header', async () => {
+      const app = createTestApp();
+      const res = await app.request('/health', {
+        headers: { Origin: 'http://localhost:3000' },
+      });
+
+      expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    });
+  });
+});

--- a/apps/api/src/middleware/cors.ts
+++ b/apps/api/src/middleware/cors.ts
@@ -1,0 +1,67 @@
+import { cors } from 'hono/cors';
+import type { MiddlewareHandler } from 'hono';
+
+/**
+ * Default allowed origins used when no ALLOWED_ORIGINS env var is set.
+ * Covers common local development ports.
+ */
+const DEFAULT_DEV_ORIGINS: readonly string[] = [
+  'http://localhost:3000',
+  'http://localhost:5173',
+  'http://localhost:8787',
+];
+
+/**
+ * Parses a comma-separated string of origins into an array.
+ * Trims whitespace and filters out empty strings.
+ */
+export function parseOrigins(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((o) => o.trim())
+    .filter((o) => o.length > 0);
+}
+
+/**
+ * Creates CORS middleware configured from environment bindings.
+ *
+ * Reads `ALLOWED_ORIGINS` from Cloudflare Workers env vars.
+ * - If set: parses as comma-separated list of allowed origins.
+ * - If empty/missing: falls back to localhost dev origins.
+ *
+ * Preflight OPTIONS requests return 204 (Hono default).
+ * Standard CORS headers are added to all responses.
+ */
+export function createCorsMiddleware(allowedOrigins: string | undefined): MiddlewareHandler {
+  const origins = allowedOrigins ? parseOrigins(allowedOrigins) : [...DEFAULT_DEV_ORIGINS];
+
+  return cors({
+    origin: origins,
+    allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowHeaders: ['Content-Type', 'Authorization'],
+    exposeHeaders: ['Content-Length'],
+    maxAge: 86400,
+    credentials: true,
+  });
+}
+
+/**
+ * Environment bindings for CORS configuration.
+ * Extends any existing env type with the optional ALLOWED_ORIGINS var.
+ */
+export type CorsEnv = {
+  readonly ALLOWED_ORIGINS?: string;
+};
+
+/**
+ * CORS middleware that reads allowed origins from Cloudflare Workers env
+ * on each request. This is necessary because CF Workers env is only
+ * available at request time, not at module scope.
+ *
+ * Wire into the app via `app.use('*', corsMiddleware)`.
+ */
+export const corsMiddleware: MiddlewareHandler<{ Bindings: CorsEnv }> = async (c, next) => {
+  const allowedOrigins = c.env.ALLOWED_ORIGINS;
+  const handler = createCorsMiddleware(allowedOrigins);
+  return handler(c, next);
+};

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -5,3 +5,4 @@ compatibility_date = "2026-03-14"
 [vars]
 SUPABASE_URL = ""
 SUPABASE_SERVICE_ROLE_KEY = ""
+ALLOWED_ORIGINS = ""


### PR DESCRIPTION
## Summary
- Adds CORS middleware to the Hono API with environment-aware origin configuration (localhost for dev, production domain for prod)
- OPTIONS preflight requests return 204 with correct CORS headers
- Includes comprehensive test suite for CORS behavior

Closes #98

## Test plan
- [ ] `pnpm nx type-check @pomofocus/api` passes
- [ ] `pnpm nx test @pomofocus/api` passes (CORS test suite)
- [ ] `curl -I -X OPTIONS http://localhost:8787/health` returns CORS headers
- [ ] Verify allowed origins match per-environment configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)