### PR TITLE
feat: implement reflection transitions (SUBMIT, SKIP)

### DIFF
--- a/packages/core/src/timer/transition.test.ts
+++ b/packages/core/src/timer/transition.test.ts
@@ -1109,6 +1109,331 @@ describe('transition — SKIP_BREAK event', () => {
   });
 });
 
+describe('transition — SUBMIT event', () => {
+  it('transitions from reflection to completed with reflectionData (locked_in)', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(
+      state,
+      {
+        type: TIMER_EVENT_TYPE.SUBMIT,
+        data: { focusQuality: 'locked_in', distractionType: 'phone' },
+      },
+      3000,
+    );
+    expect(result).toEqual({
+      status: 'completed',
+      sessionNumber: 1,
+      reflectionData: { focusQuality: 'locked_in', distractionType: 'phone' },
+    });
+  });
+
+  it('transitions from reflection to completed with reflectionData (decent)', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 2,
+      config: defaultConfig,
+    };
+    const result = transition(
+      state,
+      {
+        type: TIMER_EVENT_TYPE.SUBMIT,
+        data: { focusQuality: 'decent', distractionType: 'thoughts_wandering' },
+      },
+      4000,
+    );
+    expect(result).toEqual({
+      status: 'completed',
+      sessionNumber: 2,
+      reflectionData: { focusQuality: 'decent', distractionType: 'thoughts_wandering' },
+    });
+  });
+
+  it('transitions from reflection to completed with reflectionData (struggled)', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 3,
+      config: defaultConfig,
+    };
+    const result = transition(
+      state,
+      {
+        type: TIMER_EVENT_TYPE.SUBMIT,
+        data: { focusQuality: 'struggled', distractionType: 'got_stuck' },
+      },
+      5000,
+    );
+    expect(result).toEqual({
+      status: 'completed',
+      sessionNumber: 3,
+      reflectionData: { focusQuality: 'struggled', distractionType: 'got_stuck' },
+    });
+  });
+
+  it('preserves sessionNumber in completed state after SUBMIT', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(
+      state,
+      {
+        type: TIMER_EVENT_TYPE.SUBMIT,
+        data: { focusQuality: 'locked_in' },
+      },
+      6000,
+    );
+    expect(result).toEqual(
+      expect.objectContaining({ sessionNumber: 4 }),
+    );
+  });
+
+  it('returns state unchanged when SUBMIT from idle', () => {
+    const state: TimerState = { status: TIMER_STATUS.IDLE, config: defaultConfig };
+    const result = transition(
+      state,
+      { type: TIMER_EVENT_TYPE.SUBMIT, data: { focusQuality: 'locked_in' } },
+      1000,
+    );
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SUBMIT from focusing', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.FOCUSING,
+      timeRemaining: 1200,
+      startedAt: 1000,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(
+      state,
+      { type: TIMER_EVENT_TYPE.SUBMIT, data: { focusQuality: 'decent' } },
+      2000,
+    );
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SUBMIT from paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.PAUSED,
+      timeRemaining: 900,
+      pausedAt: 1600,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(
+      state,
+      { type: TIMER_EVENT_TYPE.SUBMIT, data: { focusQuality: 'struggled' } },
+      2000,
+    );
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SUBMIT from short_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 300,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(
+      state,
+      { type: TIMER_EVENT_TYPE.SUBMIT, data: { focusQuality: 'locked_in' } },
+      3000,
+    );
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SUBMIT from long_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 900,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(
+      state,
+      { type: TIMER_EVENT_TYPE.SUBMIT, data: { focusQuality: 'decent' } },
+      4000,
+    );
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SUBMIT from break_paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 200,
+      pausedAt: 2700,
+      breakType: 'short',
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(
+      state,
+      { type: TIMER_EVENT_TYPE.SUBMIT, data: { focusQuality: 'struggled' } },
+      3000,
+    );
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SUBMIT from completed', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.COMPLETED,
+      sessionNumber: 1,
+    };
+    const result = transition(
+      state,
+      { type: TIMER_EVENT_TYPE.SUBMIT, data: { focusQuality: 'locked_in' } },
+      3000,
+    );
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SUBMIT from abandoned', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.ABANDONED,
+      sessionNumber: 1,
+      abandonedAt: 5000,
+    };
+    const result = transition(
+      state,
+      { type: TIMER_EVENT_TYPE.SUBMIT, data: { focusQuality: 'decent' } },
+      6000,
+    );
+    expect(result).toBe(state);
+  });
+});
+
+describe('transition — SKIP event', () => {
+  it('transitions from reflection to completed without reflectionData', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 3000);
+    expect(result).toEqual({
+      status: 'completed',
+      sessionNumber: 1,
+    });
+  });
+
+  it('preserves sessionNumber in completed state after SKIP', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 6000);
+    expect(result).toEqual(
+      expect.objectContaining({ sessionNumber: 4 }),
+    );
+  });
+
+  it('does not include reflectionData in completed state after SKIP', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 2,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 4000);
+    expect(result).not.toHaveProperty('reflectionData');
+  });
+
+  it('returns state unchanged when SKIP from idle', () => {
+    const state: TimerState = { status: TIMER_STATUS.IDLE, config: defaultConfig };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 1000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP from focusing', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.FOCUSING,
+      timeRemaining: 1200,
+      startedAt: 1000,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 2000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP from paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.PAUSED,
+      timeRemaining: 900,
+      pausedAt: 1600,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 2000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP from short_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 300,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP from long_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 900,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 4000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP from break_paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 200,
+      pausedAt: 2700,
+      breakType: 'short',
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP from completed', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.COMPLETED,
+      sessionNumber: 1,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when SKIP from abandoned', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.ABANDONED,
+      sessionNumber: 1,
+      abandonedAt: 5000,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 6000);
+    expect(result).toBe(state);
+  });
+});
+
 describe('transition — unhandled events return state unchanged', () => {
   it('returns idle state unchanged for non-START events', () => {
     const idle: TimerState = { status: TIMER_STATUS.IDLE, config: defaultConfig };

--- a/packages/core/src/timer/transition.ts
+++ b/packages/core/src/timer/transition.ts
@@ -245,6 +245,32 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
         }
       }
     case TIMER_STATUS.REFLECTION:
+      switch (event.type) {
+        case TIMER_EVENT_TYPE.SUBMIT:
+          return {
+            status: TIMER_STATUS.COMPLETED,
+            sessionNumber: state.sessionNumber,
+            reflectionData: event.data,
+          };
+        case TIMER_EVENT_TYPE.SKIP:
+          return {
+            status: TIMER_STATUS.COMPLETED,
+            sessionNumber: state.sessionNumber,
+          };
+        case TIMER_EVENT_TYPE.START:
+        case TIMER_EVENT_TYPE.PAUSE:
+        case TIMER_EVENT_TYPE.RESUME:
+        case TIMER_EVENT_TYPE.TICK:
+        case TIMER_EVENT_TYPE.TIMER_DONE:
+        case TIMER_EVENT_TYPE.SKIP_BREAK:
+        case TIMER_EVENT_TYPE.ABANDON:
+        case TIMER_EVENT_TYPE.RESET:
+          return state;
+        default: {
+          const _exhaustive: never = event;
+          return _exhaustive;
+        }
+      }
     case TIMER_STATUS.COMPLETED:
     case TIMER_STATUS.ABANDONED:
       return state;


### PR DESCRIPTION
## Summary
- Implement SUBMIT and SKIP event handling from the `reflection` timer state, transitioning to `completed`
- SUBMIT carries `ReflectionData` (focusQuality + distractionType) into the completed state; SKIP transitions without reflection data
- Both events are rejected from non-reflection states
- Comprehensive test coverage for all reflection transition paths

Closes #106

## Test plan
- [x] SUBMIT from `reflection` → `completed` with `reflectionData` set from event payload
- [x] SKIP from `reflection` → `completed` without `reflectionData`
- [x] `completed` state preserves correct `sessionNumber`
- [x] SUBMIT/SKIP from non-reflection states are rejected
- [x] Tests cover each `focusQuality` value (`locked_in`, `decent`, `struggled`)
- [x] `pnpm nx test @pomofocus/core` passes
- [x] `pnpm nx type-check @pomofocus/core` exits clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)