### PR TITLE
feat: implement setInterval timer driver for web (#117)

### DIFF
--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -2,5 +2,6 @@
 // Depends on core, data-access, types.
 export { useTimerStore, createTimerStore } from './timer/timer-store.js';
 export type { TimerStore, TimerStoreInstance } from './timer/timer-store.js';
+export { startTimer, stopTimer } from './timer/timer-driver.js';
 export { createQueryClient } from './query-client.js';
 export { QueryProvider } from './providers.js';

--- a/packages/state/src/timer/timer-driver.test.ts
+++ b/packages/state/src/timer/timer-driver.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTimerStore } from './timer-store.js';
+import { startTimer, stopTimer } from './timer-driver.js';
+import type { TimerConfig } from '@pomofocus/core';
+import { TIMER_STATUS } from '@pomofocus/core';
+
+const defaultConfig: TimerConfig = {
+  focusDuration: 1500,
+  shortBreakDuration: 300,
+  longBreakDuration: 900,
+  sessionsBeforeLongBreak: 4,
+  reflectionEnabled: true,
+};
+
+function createStore(config: TimerConfig = defaultConfig): ReturnType<typeof createTimerStore> {
+  return createTimerStore(config);
+}
+
+describe('timer driver', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+  });
+
+  afterEach(() => {
+    stopTimer();
+    vi.useRealTimers();
+  });
+
+  describe('startTimer()', () => {
+    it('starts a 1-second interval when the timer is running', () => {
+      const store = createStore();
+      store.getState().start();
+
+      startTimer(store);
+
+      const initialRemaining = 1500;
+      vi.advanceTimersByTime(1000);
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.FOCUSING);
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.timeRemaining).toBe(initialRemaining - 1);
+      }
+    });
+
+    it('does not start an interval when the timer is idle', () => {
+      const store = createStore();
+
+      startTimer(store);
+      vi.advanceTimersByTime(5000);
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.IDLE);
+    });
+
+    it('starts the interval when the timer transitions to running', () => {
+      const store = createStore();
+
+      startTimer(store);
+
+      // Timer is idle, no ticks should happen
+      vi.advanceTimersByTime(3000);
+      expect(store.getState().state.status).toBe(TIMER_STATUS.IDLE);
+
+      // Now start the timer — driver should detect the change and begin ticking
+      store.getState().start();
+      vi.advanceTimersByTime(3000);
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.FOCUSING);
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.timeRemaining).toBe(1500 - 3);
+      }
+    });
+
+    it('ticks multiple times over several seconds', () => {
+      const store = createStore();
+      store.getState().start();
+
+      startTimer(store);
+      vi.advanceTimersByTime(10_000);
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.FOCUSING);
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.timeRemaining).toBe(1500 - 10);
+      }
+    });
+  });
+
+  describe('stopTimer()', () => {
+    it('clears the interval so ticks stop', () => {
+      const store = createStore();
+      store.getState().start();
+
+      startTimer(store);
+      vi.advanceTimersByTime(3000);
+
+      stopTimer();
+      vi.advanceTimersByTime(5000);
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.FOCUSING);
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        // Only 3 ticks should have occurred, not 8
+        expect(state.timeRemaining).toBe(1500 - 3);
+      }
+    });
+
+    it('is safe to call multiple times', () => {
+      const store = createStore();
+      store.getState().start();
+
+      startTimer(store);
+
+      stopTimer();
+      stopTimer();
+      stopTimer();
+
+      // No error thrown — verify timer is idle-safe
+      vi.advanceTimersByTime(5000);
+      const { state } = store.getState();
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.timeRemaining).toBe(1500);
+      }
+    });
+  });
+
+  describe('interval lifecycle', () => {
+    it('stops the interval when the timer is paused', () => {
+      const store = createStore();
+      store.getState().start();
+
+      startTimer(store);
+      vi.advanceTimersByTime(3000);
+
+      store.getState().pause();
+      vi.advanceTimersByTime(5000);
+
+      // Only 3 ticks from before the pause
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.PAUSED);
+      if (state.status === TIMER_STATUS.PAUSED) {
+        expect(state.timeRemaining).toBe(1500 - 3);
+      }
+    });
+
+    it('restarts the interval when the timer is resumed', () => {
+      const store = createStore();
+      store.getState().start();
+
+      startTimer(store);
+      vi.advanceTimersByTime(3000); // 3 ticks
+
+      store.getState().pause();
+      vi.advanceTimersByTime(2000); // no ticks
+
+      store.getState().resume();
+      vi.advanceTimersByTime(2000); // 2 more ticks
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.FOCUSING);
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.timeRemaining).toBe(1500 - 3 - 2);
+      }
+    });
+
+    it('stops the interval when the timer is abandoned', () => {
+      const store = createStore();
+      store.getState().start();
+
+      startTimer(store);
+      vi.advanceTimersByTime(2000);
+
+      store.getState().abandon();
+      vi.advanceTimersByTime(5000);
+
+      expect(store.getState().state.status).toBe(TIMER_STATUS.ABANDONED);
+    });
+  });
+
+  describe('TIMER_DONE dispatch', () => {
+    it('dispatches TIMER_DONE when focus timeRemaining reaches 0', () => {
+      const shortConfig: TimerConfig = { ...defaultConfig, focusDuration: 3 };
+      const store = createStore(shortConfig);
+      store.getState().start();
+
+      startTimer(store);
+
+      // After 3 seconds, timeRemaining hits 0 → TIMER_DONE → short_break
+      vi.advanceTimersByTime(3000);
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.SHORT_BREAK);
+      if (state.status === TIMER_STATUS.SHORT_BREAK) {
+        expect(state.timeRemaining).toBe(defaultConfig.shortBreakDuration);
+      }
+    });
+
+    it('dispatches TIMER_DONE when break timeRemaining reaches 0', () => {
+      const shortConfig: TimerConfig = {
+        ...defaultConfig,
+        focusDuration: 2,
+        shortBreakDuration: 2,
+      };
+      const store = createStore(shortConfig);
+      store.getState().start();
+
+      startTimer(store);
+
+      // 2s focus → TIMER_DONE → short_break with 2s
+      vi.advanceTimersByTime(2000);
+      expect(store.getState().state.status).toBe(TIMER_STATUS.SHORT_BREAK);
+
+      // 2s break → TIMER_DONE → reflection (reflectionEnabled: true)
+      vi.advanceTimersByTime(2000);
+      expect(store.getState().state.status).toBe(TIMER_STATUS.REFLECTION);
+    });
+
+    it('transitions through a full focus cycle: focus → break → reflection', () => {
+      const shortConfig: TimerConfig = {
+        ...defaultConfig,
+        focusDuration: 1,
+        shortBreakDuration: 1,
+      };
+      const store = createStore(shortConfig);
+      store.getState().start();
+
+      startTimer(store);
+
+      // 1s focus → short_break
+      vi.advanceTimersByTime(1000);
+      expect(store.getState().state.status).toBe(TIMER_STATUS.SHORT_BREAK);
+
+      // 1s break → reflection
+      vi.advanceTimersByTime(1000);
+      expect(store.getState().state.status).toBe(TIMER_STATUS.REFLECTION);
+
+      // Driver should have stopped ticking (reflection is not running)
+      vi.advanceTimersByTime(5000);
+      expect(store.getState().state.status).toBe(TIMER_STATUS.REFLECTION);
+    });
+
+    it('continues ticking during break after TIMER_DONE from focus', () => {
+      const shortConfig: TimerConfig = {
+        ...defaultConfig,
+        focusDuration: 2,
+        shortBreakDuration: 300,
+      };
+      const store = createStore(shortConfig);
+      store.getState().start();
+
+      startTimer(store);
+
+      // 2s focus → short_break
+      vi.advanceTimersByTime(2000);
+      expect(store.getState().state.status).toBe(TIMER_STATUS.SHORT_BREAK);
+
+      // Continue ticking during break
+      vi.advanceTimersByTime(3000);
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.SHORT_BREAK);
+      if (state.status === TIMER_STATUS.SHORT_BREAK) {
+        expect(state.timeRemaining).toBe(300 - 3);
+      }
+    });
+  });
+
+  describe('cleanup', () => {
+    it('cleans up previous driver when startTimer is called again', () => {
+      const store = createStore();
+      store.getState().start();
+
+      startTimer(store);
+      vi.advanceTimersByTime(2000); // 2 ticks
+
+      // Start again — should clean up old interval
+      startTimer(store);
+      vi.advanceTimersByTime(3000); // 3 ticks (not 3 + extra from old interval)
+
+      const { state } = store.getState();
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.timeRemaining).toBe(1500 - 2 - 3);
+      }
+    });
+  });
+});

--- a/packages/state/src/timer/timer-driver.ts
+++ b/packages/state/src/timer/timer-driver.ts
@@ -1,0 +1,61 @@
+import { isRunning, getTimeRemaining } from '@pomofocus/core';
+import type { TimerStoreInstance } from './timer-store.js';
+
+// ── Module-level State ──
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+let unsubscribe: (() => void) | null = null;
+
+// ── Driver API ──
+
+/**
+ * Starts the timer driver. Sets up a Zustand subscription that watches
+ * `isRunning(state)` and manages a 1-second interval accordingly.
+ * Each interval tick dispatches TICK, then dispatches TIMER_DONE
+ * if timeRemaining has reached 0.
+ */
+export function startTimer(store: TimerStoreInstance): void {
+  // Clean up any existing driver before starting a new one.
+  stopTimer();
+
+  const maybeStartInterval = (): void => {
+    const { state } = store.getState();
+
+    if (isRunning(state) && intervalId === null) {
+      intervalId = setInterval(() => {
+        store.getState().tick();
+
+        const afterTick = store.getState().state;
+        if (isRunning(afterTick) && getTimeRemaining(afterTick) === 0) {
+          store.getState().timerDone();
+        }
+      }, 1_000);
+    } else if (!isRunning(state) && intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  };
+
+  // Check current state immediately — the timer may already be running.
+  maybeStartInterval();
+
+  // Subscribe to future state changes.
+  unsubscribe = store.subscribe(() => {
+    maybeStartInterval();
+  });
+}
+
+/**
+ * Stops the timer driver. Clears the interval and removes the
+ * Zustand subscription. Safe to call multiple times.
+ */
+export function stopTimer(): void {
+  if (intervalId !== null) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+  if (unsubscribe !== null) {
+    unsubscribe();
+    unsubscribe = null;
+  }
+}

--- a/packages/state/src/timer/timer-store.ts
+++ b/packages/state/src/timer/timer-store.ts
@@ -18,6 +18,7 @@ type TimerActions = {
   abandon: () => void;
   reset: () => void;
   tick: () => void;
+  timerDone: () => void;
   skipBreak: () => void;
   submitReflection: (data: ReflectionData) => void;
   skipReflection: () => void;
@@ -104,6 +105,16 @@ export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerSto
             }),
             false,
             'timer/tick',
+          );
+        },
+
+        timerDone: (): void => {
+          set(
+            (store) => ({
+              state: transition(store.state, { type: TIMER_EVENT_TYPE.TIMER_DONE }, Date.now()),
+            }),
+            false,
+            'timer/timerDone',
           );
         },
 


### PR DESCRIPTION
## Summary

- Implements `startTimer(store)` / `stopTimer()` functions in `packages/state/src/timer/timer-driver.ts` that manage a 1-second `setInterval` to dispatch TICK events to the timer Zustand store
- Driver checks running state from core FSM and automatically dispatches `TIMER_DONE` when remaining time reaches zero
- Comprehensive test suite using `vi.useFakeTimers()` covering interval lifecycle, tick dispatch, auto-done detection, and cleanup

Closes #117

## Test plan

- [x] `pnpm nx test @pomofocus/state` passes
- [x] Tests verify interval starts on `startTimer()` and clears on `stopTimer()`
- [x] Tests verify TICK events are dispatched every second
- [x] Tests verify TIMER_DONE is dispatched when time reaches 0
- [x] Tests verify no memory leaks (interval properly cleaned up)
- [x] No `any` types, named exports only, explicit return types

🤖 Generated with [Claude Code](https://claude.com/claude-code)