### PR TITLE
feat: implement timer Zustand store (#116)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 // Pure domain logic: timer, goals, sessions, sync protocol.
 // No IO, no React, no Supabase imports.
 export type { StreakResult, GoalProgress } from './goals/index.js';
-export { TIMER_STATUS, TIMER_EVENT_TYPE, createInitialState, isRunning, getTimeRemaining } from './timer/index.js';
+export { TIMER_STATUS, TIMER_EVENT_TYPE, createInitialState, isRunning, getTimeRemaining, transition } from './timer/index.js';
 export type {
   TimerStatus,
   TimerEventType,

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -1,3 +1,4 @@
 // Zustand stores + TanStack Query hooks.
 // Depends on core, data-access, types.
-export {};
+export { useTimerStore, createTimerStore } from './timer/timer-store.js';
+export type { TimerStore, TimerStoreInstance } from './timer/timer-store.js';

--- a/packages/state/src/timer/timer-store.test.ts
+++ b/packages/state/src/timer/timer-store.test.ts
@@ -1,0 +1,453 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createTimerStore } from './timer-store.js';
+import type { TimerConfig, ReflectionData } from '@pomofocus/core';
+import { TIMER_STATUS } from '@pomofocus/core';
+
+const defaultConfig: TimerConfig = {
+  focusDuration: 1500,
+  shortBreakDuration: 300,
+  longBreakDuration: 900,
+  sessionsBeforeLongBreak: 4,
+  reflectionEnabled: true,
+};
+
+function createStore(config: TimerConfig = defaultConfig): ReturnType<typeof createTimerStore> {
+  return createTimerStore(config);
+}
+
+describe('timer store', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+  });
+
+  describe('initial state', () => {
+    it('starts in idle status with given config', () => {
+      const store = createStore();
+      const { state } = store.getState();
+
+      expect(state.status).toBe(TIMER_STATUS.IDLE);
+      expect(state.config).toEqual(defaultConfig);
+    });
+  });
+
+  describe('start()', () => {
+    it('transitions from idle to focusing', () => {
+      const store = createStore();
+
+      store.getState().start();
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.FOCUSING);
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.timeRemaining).toBe(defaultConfig.focusDuration);
+        expect(state.startedAt).toBe(1000);
+        expect(state.sessionNumber).toBe(1);
+      }
+    });
+
+    it('is a no-op when already focusing', () => {
+      const store = createStore();
+      store.getState().start();
+      const stateAfterStart = store.getState().state;
+
+      store.getState().start();
+
+      expect(store.getState().state).toEqual(stateAfterStart);
+    });
+  });
+
+  describe('pause()', () => {
+    it('transitions from focusing to paused', () => {
+      const store = createStore();
+      store.getState().start();
+
+      vi.setSystemTime(2000);
+      store.getState().pause();
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.PAUSED);
+      if (state.status === TIMER_STATUS.PAUSED) {
+        expect(state.pausedAt).toBe(2000);
+        expect(state.timeRemaining).toBe(defaultConfig.focusDuration);
+      }
+    });
+
+    it('is a no-op when idle', () => {
+      const store = createStore();
+      const initialState = store.getState().state;
+
+      store.getState().pause();
+
+      expect(store.getState().state).toEqual(initialState);
+    });
+  });
+
+  describe('resume()', () => {
+    it('transitions from paused to focusing', () => {
+      const store = createStore();
+      store.getState().start();
+      store.getState().pause();
+
+      vi.setSystemTime(3000);
+      store.getState().resume();
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.FOCUSING);
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.startedAt).toBe(3000);
+      }
+    });
+
+    it('is a no-op when idle', () => {
+      const store = createStore();
+      const initialState = store.getState().state;
+
+      store.getState().resume();
+
+      expect(store.getState().state).toEqual(initialState);
+    });
+  });
+
+  describe('tick()', () => {
+    it('decrements timeRemaining by 1 when focusing', () => {
+      const store = createStore();
+      store.getState().start();
+
+      store.getState().tick();
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.FOCUSING);
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.timeRemaining).toBe(defaultConfig.focusDuration - 1);
+      }
+    });
+
+    it('does not go below 0', () => {
+      const shortConfig: TimerConfig = { ...defaultConfig, focusDuration: 1 };
+      const store = createStore(shortConfig);
+      store.getState().start();
+
+      store.getState().tick();
+      store.getState().tick();
+
+      const { state } = store.getState();
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.timeRemaining).toBe(0);
+      }
+    });
+
+    it('is a no-op when idle', () => {
+      const store = createStore();
+      const initialState = store.getState().state;
+
+      store.getState().tick();
+
+      expect(store.getState().state).toEqual(initialState);
+    });
+  });
+
+  describe('abandon()', () => {
+    it('transitions from focusing to abandoned', () => {
+      const store = createStore();
+      store.getState().start();
+
+      vi.setSystemTime(5000);
+      store.getState().abandon();
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.ABANDONED);
+      if (state.status === TIMER_STATUS.ABANDONED) {
+        expect(state.abandonedAt).toBe(5000);
+        expect(state.sessionNumber).toBe(1);
+      }
+    });
+
+    it('transitions from paused to abandoned', () => {
+      const store = createStore();
+      store.getState().start();
+      store.getState().pause();
+
+      vi.setSystemTime(5000);
+      store.getState().abandon();
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.ABANDONED);
+    });
+
+    it('is a no-op when idle', () => {
+      const store = createStore();
+      const initialState = store.getState().state;
+
+      store.getState().abandon();
+
+      expect(store.getState().state).toEqual(initialState);
+    });
+  });
+
+  describe('reset()', () => {
+    it('transitions from abandoned to idle', () => {
+      const store = createStore();
+      store.getState().start();
+      store.getState().abandon();
+
+      store.getState().reset();
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.IDLE);
+      expect(state.config).toEqual(defaultConfig);
+    });
+
+    it('transitions from completed to idle', () => {
+      const noReflectionConfig: TimerConfig = { ...defaultConfig, reflectionEnabled: false };
+      const store = createStore(noReflectionConfig);
+
+      // Go through a full focus + short break + skip break cycle to reach completed
+      // Focus session
+      store.getState().start();
+      // Simulate TIMER_DONE via the transition directly — use skipBreak after break starts
+      // Actually, the store doesn't expose TIMER_DONE. We need to go through the break flow.
+      // Let's use a config with reflectionEnabled: false and shortBreakDuration so skipBreak works.
+
+      // The store only exposes the listed actions. TIMER_DONE is not a store action.
+      // To reach completed state, we need reflection → skip or submit.
+      // With reflection disabled, short_break → SKIP_BREAK → focusing (next session).
+      // With reflection enabled, short_break → SKIP_BREAK → reflection → SKIP → completed.
+
+      // Let's use reflectionEnabled: true for this test.
+      const reflectStore = createStore(defaultConfig);
+      reflectStore.getState().start();
+
+      // We can't easily trigger TIMER_DONE from the store (no action for it).
+      // The store is a thin wrapper — TIMER_DONE would be dispatched by a driver.
+      // For testing reset from completed, we need to set the store state manually
+      // or use a focused approach. Since the store wraps transition(), let's verify
+      // the action dispatches correctly by setting up the prerequisite state.
+
+      // Alternative: use the Zustand setState escape hatch for test setup.
+      reflectStore.setState({
+        state: {
+          status: TIMER_STATUS.COMPLETED,
+          sessionNumber: 1,
+          config: defaultConfig,
+        },
+      });
+
+      reflectStore.getState().reset();
+
+      const { state } = reflectStore.getState();
+      expect(state.status).toBe(TIMER_STATUS.IDLE);
+    });
+
+    it('is a no-op when idle', () => {
+      const store = createStore();
+      const initialState = store.getState().state;
+
+      store.getState().reset();
+
+      expect(store.getState().state).toEqual(initialState);
+    });
+  });
+
+  describe('skipBreak()', () => {
+    it('transitions from short_break to reflection when reflection enabled', () => {
+      const store = createStore();
+
+      // Set up short_break state directly (TIMER_DONE is not a store action)
+      store.setState({
+        state: {
+          status: TIMER_STATUS.SHORT_BREAK,
+          timeRemaining: 300,
+          startedAt: 1000,
+          sessionNumber: 1,
+          config: defaultConfig,
+        },
+      });
+
+      store.getState().skipBreak();
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.REFLECTION);
+    });
+
+    it('transitions from short_break to focusing when reflection disabled', () => {
+      const noReflectionConfig: TimerConfig = { ...defaultConfig, reflectionEnabled: false };
+      const store = createStore(noReflectionConfig);
+
+      store.setState({
+        state: {
+          status: TIMER_STATUS.SHORT_BREAK,
+          timeRemaining: 300,
+          startedAt: 1000,
+          sessionNumber: 1,
+          config: noReflectionConfig,
+        },
+      });
+
+      vi.setSystemTime(2000);
+      store.getState().skipBreak();
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.FOCUSING);
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.sessionNumber).toBe(2);
+        expect(state.startedAt).toBe(2000);
+      }
+    });
+
+    it('transitions from break_paused to reflection when reflection enabled', () => {
+      const store = createStore();
+
+      store.setState({
+        state: {
+          status: TIMER_STATUS.BREAK_PAUSED,
+          timeRemaining: 200,
+          pausedAt: 1500,
+          breakType: 'short' as const,
+          sessionNumber: 1,
+          config: defaultConfig,
+        },
+      });
+
+      store.getState().skipBreak();
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.REFLECTION);
+    });
+
+    it('is a no-op when idle', () => {
+      const store = createStore();
+      const initialState = store.getState().state;
+
+      store.getState().skipBreak();
+
+      expect(store.getState().state).toEqual(initialState);
+    });
+  });
+
+  describe('submitReflection()', () => {
+    it('transitions from reflection to completed with reflection data', () => {
+      const store = createStore();
+
+      store.setState({
+        state: {
+          status: TIMER_STATUS.REFLECTION,
+          sessionNumber: 1,
+          config: defaultConfig,
+        },
+      });
+
+      const reflectionData: ReflectionData = {
+        focusQuality: 'locked_in',
+        distractionType: 'phone',
+      };
+
+      store.getState().submitReflection(reflectionData);
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.COMPLETED);
+      if (state.status === TIMER_STATUS.COMPLETED) {
+        expect(state.reflectionData).toEqual(reflectionData);
+        expect(state.sessionNumber).toBe(1);
+      }
+    });
+
+    it('is a no-op when idle', () => {
+      const store = createStore();
+      const initialState = store.getState().state;
+
+      store.getState().submitReflection({ focusQuality: 'locked_in' });
+
+      expect(store.getState().state).toEqual(initialState);
+    });
+  });
+
+  describe('skipReflection()', () => {
+    it('transitions from reflection to completed without reflection data', () => {
+      const store = createStore();
+
+      store.setState({
+        state: {
+          status: TIMER_STATUS.REFLECTION,
+          sessionNumber: 1,
+          config: defaultConfig,
+        },
+      });
+
+      store.getState().skipReflection();
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.COMPLETED);
+      if (state.status === TIMER_STATUS.COMPLETED) {
+        expect(state.reflectionData).toBeUndefined();
+      }
+    });
+
+    it('is a no-op when idle', () => {
+      const store = createStore();
+      const initialState = store.getState().state;
+
+      store.getState().skipReflection();
+
+      expect(store.getState().state).toEqual(initialState);
+    });
+  });
+
+  describe('full flow: idle → focusing → paused → focusing → abandoned → idle', () => {
+    it('transitions through a complete abandon cycle', () => {
+      const store = createStore();
+
+      expect(store.getState().state.status).toBe(TIMER_STATUS.IDLE);
+
+      store.getState().start();
+      expect(store.getState().state.status).toBe(TIMER_STATUS.FOCUSING);
+
+      store.getState().pause();
+      expect(store.getState().state.status).toBe(TIMER_STATUS.PAUSED);
+
+      store.getState().resume();
+      expect(store.getState().state.status).toBe(TIMER_STATUS.FOCUSING);
+
+      store.getState().abandon();
+      expect(store.getState().state.status).toBe(TIMER_STATUS.ABANDONED);
+
+      store.getState().reset();
+      expect(store.getState().state.status).toBe(TIMER_STATUS.IDLE);
+    });
+  });
+
+  describe('full flow: idle → focusing → break → reflection → completed → idle', () => {
+    it('transitions through a complete session cycle', () => {
+      const store = createStore();
+
+      expect(store.getState().state.status).toBe(TIMER_STATUS.IDLE);
+
+      // Start focusing
+      store.getState().start();
+      expect(store.getState().state.status).toBe(TIMER_STATUS.FOCUSING);
+
+      // Simulate reaching short break (TIMER_DONE is a driver concern, not a store action)
+      store.setState({
+        state: {
+          status: TIMER_STATUS.SHORT_BREAK,
+          timeRemaining: defaultConfig.shortBreakDuration,
+          startedAt: 2000,
+          sessionNumber: 1,
+          config: defaultConfig,
+        },
+      });
+
+      // Skip break → goes to reflection (reflectionEnabled: true)
+      store.getState().skipBreak();
+      expect(store.getState().state.status).toBe(TIMER_STATUS.REFLECTION);
+
+      // Submit reflection → goes to completed
+      store.getState().submitReflection({ focusQuality: 'decent' });
+      expect(store.getState().state.status).toBe(TIMER_STATUS.COMPLETED);
+
+      // Reset → goes back to idle
+      store.getState().reset();
+      expect(store.getState().state.status).toBe(TIMER_STATUS.IDLE);
+    });
+  });
+});

--- a/packages/state/src/timer/timer-store.ts
+++ b/packages/state/src/timer/timer-store.ts
@@ -1,0 +1,147 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
+import type { TimerState, ReflectionData, TimerConfig } from '@pomofocus/core';
+import {
+  transition,
+  createInitialState,
+  TIMER_EVENT_TYPE,
+} from '@pomofocus/core';
+
+// ── Store Shape ──
+
+type TimerActions = {
+  start: () => void;
+  pause: () => void;
+  resume: () => void;
+  abandon: () => void;
+  reset: () => void;
+  tick: () => void;
+  skipBreak: () => void;
+  submitReflection: (data: ReflectionData) => void;
+  skipReflection: () => void;
+};
+
+export type TimerStore = {
+  state: TimerState;
+} & TimerActions;
+
+// ── Default Config ──
+
+const DEFAULT_CONFIG: TimerConfig = {
+  focusDuration: 1500,
+  shortBreakDuration: 300,
+  longBreakDuration: 900,
+  sessionsBeforeLongBreak: 4,
+  reflectionEnabled: true,
+};
+
+// ── Store Factory ──
+
+export type TimerStoreInstance = UseBoundStore<StoreApi<TimerStore>>;
+
+export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerStoreInstance {
+  return create<TimerStore>()(
+    devtools(
+      (set) => ({
+        state: createInitialState(config),
+
+        start: (): void => {
+          set(
+            (store) => ({
+              state: transition(store.state, { type: TIMER_EVENT_TYPE.START }, Date.now()),
+            }),
+            false,
+            'timer/start',
+          );
+        },
+
+        pause: (): void => {
+          set(
+            (store) => ({
+              state: transition(store.state, { type: TIMER_EVENT_TYPE.PAUSE }, Date.now()),
+            }),
+            false,
+            'timer/pause',
+          );
+        },
+
+        resume: (): void => {
+          set(
+            (store) => ({
+              state: transition(store.state, { type: TIMER_EVENT_TYPE.RESUME }, Date.now()),
+            }),
+            false,
+            'timer/resume',
+          );
+        },
+
+        abandon: (): void => {
+          set(
+            (store) => ({
+              state: transition(store.state, { type: TIMER_EVENT_TYPE.ABANDON }, Date.now()),
+            }),
+            false,
+            'timer/abandon',
+          );
+        },
+
+        reset: (): void => {
+          set(
+            (store) => ({
+              state: transition(store.state, { type: TIMER_EVENT_TYPE.RESET }, Date.now()),
+            }),
+            false,
+            'timer/reset',
+          );
+        },
+
+        tick: (): void => {
+          set(
+            (store) => ({
+              state: transition(store.state, { type: TIMER_EVENT_TYPE.TICK }, Date.now()),
+            }),
+            false,
+            'timer/tick',
+          );
+        },
+
+        skipBreak: (): void => {
+          set(
+            (store) => ({
+              state: transition(store.state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, Date.now()),
+            }),
+            false,
+            'timer/skipBreak',
+          );
+        },
+
+        submitReflection: (data: ReflectionData): void => {
+          set(
+            (store) => ({
+              state: transition(store.state, { type: TIMER_EVENT_TYPE.SUBMIT, data }, Date.now()),
+            }),
+            false,
+            'timer/submitReflection',
+          );
+        },
+
+        skipReflection: (): void => {
+          set(
+            (store) => ({
+              state: transition(store.state, { type: TIMER_EVENT_TYPE.SKIP }, Date.now()),
+            }),
+            false,
+            'timer/skipReflection',
+          );
+        },
+      }),
+      { name: 'TimerStore' },
+    ),
+  );
+}
+
+// ── Singleton Instance ──
+
+export const useTimerStore = createTimerStore();


### PR DESCRIPTION
## Summary

- Implements a Zustand store in `packages/state/src/timer/timer-store.ts` that wraps the `@pomofocus/core` timer `transition()` function, exposing actions (`start`, `pause`, `resume`, `abandon`, `reset`, `tick`, `skipBreak`, `submitReflection`, `skipReflection`) that dispatch events to the pure FSM
- Store uses `devtools` middleware and is designed for selector usage (`useTimerStore(s => s.state)`)
- Comprehensive test suite (453 lines) verifies each action dispatches the correct event and state updates correctly after transitions

Closes #116

## Test plan

- [x] `pnpm nx test @pomofocus/state` passes
- [ ] Manual review: store is a thin wrapper with no intervals/setTimeout/side effects
- [ ] Manual review: no `any` types, named exports only, explicit return types

🤖 Generated with [Claude Code](https://claude.com/claude-code)