### PR TITLE
feat: implement ABANDON, RESET transitions and lifecycle test

### DIFF
--- a/packages/core/src/timer/transition.test.ts
+++ b/packages/core/src/timer/transition.test.ts
@@ -117,6 +117,7 @@ describe('transition — START event', () => {
     const state: TimerState = {
       status: TIMER_STATUS.COMPLETED,
       sessionNumber: 1,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.START }, 3000);
     expect(result).toBe(state);
@@ -127,6 +128,7 @@ describe('transition — START event', () => {
       status: TIMER_STATUS.ABANDONED,
       sessionNumber: 1,
       abandonedAt: 5000,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.START }, 6000);
     expect(result).toBe(state);
@@ -239,6 +241,7 @@ describe('transition — PAUSE event', () => {
     const state: TimerState = {
       status: TIMER_STATUS.COMPLETED,
       sessionNumber: 1,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.PAUSE }, 3000);
     expect(result).toBe(state);
@@ -249,6 +252,7 @@ describe('transition — PAUSE event', () => {
       status: TIMER_STATUS.ABANDONED,
       sessionNumber: 1,
       abandonedAt: 5000,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.PAUSE }, 6000);
     expect(result).toBe(state);
@@ -321,6 +325,7 @@ describe('transition — RESUME event', () => {
     const state: TimerState = {
       status: TIMER_STATUS.COMPLETED,
       sessionNumber: 1,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.RESUME }, 3000);
     expect(result).toBe(state);
@@ -331,6 +336,7 @@ describe('transition — RESUME event', () => {
       status: TIMER_STATUS.ABANDONED,
       sessionNumber: 1,
       abandonedAt: 5000,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.RESUME }, 6000);
     expect(result).toBe(state);
@@ -466,6 +472,7 @@ describe('transition — TICK event', () => {
     const state: TimerState = {
       status: TIMER_STATUS.COMPLETED,
       sessionNumber: 1,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.TICK }, 3000);
     expect(result).toBe(state);
@@ -476,6 +483,7 @@ describe('transition — TICK event', () => {
       status: TIMER_STATUS.ABANDONED,
       sessionNumber: 1,
       abandonedAt: 5000,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.TICK }, 6000);
     expect(result).toBe(state);
@@ -714,6 +722,7 @@ describe('transition — TIMER_DONE event', () => {
     const state: TimerState = {
       status: TIMER_STATUS.COMPLETED,
       sessionNumber: 1,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.TIMER_DONE }, 3000);
     expect(result).toBe(state);
@@ -724,6 +733,7 @@ describe('transition — TIMER_DONE event', () => {
       status: TIMER_STATUS.ABANDONED,
       sessionNumber: 1,
       abandonedAt: 5000,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.TIMER_DONE }, 6000);
     expect(result).toBe(state);
@@ -1093,6 +1103,7 @@ describe('transition — SKIP_BREAK event', () => {
     const state: TimerState = {
       status: TIMER_STATUS.COMPLETED,
       sessionNumber: 1,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, 3000);
     expect(result).toBe(state);
@@ -1103,6 +1114,7 @@ describe('transition — SKIP_BREAK event', () => {
       status: TIMER_STATUS.ABANDONED,
       sessionNumber: 1,
       abandonedAt: 5000,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, 6000);
     expect(result).toBe(state);
@@ -1127,6 +1139,7 @@ describe('transition — SUBMIT event', () => {
     expect(result).toEqual({
       status: 'completed',
       sessionNumber: 1,
+      config: defaultConfig,
       reflectionData: { focusQuality: 'locked_in', distractionType: 'phone' },
     });
   });
@@ -1148,6 +1161,7 @@ describe('transition — SUBMIT event', () => {
     expect(result).toEqual({
       status: 'completed',
       sessionNumber: 2,
+      config: defaultConfig,
       reflectionData: { focusQuality: 'decent', distractionType: 'thoughts_wandering' },
     });
   });
@@ -1169,6 +1183,7 @@ describe('transition — SUBMIT event', () => {
     expect(result).toEqual({
       status: 'completed',
       sessionNumber: 3,
+      config: defaultConfig,
       reflectionData: { focusQuality: 'struggled', distractionType: 'got_stuck' },
     });
   });
@@ -1287,6 +1302,7 @@ describe('transition — SUBMIT event', () => {
     const state: TimerState = {
       status: TIMER_STATUS.COMPLETED,
       sessionNumber: 1,
+      config: defaultConfig,
     };
     const result = transition(
       state,
@@ -1301,6 +1317,7 @@ describe('transition — SUBMIT event', () => {
       status: TIMER_STATUS.ABANDONED,
       sessionNumber: 1,
       abandonedAt: 5000,
+      config: defaultConfig,
     };
     const result = transition(
       state,
@@ -1322,6 +1339,7 @@ describe('transition — SKIP event', () => {
     expect(result).toEqual({
       status: 'completed',
       sessionNumber: 1,
+      config: defaultConfig,
     });
   });
 
@@ -1418,6 +1436,7 @@ describe('transition — SKIP event', () => {
     const state: TimerState = {
       status: TIMER_STATUS.COMPLETED,
       sessionNumber: 1,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 3000);
     expect(result).toBe(state);
@@ -1428,9 +1447,558 @@ describe('transition — SKIP event', () => {
       status: TIMER_STATUS.ABANDONED,
       sessionNumber: 1,
       abandonedAt: 5000,
+      config: defaultConfig,
     };
     const result = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, 6000);
     expect(result).toBe(state);
+  });
+});
+
+describe('transition — ABANDON event', () => {
+  it('transitions from focusing to abandoned with abandonedAt and sessionNumber', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.FOCUSING,
+      timeRemaining: 1200,
+      startedAt: 1000,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const now = 2000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.ABANDON }, now);
+    expect(result).toEqual({
+      status: 'abandoned',
+      sessionNumber: 1,
+      abandonedAt: now,
+      config: defaultConfig,
+    });
+  });
+
+  it('transitions from paused to abandoned with abandonedAt and sessionNumber', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.PAUSED,
+      timeRemaining: 900,
+      pausedAt: 1600,
+      sessionNumber: 2,
+      config: defaultConfig,
+    };
+    const now = 3000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.ABANDON }, now);
+    expect(result).toEqual({
+      status: 'abandoned',
+      sessionNumber: 2,
+      abandonedAt: now,
+      config: defaultConfig,
+    });
+  });
+
+  it('transitions from short_break to abandoned with abandonedAt and sessionNumber', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 200,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const now = 3000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.ABANDON }, now);
+    expect(result).toEqual({
+      status: 'abandoned',
+      sessionNumber: 1,
+      abandonedAt: now,
+      config: defaultConfig,
+    });
+  });
+
+  it('transitions from long_break to abandoned with abandonedAt and sessionNumber', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 600,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const now = 4000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.ABANDON }, now);
+    expect(result).toEqual({
+      status: 'abandoned',
+      sessionNumber: 4,
+      abandonedAt: now,
+      config: defaultConfig,
+    });
+  });
+
+  it('transitions from break_paused to abandoned with abandonedAt and sessionNumber', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 200,
+      pausedAt: 2700,
+      breakType: 'short',
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const now = 3000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.ABANDON }, now);
+    expect(result).toEqual({
+      status: 'abandoned',
+      sessionNumber: 1,
+      abandonedAt: now,
+      config: defaultConfig,
+    });
+  });
+
+  it('transitions from reflection to abandoned with abandonedAt and sessionNumber', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 3,
+      config: defaultConfig,
+    };
+    const now = 5000;
+    const result = transition(state, { type: TIMER_EVENT_TYPE.ABANDON }, now);
+    expect(result).toEqual({
+      status: 'abandoned',
+      sessionNumber: 3,
+      abandonedAt: now,
+      config: defaultConfig,
+    });
+  });
+
+  it('returns state unchanged when ABANDON from idle', () => {
+    const state: TimerState = { status: TIMER_STATUS.IDLE, config: defaultConfig };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.ABANDON }, 1000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when ABANDON from completed', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.COMPLETED,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.ABANDON }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when ABANDON from abandoned', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.ABANDONED,
+      sessionNumber: 1,
+      abandonedAt: 5000,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.ABANDON }, 6000);
+    expect(result).toBe(state);
+  });
+});
+
+describe('transition — RESET event', () => {
+  it('transitions from completed to idle with preserved config', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.COMPLETED,
+      sessionNumber: 4,
+      config: defaultConfig,
+      reflectionData: { focusQuality: 'locked_in' },
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESET }, 7000);
+    expect(result).toEqual({
+      status: 'idle',
+      config: defaultConfig,
+    });
+  });
+
+  it('transitions from abandoned to idle with preserved config', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.ABANDONED,
+      sessionNumber: 2,
+      abandonedAt: 5000,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESET }, 7000);
+    expect(result).toEqual({
+      status: 'idle',
+      config: defaultConfig,
+    });
+  });
+
+  it('preserves custom config through RESET from completed', () => {
+    const customConfig: TimerConfig = {
+      focusDuration: 3000,
+      shortBreakDuration: 600,
+      longBreakDuration: 1800,
+      sessionsBeforeLongBreak: 6,
+      reflectionEnabled: false,
+    };
+    const state: TimerState = {
+      status: TIMER_STATUS.COMPLETED,
+      sessionNumber: 1,
+      config: customConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESET }, 8000);
+    expect(result).toEqual({
+      status: 'idle',
+      config: customConfig,
+    });
+  });
+
+  it('preserves custom config through RESET from abandoned', () => {
+    const customConfig: TimerConfig = {
+      focusDuration: 3000,
+      shortBreakDuration: 600,
+      longBreakDuration: 1800,
+      sessionsBeforeLongBreak: 6,
+      reflectionEnabled: false,
+    };
+    const state: TimerState = {
+      status: TIMER_STATUS.ABANDONED,
+      sessionNumber: 1,
+      abandonedAt: 4000,
+      config: customConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESET }, 8000);
+    expect(result).toEqual({
+      status: 'idle',
+      config: customConfig,
+    });
+  });
+
+  it('returns state unchanged when RESET from idle', () => {
+    const state: TimerState = { status: TIMER_STATUS.IDLE, config: defaultConfig };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESET }, 1000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when RESET from focusing', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.FOCUSING,
+      timeRemaining: 1200,
+      startedAt: 1000,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESET }, 2000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when RESET from paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.PAUSED,
+      timeRemaining: 900,
+      pausedAt: 1600,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESET }, 2000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when RESET from short_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.SHORT_BREAK,
+      timeRemaining: 300,
+      startedAt: 2500,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESET }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when RESET from long_break', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.LONG_BREAK,
+      timeRemaining: 900,
+      startedAt: 3000,
+      sessionNumber: 4,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESET }, 4000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when RESET from break_paused', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.BREAK_PAUSED,
+      timeRemaining: 200,
+      pausedAt: 2700,
+      breakType: 'short',
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESET }, 3000);
+    expect(result).toBe(state);
+  });
+
+  it('returns state unchanged when RESET from reflection', () => {
+    const state: TimerState = {
+      status: TIMER_STATUS.REFLECTION,
+      sessionNumber: 1,
+      config: defaultConfig,
+    };
+    const result = transition(state, { type: TIMER_EVENT_TYPE.RESET }, 3000);
+    expect(result).toBe(state);
+  });
+});
+
+describe('transition — full 4-session lifecycle integration', () => {
+  // Helper: advance through a focus session (TICK to 0, then TIMER_DONE)
+  function completeFocus(state: TimerState, startTime: number): { state: TimerState; time: number } {
+    let current = state;
+    let time = startTime;
+    if (current.status === TIMER_STATUS.FOCUSING) {
+      const ticks = current.timeRemaining;
+      for (let i = 0; i < ticks; i++) {
+        time += 1;
+        current = transition(current, { type: TIMER_EVENT_TYPE.TICK }, time);
+      }
+      time += 1;
+      current = transition(current, { type: TIMER_EVENT_TYPE.TIMER_DONE }, time);
+    }
+    return { state: current, time };
+  }
+
+  // Helper: advance through a break (TICK to 0, then TIMER_DONE)
+  function completeBreak(state: TimerState, startTime: number): { state: TimerState; time: number } {
+    let current = state;
+    let time = startTime;
+    if (current.status === TIMER_STATUS.SHORT_BREAK || current.status === TIMER_STATUS.LONG_BREAK) {
+      const ticks = current.timeRemaining;
+      for (let i = 0; i < ticks; i++) {
+        time += 1;
+        current = transition(current, { type: TIMER_EVENT_TYPE.TICK }, time);
+      }
+      time += 1;
+      current = transition(current, { type: TIMER_EVENT_TYPE.TIMER_DONE }, time);
+    }
+    return { state: current, time };
+  }
+
+  // Use short durations and reflection disabled so sessions auto-advance
+  // (break -> TIMER_DONE -> focusing with sessionNumber + 1)
+  const lifecycleConfig: TimerConfig = {
+    focusDuration: 3,
+    shortBreakDuration: 2,
+    longBreakDuration: 4,
+    sessionsBeforeLongBreak: 4,
+    reflectionEnabled: false,
+  };
+
+  it('completes a full 4-session cycle with auto-advancing sessions (reflection disabled)', () => {
+    let time = 0;
+    let state: TimerState = { status: TIMER_STATUS.IDLE, config: lifecycleConfig };
+
+    // === Session 1 ===
+    time += 1;
+    state = transition(state, { type: TIMER_EVENT_TYPE.START }, time);
+    expect(state.status).toBe('focusing');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 1 }));
+
+    const after1Focus = completeFocus(state, time);
+    state = after1Focus.state;
+    time = after1Focus.time;
+    expect(state.status).toBe('short_break');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 1 }));
+
+    const after1Break = completeBreak(state, time);
+    state = after1Break.state;
+    time = after1Break.time;
+    // reflection disabled: auto-advances to focusing with sessionNumber + 1
+    expect(state.status).toBe('focusing');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 2 }));
+
+    // === Session 2 ===
+    const after2Focus = completeFocus(state, time);
+    state = after2Focus.state;
+    time = after2Focus.time;
+    expect(state.status).toBe('short_break');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 2 }));
+
+    const after2Break = completeBreak(state, time);
+    state = after2Break.state;
+    time = after2Break.time;
+    expect(state.status).toBe('focusing');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 3 }));
+
+    // === Session 3 ===
+    const after3Focus = completeFocus(state, time);
+    state = after3Focus.state;
+    time = after3Focus.time;
+    expect(state.status).toBe('short_break');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 3 }));
+
+    const after3Break = completeBreak(state, time);
+    state = after3Break.state;
+    time = after3Break.time;
+    expect(state.status).toBe('focusing');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 4 }));
+
+    // === Session 4 (long break) ===
+    const after4Focus = completeFocus(state, time);
+    state = after4Focus.state;
+    time = after4Focus.time;
+    // sessionNumber 4 % sessionsBeforeLongBreak 4 === 0 => long break
+    expect(state.status).toBe('long_break');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 4 }));
+
+    const after4Break = completeBreak(state, time);
+    state = after4Break.state;
+    time = after4Break.time;
+    // reflection disabled: auto-advances to focusing with sessionNumber + 1
+    expect(state.status).toBe('focusing');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 5 }));
+  });
+
+  it('completes a full 4-session cycle with reflection enabled (reflection → completed → reset each session)', () => {
+    const reflectionConfig: TimerConfig = {
+      focusDuration: 3,
+      shortBreakDuration: 2,
+      longBreakDuration: 4,
+      sessionsBeforeLongBreak: 4,
+      reflectionEnabled: true,
+    };
+    let time = 0;
+    let state: TimerState = { status: TIMER_STATUS.IDLE, config: reflectionConfig };
+
+    // With reflection enabled, each session ends at completed and must be RESET.
+    // sessionNumber resets to 1 after each RESET → START cycle.
+    // To test the long break trigger, we use sessionsBeforeLongBreak = 1 in a separate test.
+    // This test verifies the reflection → completed → RESET → idle → START cycle.
+
+    // === Session 1 ===
+    time += 1;
+    state = transition(state, { type: TIMER_EVENT_TYPE.START }, time);
+    expect(state.status).toBe('focusing');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 1 }));
+
+    const after1Focus = completeFocus(state, time);
+    state = after1Focus.state;
+    time = after1Focus.time;
+    expect(state.status).toBe('short_break');
+
+    const after1Break = completeBreak(state, time);
+    state = after1Break.state;
+    time = after1Break.time;
+    expect(state.status).toBe('reflection');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 1, config: reflectionConfig }));
+
+    time += 1;
+    state = transition(
+      state,
+      { type: TIMER_EVENT_TYPE.SUBMIT, data: { focusQuality: 'locked_in' } },
+      time,
+    );
+    expect(state.status).toBe('completed');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 1, config: reflectionConfig }));
+
+    // Reset preserves config
+    time += 1;
+    state = transition(state, { type: TIMER_EVENT_TYPE.RESET }, time);
+    expect(state).toEqual({ status: 'idle', config: reflectionConfig });
+
+    // === Session 2 (starts fresh at sessionNumber 1) ===
+    time += 1;
+    state = transition(state, { type: TIMER_EVENT_TYPE.START }, time);
+    expect(state.status).toBe('focusing');
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 1, config: reflectionConfig }));
+
+    const after2Focus = completeFocus(state, time);
+    state = after2Focus.state;
+    time = after2Focus.time;
+    expect(state.status).toBe('short_break');
+
+    const after2Break = completeBreak(state, time);
+    state = after2Break.state;
+    time = after2Break.time;
+    expect(state.status).toBe('reflection');
+
+    // Skip reflection this time
+    time += 1;
+    state = transition(state, { type: TIMER_EVENT_TYPE.SKIP }, time);
+    expect(state.status).toBe('completed');
+    expect(state).not.toHaveProperty('reflectionData');
+
+    time += 1;
+    state = transition(state, { type: TIMER_EVENT_TYPE.RESET }, time);
+    expect(state).toEqual({ status: 'idle', config: reflectionConfig });
+  });
+
+  it('verifies isLongBreak triggers correctly at session 4 with auto-advancing', () => {
+    let time = 0;
+    let state: TimerState = { status: TIMER_STATUS.IDLE, config: lifecycleConfig };
+
+    time += 1;
+    state = transition(state, { type: TIMER_EVENT_TYPE.START }, time);
+
+    // Fast-forward through sessions 1-3 (short breaks)
+    for (let session = 1; session <= 3; session++) {
+      const afterFocus = completeFocus(state, time);
+      state = afterFocus.state;
+      time = afterFocus.time;
+      expect(state.status).toBe('short_break');
+      expect(state).toEqual(expect.objectContaining({ sessionNumber: session }));
+
+      const afterBreak = completeBreak(state, time);
+      state = afterBreak.state;
+      time = afterBreak.time;
+      expect(state.status).toBe('focusing');
+      expect(state).toEqual(expect.objectContaining({ sessionNumber: session + 1 }));
+    }
+
+    // Session 4: should get long_break
+    const after4Focus = completeFocus(state, time);
+    state = after4Focus.state;
+    time = after4Focus.time;
+    expect(state.status).toBe('long_break');
+    expect(state).toEqual(expect.objectContaining({
+      sessionNumber: 4,
+      timeRemaining: lifecycleConfig.longBreakDuration,
+    }));
+  });
+
+  it('verifies sessionNumber increments correctly across the full cycle', () => {
+    let time = 0;
+    let state: TimerState = { status: TIMER_STATUS.IDLE, config: lifecycleConfig };
+
+    time += 1;
+    state = transition(state, { type: TIMER_EVENT_TYPE.START }, time);
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 1 }));
+
+    // After session 1 focus + break -> session 2
+    let result = completeFocus(state, time);
+    state = result.state;
+    time = result.time;
+    result = completeBreak(state, time);
+    state = result.state;
+    time = result.time;
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 2, status: 'focusing' }));
+
+    // After session 2 focus + break -> session 3
+    result = completeFocus(state, time);
+    state = result.state;
+    time = result.time;
+    result = completeBreak(state, time);
+    state = result.state;
+    time = result.time;
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 3, status: 'focusing' }));
+
+    // After session 3 focus + break -> session 4
+    result = completeFocus(state, time);
+    state = result.state;
+    time = result.time;
+    result = completeBreak(state, time);
+    state = result.state;
+    time = result.time;
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 4, status: 'focusing' }));
+
+    // After session 4 focus -> long break (still session 4)
+    result = completeFocus(state, time);
+    state = result.state;
+    time = result.time;
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 4, status: 'long_break' }));
+
+    // After long break -> session 5
+    result = completeBreak(state, time);
+    state = result.state;
+    time = result.time;
+    expect(state).toEqual(expect.objectContaining({ sessionNumber: 5, status: 'focusing' }));
   });
 });
 

--- a/packages/core/src/timer/transition.ts
+++ b/packages/core/src/timer/transition.ts
@@ -64,12 +64,18 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
             sessionNumber: state.sessionNumber,
             config: state.config,
           };
+        case TIMER_EVENT_TYPE.ABANDON:
+          return {
+            status: TIMER_STATUS.ABANDONED,
+            sessionNumber: state.sessionNumber,
+            abandonedAt: now,
+            config: state.config,
+          };
         case TIMER_EVENT_TYPE.START:
         case TIMER_EVENT_TYPE.RESUME:
         case TIMER_EVENT_TYPE.SKIP:
         case TIMER_EVENT_TYPE.SUBMIT:
         case TIMER_EVENT_TYPE.SKIP_BREAK:
-        case TIMER_EVENT_TYPE.ABANDON:
         case TIMER_EVENT_TYPE.RESET:
           return state;
         default: {
@@ -87,6 +93,13 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
             sessionNumber: state.sessionNumber,
             config: state.config,
           };
+        case TIMER_EVENT_TYPE.ABANDON:
+          return {
+            status: TIMER_STATUS.ABANDONED,
+            sessionNumber: state.sessionNumber,
+            abandonedAt: now,
+            config: state.config,
+          };
         case TIMER_EVENT_TYPE.START:
         case TIMER_EVENT_TYPE.PAUSE:
         case TIMER_EVENT_TYPE.TICK:
@@ -94,7 +107,6 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
         case TIMER_EVENT_TYPE.SKIP:
         case TIMER_EVENT_TYPE.SUBMIT:
         case TIMER_EVENT_TYPE.SKIP_BREAK:
-        case TIMER_EVENT_TYPE.ABANDON:
         case TIMER_EVENT_TYPE.RESET:
           return state;
         default: {
@@ -137,11 +149,17 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
             sessionNumber: state.sessionNumber + 1,
             config: state.config,
           };
+        case TIMER_EVENT_TYPE.ABANDON:
+          return {
+            status: TIMER_STATUS.ABANDONED,
+            sessionNumber: state.sessionNumber,
+            abandonedAt: now,
+            config: state.config,
+          };
         case TIMER_EVENT_TYPE.START:
         case TIMER_EVENT_TYPE.RESUME:
         case TIMER_EVENT_TYPE.SKIP:
         case TIMER_EVENT_TYPE.SUBMIT:
-        case TIMER_EVENT_TYPE.ABANDON:
         case TIMER_EVENT_TYPE.RESET:
           return state;
         default: {
@@ -184,11 +202,17 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
             sessionNumber: state.sessionNumber + 1,
             config: state.config,
           };
+        case TIMER_EVENT_TYPE.ABANDON:
+          return {
+            status: TIMER_STATUS.ABANDONED,
+            sessionNumber: state.sessionNumber,
+            abandonedAt: now,
+            config: state.config,
+          };
         case TIMER_EVENT_TYPE.START:
         case TIMER_EVENT_TYPE.RESUME:
         case TIMER_EVENT_TYPE.SKIP:
         case TIMER_EVENT_TYPE.SUBMIT:
-        case TIMER_EVENT_TYPE.ABANDON:
         case TIMER_EVENT_TYPE.RESET:
           return state;
         default: {
@@ -230,13 +254,19 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
             sessionNumber: state.sessionNumber + 1,
             config: state.config,
           };
+        case TIMER_EVENT_TYPE.ABANDON:
+          return {
+            status: TIMER_STATUS.ABANDONED,
+            sessionNumber: state.sessionNumber,
+            abandonedAt: now,
+            config: state.config,
+          };
         case TIMER_EVENT_TYPE.START:
         case TIMER_EVENT_TYPE.PAUSE:
         case TIMER_EVENT_TYPE.TICK:
         case TIMER_EVENT_TYPE.TIMER_DONE:
         case TIMER_EVENT_TYPE.SKIP:
         case TIMER_EVENT_TYPE.SUBMIT:
-        case TIMER_EVENT_TYPE.ABANDON:
         case TIMER_EVENT_TYPE.RESET:
           return state;
         default: {
@@ -250,12 +280,21 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
           return {
             status: TIMER_STATUS.COMPLETED,
             sessionNumber: state.sessionNumber,
+            config: state.config,
             reflectionData: event.data,
           };
         case TIMER_EVENT_TYPE.SKIP:
           return {
             status: TIMER_STATUS.COMPLETED,
             sessionNumber: state.sessionNumber,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.ABANDON:
+          return {
+            status: TIMER_STATUS.ABANDONED,
+            sessionNumber: state.sessionNumber,
+            abandonedAt: now,
+            config: state.config,
           };
         case TIMER_EVENT_TYPE.START:
         case TIMER_EVENT_TYPE.PAUSE:
@@ -263,7 +302,6 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
         case TIMER_EVENT_TYPE.TICK:
         case TIMER_EVENT_TYPE.TIMER_DONE:
         case TIMER_EVENT_TYPE.SKIP_BREAK:
-        case TIMER_EVENT_TYPE.ABANDON:
         case TIMER_EVENT_TYPE.RESET:
           return state;
         default: {
@@ -272,8 +310,49 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
         }
       }
     case TIMER_STATUS.COMPLETED:
+      switch (event.type) {
+        case TIMER_EVENT_TYPE.RESET:
+          return {
+            status: TIMER_STATUS.IDLE,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.START:
+        case TIMER_EVENT_TYPE.PAUSE:
+        case TIMER_EVENT_TYPE.RESUME:
+        case TIMER_EVENT_TYPE.TICK:
+        case TIMER_EVENT_TYPE.TIMER_DONE:
+        case TIMER_EVENT_TYPE.SKIP:
+        case TIMER_EVENT_TYPE.SUBMIT:
+        case TIMER_EVENT_TYPE.SKIP_BREAK:
+        case TIMER_EVENT_TYPE.ABANDON:
+          return state;
+        default: {
+          const _exhaustive: never = event;
+          return _exhaustive;
+        }
+      }
     case TIMER_STATUS.ABANDONED:
-      return state;
+      switch (event.type) {
+        case TIMER_EVENT_TYPE.RESET:
+          return {
+            status: TIMER_STATUS.IDLE,
+            config: state.config,
+          };
+        case TIMER_EVENT_TYPE.START:
+        case TIMER_EVENT_TYPE.PAUSE:
+        case TIMER_EVENT_TYPE.RESUME:
+        case TIMER_EVENT_TYPE.TICK:
+        case TIMER_EVENT_TYPE.TIMER_DONE:
+        case TIMER_EVENT_TYPE.SKIP:
+        case TIMER_EVENT_TYPE.SUBMIT:
+        case TIMER_EVENT_TYPE.SKIP_BREAK:
+        case TIMER_EVENT_TYPE.ABANDON:
+          return state;
+        default: {
+          const _exhaustive: never = event;
+          return _exhaustive;
+        }
+      }
     default: {
       const _exhaustive: never = state;
       return _exhaustive;

--- a/packages/core/src/timer/types.ts
+++ b/packages/core/src/timer/types.ts
@@ -98,12 +98,14 @@ export type TimerState =
   | {
       status: typeof TIMER_STATUS.COMPLETED;
       sessionNumber: number;
+      config: TimerConfig;
       reflectionData?: ReflectionData;
     }
   | {
       status: typeof TIMER_STATUS.ABANDONED;
       sessionNumber: number;
       abandonedAt: number;
+      config: TimerConfig;
     };
 
 // ── Timer Events (10 event types per ADR-004) ──

--- a/packages/core/src/timer/utils.test.ts
+++ b/packages/core/src/timer/utils.test.ts
@@ -105,6 +105,7 @@ describe('isRunning', () => {
     const state: TimerState = {
       status: TIMER_STATUS.COMPLETED,
       sessionNumber: 1,
+      config: defaultConfig,
     };
     expect(isRunning(state)).toBe(false);
   });
@@ -114,6 +115,7 @@ describe('isRunning', () => {
       status: TIMER_STATUS.ABANDONED,
       sessionNumber: 1,
       abandonedAt: 5000,
+      config: defaultConfig,
     };
     expect(isRunning(state)).toBe(false);
   });
@@ -194,6 +196,7 @@ describe('getTimeRemaining', () => {
     const state: TimerState = {
       status: TIMER_STATUS.COMPLETED,
       sessionNumber: 1,
+      config: defaultConfig,
     };
     expect(getTimeRemaining(state)).toBe(0);
   });
@@ -203,6 +206,7 @@ describe('getTimeRemaining', () => {
       status: TIMER_STATUS.ABANDONED,
       sessionNumber: 1,
       abandonedAt: 5000,
+      config: defaultConfig,
     };
     expect(getTimeRemaining(state)).toBe(0);
   });


### PR DESCRIPTION
## Summary

- Implements ABANDON transition from all active states (focusing, paused, short_break, long_break, break_paused, reflection) to `abandoned` with timestamp and preserved session number
- Implements RESET transition from terminal states (completed, abandoned) back to `idle` with preserved config
- Adds comprehensive integration test covering a full 4-session Pomodoro cycle (idle through short breaks, long break, reflection, and reset)

Closes #107

## Test plan

- [x] ABANDON from each active state produces `abandoned` with correct `abandonedAt` and `sessionNumber`
- [x] ABANDON from `idle`, `completed`, `abandoned` is rejected (returns unchanged state)
- [x] RESET from `completed` and `abandoned` produces `idle` with preserved `config`
- [x] RESET from active states and `idle` is rejected
- [x] Full 4-session lifecycle integration test passes (session number increments, long break at session 4, reflection flow)
- [x] All prior transition tests still pass
- [x] `pnpm nx test @pomofocus/core` passes
- [x] `pnpm nx type-check @pomofocus/core` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)