### PR TITLE
feat: implement break state transitions (PAUSE, RESUME, TICK, SKIP_BREAK)

### DIFF
--- a/packages/core/src/timer/transition.test.ts
+++ b/packages/core/src/timer/transition.test.ts
@@ -185,7 +185,7 @@ describe('transition — PAUSE event', () => {
     expect(result).toBe(state);
   });
 
-  it('returns state unchanged when PAUSE from short_break', () => {
+  it('transitions from short_break to break_paused with breakType short', () => {
     const state: TimerState = {
       status: TIMER_STATUS.SHORT_BREAK,
       timeRemaining: 300,
@@ -193,11 +193,19 @@ describe('transition — PAUSE event', () => {
       sessionNumber: 1,
       config: defaultConfig,
     };
-    const result = transition(state, { type: TIMER_EVENT_TYPE.PAUSE }, 3000);
-    expect(result).toBe(state);
+    const now = 3000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.PAUSE }, now);
+    expect(result).toEqual({
+      status: 'break_paused',
+      timeRemaining: 300,
+      pausedAt: now,
+      breakType: 'short',
+      sessionNumber: 1,
+      config: defaultConfig,
+    });
   });
 
-  it('returns state unchanged when PAUSE from long_break', () => {
+  it('transitions from long_break to break_paused with breakType long', () => {
     const state: TimerState = {
       status: TIMER_STATUS.LONG_BREAK,
       timeRemaining: 900,
@@ -205,8 +213,16 @@ describe('transition — PAUSE event', () => {
       sessionNumber: 4,
       config: defaultConfig,
     };
-    const result = transition(state, { type: TIMER_EVENT_TYPE.PAUSE }, 4000);
-    expect(result).toBe(state);
+    const now = 4000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.PAUSE }, now);
+    expect(result).toEqual({
+      status: 'break_paused',
+      timeRemaining: 900,
+      pausedAt: now,
+      breakType: 'long',
+      sessionNumber: 4,
+      config: defaultConfig,
+    });
   });
 
   it('returns state unchanged when PAUSE from reflection', () => {
@@ -288,30 +304,6 @@ describe('transition — RESUME event', () => {
       config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.RESUME }, 2000);
-    expect(result).toBe(state);
-  });
-
-  it('returns state unchanged when RESUME from short_break', () => {
-    const state: TimerState = {
-      status: TIMER_STATUS.SHORT_BREAK,
-      timeRemaining: 300,
-      startedAt: 2500,
-      sessionNumber: 1,
-      config: defaultConfig,
-    };
-    const result = transition(state, { type: TIMER_EVENT_TYPE.RESUME }, 3000);
-    expect(result).toBe(state);
-  });
-
-  it('returns state unchanged when RESUME from long_break', () => {
-    const state: TimerState = {
-      status: TIMER_STATUS.LONG_BREAK,
-      timeRemaining: 900,
-      startedAt: 3000,
-      sessionNumber: 4,
-      config: defaultConfig,
-    };
-    const result = transition(state, { type: TIMER_EVENT_TYPE.RESUME }, 4000);
     expect(result).toBe(state);
   });
 
@@ -424,7 +416,7 @@ describe('transition — TICK event', () => {
     expect(result).toBe(state);
   });
 
-  it('returns state unchanged when TICK from short_break', () => {
+  it('decrements timeRemaining by 1 from short_break', () => {
     const state: TimerState = {
       status: TIMER_STATUS.SHORT_BREAK,
       timeRemaining: 300,
@@ -433,10 +425,16 @@ describe('transition — TICK event', () => {
       config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.TICK }, 3000);
-    expect(result).toBe(state);
+    expect(result).toEqual({
+      status: 'short_break',
+      timeRemaining: 299,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: defaultConfig,
+    });
   });
 
-  it('returns state unchanged when TICK from long_break', () => {
+  it('decrements timeRemaining by 1 from long_break', () => {
     const state: TimerState = {
       status: TIMER_STATUS.LONG_BREAK,
       timeRemaining: 900,
@@ -445,7 +443,13 @@ describe('transition — TICK event', () => {
       config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.TICK }, 4000);
-    expect(result).toBe(state);
+    expect(result).toEqual({
+      status: 'long_break',
+      timeRemaining: 899,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    });
   });
 
   it('returns state unchanged when TICK from reflection', () => {
@@ -674,6 +678,385 @@ describe('transition — TIMER_DONE event', () => {
       abandonedAt: 5000,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.TIMER_DONE }, 6000);
+    expect(result).toBe(state);
+  });
+});
+
+describe('transition — PAUSE from break states', () => {
+  it('preserves timeRemaining when pausing short_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 150,
+      startedAt: 2000,
+      sessionNumber: 2,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.PAUSE }, 2500);
+    expect(result).toEqual(
+      expect.objectContaining({ timeRemaining: 150, sessionNumber: 2 }),
+    );
+  });
+
+  it('preserves timeRemaining when pausing long_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 450,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.PAUSE }, 3500);
+    expect(result).toEqual(
+      expect.objectContaining({ timeRemaining: 450, sessionNumber: 4 }),
+    );
+  });
+
+  it('returns state unchanged when PAUSE from break_paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 200,
+      pausedAt: 2700,
+      breakType: 'short',
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.PAUSE }, 3000);
+    expect(result).toBe(state);
+  });
+});
+
+describe('transition — RESUME from break_paused', () => {
+  it('resumes to short_break when breakType is short', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 200,
+      pausedAt: 2700,
+      breakType: 'short',
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const now = 3000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESUME }, now);
+    expect(result).toEqual({
+      status: 'short_break',
+      timeRemaining: 200,
+      startedAt: now,
+      sessionNumber: 1,
+      config: defaultConfig,
+    });
+  });
+
+  it('resumes to long_break when breakType is long', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 600,
+      pausedAt: 4000,
+      breakType: 'long',
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const now = 5000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESUME }, now);
+    expect(result).toEqual({
+      status: 'long_break',
+      timeRemaining: 600,
+      startedAt: now,
+      sessionNumber: 4,
+      config: defaultConfig,
+    });
+  });
+
+  it('preserves timeRemaining across pause/resume cycle', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 123,
+      pausedAt: 5000,
+      breakType: 'short',
+      sessionNumber: 2,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESUME }, 6000);
+    expect(result).toEqual(
+      expect.objectContaining({ timeRemaining: 123 }),
+    );
+  });
+
+  it('returns state unchanged when RESUME from short_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 300,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESUME }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when RESUME from long_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 900,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESUME }, 4000);
+    expect(result).toBe(state);
+  });
+});
+
+describe('transition — TICK from break states', () => {
+  it('does not decrement short_break timeRemaining below 0', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 0,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.TICK }, 3000);
+    expect(result).toEqual(
+      expect.objectContaining({ timeRemaining: 0 }),
+    );
+  });
+
+  it('does not decrement long_break timeRemaining below 0', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 0,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.TICK }, 4000);
+    expect(result).toEqual(
+      expect.objectContaining({ timeRemaining: 0 }),
+    );
+  });
+
+  it('preserves startedAt and sessionNumber across short_break tick', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 200,
+      startedAt: 2500,
+      sessionNumber: 2,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.TICK }, 3000);
+    expect(result).toEqual(
+      expect.objectContaining({ startedAt: 2500, sessionNumber: 2 }),
+    );
+  });
+
+  it('preserves startedAt and sessionNumber across long_break tick', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 800,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.TICK }, 4000);
+    expect(result).toEqual(
+      expect.objectContaining({ startedAt: 3000, sessionNumber: 4 }),
+    );
+  });
+
+  it('returns state unchanged when TICK from break_paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 200,
+      pausedAt: 2700,
+      breakType: 'short',
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.TICK }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when TICK from break_paused (long)', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 600,
+      pausedAt: 4000,
+      breakType: 'long',
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.TICK }, 5000);
+    expect(result).toBe(state);
+  });
+});
+
+describe('transition — SKIP_BREAK event', () => {
+  it('transitions from short_break to reflection when reflectionEnabled', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 200,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, 3000);
+    expect(result).toEqual({
+      status: 'reflection',
+      sessionNumber: 1,
+      config: defaultConfig,
+    });
+  });
+
+  it('transitions from long_break to reflection when reflectionEnabled', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 600,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, 4000);
+    expect(result).toEqual({
+      status: 'reflection',
+      sessionNumber: 4,
+      config: defaultConfig,
+    });
+  });
+
+  it('transitions from break_paused to reflection when reflectionEnabled', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 200,
+      pausedAt: 2700,
+      breakType: 'short',
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, 3000);
+    expect(result).toEqual({
+      status: 'reflection',
+      sessionNumber: 1,
+      config: defaultConfig,
+    });
+  });
+
+  it('transitions from short_break to focusing with sessionNumber + 1 when reflection disabled', () => {
+    const noReflectionConfig: TimerConfig = { ...defaultConfig, reflectionEnabled: false };
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 200,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: noReflectionConfig,
+    };
+    const now = 3000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, now);
+    expect(result).toEqual({
+      status: 'focusing',
+      timeRemaining: noReflectionConfig.focusDuration,
+      startedAt: now,
+      sessionNumber: 2,
+      config: noReflectionConfig,
+    });
+  });
+
+  it('transitions from long_break to focusing with sessionNumber + 1 when reflection disabled', () => {
+    const noReflectionConfig: TimerConfig = { ...defaultConfig, reflectionEnabled: false };
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 600,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: noReflectionConfig,
+    };
+    const now = 4000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, now);
+    expect(result).toEqual({
+      status: 'focusing',
+      timeRemaining: noReflectionConfig.focusDuration,
+      startedAt: now,
+      sessionNumber: 5,
+      config: noReflectionConfig,
+    });
+  });
+
+  it('transitions from break_paused to focusing with sessionNumber + 1 when reflection disabled', () => {
+    const noReflectionConfig: TimerConfig = { ...defaultConfig, reflectionEnabled: false };
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 200,
+      pausedAt: 2700,
+      breakType: 'long',
+      sessionNumber: 4,
+      config: noReflectionConfig,
+    };
+    const now = 3000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, now);
+    expect(result).toEqual({
+      status: 'focusing',
+      timeRemaining: noReflectionConfig.focusDuration,
+      startedAt: now,
+      sessionNumber: 5,
+      config: noReflectionConfig,
+    });
+  });
+
+  it('returns state unchanged when SKIP_BREAK from idle', () => {
+    const state: TimerState = { status: TIMER_STATUS.IDLE, config: defaultConfig };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, 1000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP_BREAK from focusing', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.FOCUSING,
+      timeRemaining: 1200,
+      startedAt: 1000,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, 2000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP_BREAK from paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.PAUSED,
+      timeRemaining: 900,
+      pausedAt: 1600,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, 2000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP_BREAK from reflection', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP_BREAK from completed', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.COMPLETED,
+      sessionNumber: 1,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP_BREAK from abandoned', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.ABANDONED,
+      sessionNumber: 1,
+      abandonedAt: 5000,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, 6000);
     expect(result).toBe(state);
   });
 });

--- a/packages/core/src/timer/transition.ts
+++ b/packages/core/src/timer/transition.ts
@@ -1,6 +1,6 @@
 import { TIMER_STATUS, TIMER_EVENT_TYPE } from './types.js';
 import type { TimerState, TimerEvent } from './types.js';
-import { isLongBreak } from './guards.js';
+import { isLongBreak, isReflectionEnabled } from './guards.js';
 
 export function transition(state: TimerState, event: TimerEvent, now: number): TimerState {
   switch (state.status) {
@@ -103,8 +103,147 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
         }
       }
     case TIMER_STATUS.SHORT_BREAK:
+      switch (event.type) {
+        case TIMER_EVENT_TYPE.PAUSE:
+          return {
+            status: TIMER_STATUS.BREAK_PAUSED,
+            timeRemaining: state.timeRemaining,
+            pausedAt: now,
+            breakType: 'short',
+            sessionNumber: state.sessionNumber,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.TICK:
+          return {
+            status: TIMER_STATUS.SHORT_BREAK,
+            timeRemaining: Math.max(0, state.timeRemaining - 1),
+            startedAt: state.startedAt,
+            sessionNumber: state.sessionNumber,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.SKIP_BREAK:
+          if (isReflectionEnabled(state.config)) {
+            return {
+              status: TIMER_STATUS.REFLECTION,
+              sessionNumber: state.sessionNumber,
+              config: state.config,
+            };
+          }
+          return {
+            status: TIMER_STATUS.FOCUSING,
+            timeRemaining: state.config.focusDuration,
+            startedAt: now,
+            sessionNumber: state.sessionNumber + 1,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.START:
+        case TIMER_EVENT_TYPE.RESUME:
+        case TIMER_EVENT_TYPE.TIMER_DONE:
+        case TIMER_EVENT_TYPE.SKIP:
+        case TIMER_EVENT_TYPE.SUBMIT:
+        case TIMER_EVENT_TYPE.ABANDON:
+        case TIMER_EVENT_TYPE.RESET:
+          return state;
+        default: {
+          const _exhaustive: never = event;
+          return _exhaustive;
+        }
+      }
     case TIMER_STATUS.LONG_BREAK:
+      switch (event.type) {
+        case TIMER_EVENT_TYPE.PAUSE:
+          return {
+            status: TIMER_STATUS.BREAK_PAUSED,
+            timeRemaining: state.timeRemaining,
+            pausedAt: now,
+            breakType: 'long',
+            sessionNumber: state.sessionNumber,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.TICK:
+          return {
+            status: TIMER_STATUS.LONG_BREAK,
+            timeRemaining: Math.max(0, state.timeRemaining - 1),
+            startedAt: state.startedAt,
+            sessionNumber: state.sessionNumber,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.SKIP_BREAK:
+          if (isReflectionEnabled(state.config)) {
+            return {
+              status: TIMER_STATUS.REFLECTION,
+              sessionNumber: state.sessionNumber,
+              config: state.config,
+            };
+          }
+          return {
+            status: TIMER_STATUS.FOCUSING,
+            timeRemaining: state.config.focusDuration,
+            startedAt: now,
+            sessionNumber: state.sessionNumber + 1,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.START:
+        case TIMER_EVENT_TYPE.RESUME:
+        case TIMER_EVENT_TYPE.TIMER_DONE:
+        case TIMER_EVENT_TYPE.SKIP:
+        case TIMER_EVENT_TYPE.SUBMIT:
+        case TIMER_EVENT_TYPE.ABANDON:
+        case TIMER_EVENT_TYPE.RESET:
+          return state;
+        default: {
+          const _exhaustive: never = event;
+          return _exhaustive;
+        }
+      }
     case TIMER_STATUS.BREAK_PAUSED:
+      switch (event.type) {
+        case TIMER_EVENT_TYPE.RESUME:
+          if (state.breakType === 'short') {
+            return {
+              status: TIMER_STATUS.SHORT_BREAK,
+              timeRemaining: state.timeRemaining,
+              startedAt: now,
+              sessionNumber: state.sessionNumber,
+              config: state.config,
+            };
+          }
+          return {
+            status: TIMER_STATUS.LONG_BREAK,
+            timeRemaining: state.timeRemaining,
+            startedAt: now,
+            sessionNumber: state.sessionNumber,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.SKIP_BREAK:
+          if (isReflectionEnabled(state.config)) {
+            return {
+              status: TIMER_STATUS.REFLECTION,
+              sessionNumber: state.sessionNumber,
+              config: state.config,
+            };
+          }
+          return {
+            status: TIMER_STATUS.FOCUSING,
+            timeRemaining: state.config.focusDuration,
+            startedAt: now,
+            sessionNumber: state.sessionNumber + 1,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.START:
+        case TIMER_EVENT_TYPE.PAUSE:
+        case TIMER_EVENT_TYPE.TICK:
+        case TIMER_EVENT_TYPE.TIMER_DONE:
+        case TIMER_EVENT_TYPE.SKIP:
+        case TIMER_EVENT_TYPE.SUBMIT:
+        case TIMER_EVENT_TYPE.ABANDON:
+        case TIMER_EVENT_TYPE.RESET:
+          return state;
+        default: {
+          const _exhaustive: never = event;
+          return _exhaustive;
+        }
+      }
     case TIMER_STATUS.REFLECTION:
     case TIMER_STATUS.COMPLETED:
     case TIMER_STATUS.ABANDONED:


### PR DESCRIPTION
## Summary

- Implements break state transitions for the timer FSM: PAUSE, RESUME, TICK, and SKIP_BREAK on `short_break`, `long_break`, and `break_paused` states
- Adds `break_paused` state with `breakType` tracking to correctly restore the original break type on RESUME
- SKIP_BREAK transitions to `reflection` (if enabled) or next `focusing` session with incremented `sessionNumber`

Closes #101

## Test plan

- [x] PAUSE from `short_break` → `break_paused` with `breakType: 'short'`
- [x] PAUSE from `long_break` → `break_paused` with `breakType: 'long'`
- [x] RESUME from `break_paused` → correct break type based on stored `breakType`
- [x] TICK decrements `timeRemaining` on break states, rejected on `break_paused`
- [x] SKIP_BREAK from any break state → `reflection` or `focusing` based on `reflectionEnabled`
- [x] SKIP_BREAK rejected from non-break states
- [x] `pnpm nx test @pomofocus/core` passes
- [x] `pnpm nx type-check @pomofocus/core` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)