### PR TITLE
feat: implement break completion transitions

### DIFF
--- a/packages/core/src/timer/transition.test.ts
+++ b/packages/core/src/timer/transition.test.ts
@@ -615,28 +615,76 @@ describe('transition — TIMER_DONE event', () => {
     expect(result).toBe(state);
   });
 
-  it('returns state unchanged when TIMER_DONE from short_break', () => {
+  it('transitions from short_break to reflection when reflectionEnabled', () => {
     const state: TimerState = {
       status: TIMER_STATUS.SHORT_BREAK,
-      timeRemaining: 300,
+      timeRemaining: 0,
       startedAt: 2500,
       sessionNumber: 1,
       config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.TIMER_DONE }, 3000);
-    expect(result).toBe(state);
+    expect(result).toEqual({
+      status: 'reflection',
+      sessionNumber: 1,
+      config: defaultConfig,
+    });
   });
 
-  it('returns state unchanged when TIMER_DONE from long_break', () => {
+  it('transitions from short_break to focusing with sessionNumber + 1 when reflection disabled', () => {
+    const noReflectionConfig: TimerConfig = { ...defaultConfig, reflectionEnabled: false };
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 0,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: noReflectionConfig,
+    };
+    const now = 3000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.TIMER_DONE }, now);
+    expect(result).toEqual({
+      status: 'focusing',
+      timeRemaining: noReflectionConfig.focusDuration,
+      startedAt: now,
+      sessionNumber: 2,
+      config: noReflectionConfig,
+    });
+  });
+
+  it('transitions from long_break to reflection when reflectionEnabled', () => {
     const state: TimerState = {
       status: TIMER_STATUS.LONG_BREAK,
-      timeRemaining: 900,
+      timeRemaining: 0,
       startedAt: 3000,
       sessionNumber: 4,
       config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.TIMER_DONE }, 4000);
-    expect(result).toBe(state);
+    expect(result).toEqual({
+      status: 'reflection',
+      sessionNumber: 4,
+      config: defaultConfig,
+    });
+  });
+
+  it('transitions from long_break to focusing with sessionNumber + 1 when reflection disabled', () => {
+    const noReflectionConfig: TimerConfig = { ...defaultConfig, reflectionEnabled: false };
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 0,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: noReflectionConfig,
+    };
+    const now = 4000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.TIMER_DONE }, now);
+    expect(result).toEqual({
+      status: 'focusing',
+      timeRemaining: noReflectionConfig.focusDuration,
+      startedAt: now,
+      sessionNumber: 5,
+      config: noReflectionConfig,
+    });
   });
 
   it('returns state unchanged when TIMER_DONE from break_paused', () => {

--- a/packages/core/src/timer/transition.ts
+++ b/packages/core/src/timer/transition.ts
@@ -121,6 +121,7 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
             sessionNumber: state.sessionNumber,
             config: state.config,
           };
+        case TIMER_EVENT_TYPE.TIMER_DONE:
         case TIMER_EVENT_TYPE.SKIP_BREAK:
           if (isReflectionEnabled(state.config)) {
             return {
@@ -138,7 +139,6 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
           };
         case TIMER_EVENT_TYPE.START:
         case TIMER_EVENT_TYPE.RESUME:
-        case TIMER_EVENT_TYPE.TIMER_DONE:
         case TIMER_EVENT_TYPE.SKIP:
         case TIMER_EVENT_TYPE.SUBMIT:
         case TIMER_EVENT_TYPE.ABANDON:
@@ -168,6 +168,7 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
             sessionNumber: state.sessionNumber,
             config: state.config,
           };
+        case TIMER_EVENT_TYPE.TIMER_DONE:
         case TIMER_EVENT_TYPE.SKIP_BREAK:
           if (isReflectionEnabled(state.config)) {
             return {
@@ -185,7 +186,6 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
           };
         case TIMER_EVENT_TYPE.START:
         case TIMER_EVENT_TYPE.RESUME:
-        case TIMER_EVENT_TYPE.TIMER_DONE:
         case TIMER_EVENT_TYPE.SKIP:
         case TIMER_EVENT_TYPE.SUBMIT:
         case TIMER_EVENT_TYPE.ABANDON:


### PR DESCRIPTION
## Summary

- Implements TIMER_DONE transitions from `short_break` and `long_break` states
- When `reflectionEnabled = true`, breaks transition to `reflection` state (preserving sessionNumber and config)
- When `reflectionEnabled = false`, breaks transition to `focusing` state (incrementing sessionNumber, resetting timeRemaining and startedAt)
- Adds 4 test cases covering both break types with reflection on/off

Closes #104

## Test plan

- [x] `pnpm nx test @pomofocus/core` passes with no failures
- [x] `pnpm nx type-check @pomofocus/core` exits clean
- [x] TIMER_DONE from `short_break` with reflection enabled → `reflection`
- [x] TIMER_DONE from `short_break` with reflection disabled → `focusing` with sessionNumber + 1
- [x] TIMER_DONE from `long_break` with reflection enabled → `reflection`
- [x] TIMER_DONE from `long_break` with reflection disabled → `focusing` with sessionNumber + 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)