### PR TITLE
feat: configure TanStack Query provider and defaults (#115)

### DIFF
--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -12,14 +12,17 @@
     }
   },
   "dependencies": {
-    "@pomofocus/types": "workspace:*",
     "@pomofocus/core": "workspace:*",
     "@pomofocus/data-access": "workspace:*",
-    "zustand": "^5.0.0",
+    "@pomofocus/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "immer": "^10.0.0"
+    "immer": "^10.0.0",
+    "zustand": "^5.0.0"
   },
   "peerDependencies": {
     "react": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.28"
   }
 }

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -2,3 +2,5 @@
 // Depends on core, data-access, types.
 export { useTimerStore, createTimerStore } from './timer/timer-store.js';
 export type { TimerStore, TimerStoreInstance } from './timer/timer-store.js';
+export { createQueryClient } from './query-client.js';
+export { QueryProvider } from './providers.js';

--- a/packages/state/src/providers.tsx
+++ b/packages/state/src/providers.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+import type { QueryClient } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
+
+type QueryProviderProps = {
+  readonly client: QueryClient;
+  readonly children: ReactNode;
+};
+
+/**
+ * App-level provider wrapping TanStack Query's QueryClientProvider.
+ * App shells pass a QueryClient created via `createQueryClient()`.
+ */
+export function QueryProvider({
+  client,
+  children,
+}: QueryProviderProps): ReactNode {
+  return (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}

--- a/packages/state/src/query-client.ts
+++ b/packages/state/src/query-client.ts
@@ -1,0 +1,45 @@
+import { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Default stale time for all queries (30s).
+ * Matches the 30s polling interval per ADR-003.
+ */
+const DEFAULT_STALE_TIME = 30_000;
+
+/**
+ * Default refetch interval for polling (30s).
+ * Per ADR-003: TanStack Query polling at 30s, no Realtime WebSockets.
+ */
+const DEFAULT_REFETCH_INTERVAL = 30_000;
+
+/**
+ * Maximum number of retries for failed queries.
+ */
+const MAX_RETRIES = 3;
+
+/**
+ * Exponential backoff delay calculation.
+ * Returns delay in ms: 1s, 2s, 4s (capped at 30s).
+ */
+function retryDelay(attemptIndex: number): number {
+  return Math.min(1000 * 2 ** attemptIndex, 30_000);
+}
+
+/**
+ * Creates a configured QueryClient with PomoFocus defaults:
+ * - staleTime: 30s (PKG-S04)
+ * - refetchInterval: 30s for polling (ADR-003)
+ * - retry: 3 attempts with exponential backoff
+ */
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: DEFAULT_STALE_TIME,
+        refetchInterval: DEFAULT_REFETCH_INTERVAL,
+        retry: MAX_RETRIES,
+        retryDelay,
+      },
+    },
+  });
+}

--- a/packages/state/tsconfig.lib.json
+++ b/packages/state/tsconfig.lib.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,
+    "jsx": "react-jsx",
     "types": [],
     "paths": {
       "@pomofocus/types": ["../types/src/index.ts"],
@@ -11,5 +12,5 @@
       "@pomofocus/data-access": ["../data-access/src/index.ts"]
     }
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,10 @@ importers:
       zustand:
         specifier: ^5.0.0
         version: 5.0.12(@types/react@18.3.28)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
 
   packages/types: {}
 


### PR DESCRIPTION
## Summary

- Configure `QueryClient` with 30s `staleTime`, 30s `refetchInterval` polling, and exponential backoff retry policy (3 retries) per ADR-003
- Export `QueryProvider` component wrapping TanStack Query's `QueryClientProvider` for app shells
- Add `createQueryClient()` factory function with all defaults pre-configured

Closes #115

## Test plan

- [ ] `pnpm nx type-check @pomofocus/state` passes
- [ ] `createQueryClient()` returns a configured `QueryClient` with correct defaults
- [ ] `QueryProvider` component renders without errors
- [ ] All exports are named exports (U-002)
- [ ] All exported functions have explicit return types (U-005)

🤖 Generated with [Claude Code](https://claude.com/claude-code)