### PR TITLE
feat: implement useCreateSession mutation hook

### DIFF
--- a/packages/state/src/hooks/use-create-session.test.ts
+++ b/packages/state/src/hooks/use-create-session.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { createElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { createSession, createApiClient } from '@pomofocus/data-access';
+import { useCreateSession } from './use-create-session.js';
+
+vi.mock('@pomofocus/data-access', () => ({
+  createSession: vi.fn(),
+  createApiClient: vi.fn(() => ({})),
+}));
+
+const mockedCreateSession = vi.mocked(createSession);
+
+function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient): (props: { children: ReactNode }) => ReactNode {
+  return function Wrapper({ children }: { children: ReactNode }): ReactNode {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+// ApiClient resolves from openapi-fetch which uses complex generics.
+// In tests, createSession is mocked so the client is never called.
+const mockClient = createApiClient('https://test.example.com');
+
+const mockSessionBody = {
+  started_at: '2026-03-17T10:00:00Z',
+  ended_at: '2026-03-17T10:25:00Z',
+  focus_quality: 'locked_in' as const,
+};
+
+const mockSessionResponse = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  user_id: 'user-1',
+  process_goal_id: 'goal-1',
+  intention_text: null,
+  started_at: '2026-03-17T10:00:00Z',
+  ended_at: '2026-03-17T10:25:00Z',
+  completed: true,
+  abandonment_reason: null,
+  focus_quality: 'locked_in' as const,
+  distraction_type: null,
+  device_id: null,
+  created_at: '2026-03-17T10:25:00Z',
+};
+
+describe('useCreateSession', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+    mockedCreateSession.mockReset();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it('calls createSession from data-access with the provided body', async () => {
+    mockedCreateSession.mockResolvedValue({
+      data: mockSessionResponse,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useCreateSession(mockClient), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate(mockSessionBody);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockedCreateSession).toHaveBeenCalledWith(mockClient, mockSessionBody);
+  });
+
+  it('returns created session data on success', async () => {
+    mockedCreateSession.mockResolvedValue({
+      data: mockSessionResponse,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useCreateSession(mockClient), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate(mockSessionBody);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockSessionResponse);
+  });
+
+  it('invalidates sessions query cache on success (PKG-S07)', async () => {
+    // Seed the sessions query cache so we can verify invalidation
+    queryClient.setQueryData(['sessions'], { data: [], total: 0 });
+
+    mockedCreateSession.mockResolvedValue({
+      data: mockSessionResponse,
+      error: undefined,
+    });
+
+    const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateSession(mockClient), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate(mockSessionBody);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ['sessions'] });
+
+    invalidateQueriesSpy.mockRestore();
+  });
+
+  it('sets error state when createSession returns an error', async () => {
+    mockedCreateSession.mockResolvedValue({
+      data: undefined,
+      error: { error: 'Validation error' },
+    });
+
+    const { result } = renderHook(() => useCreateSession(mockClient), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate(mockSessionBody);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+
+  it('does not invalidate sessions cache on error', async () => {
+    mockedCreateSession.mockResolvedValue({
+      data: undefined,
+      error: { error: 'Server error' },
+    });
+
+    const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateSession(mockClient), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate(mockSessionBody);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+
+    invalidateQueriesSpy.mockRestore();
+  });
+});

--- a/packages/state/src/hooks/use-create-session.ts
+++ b/packages/state/src/hooks/use-create-session.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { UseMutationResult } from '@tanstack/react-query';
+import { createSession } from '@pomofocus/data-access';
+import type { ApiClient, CreateSessionBody, SessionResponse } from '@pomofocus/data-access';
+
+/**
+ * Creates a new session via the API and invalidates the sessions cache (PKG-S07).
+ * Server data stays in TanStack Query cache — not stored in Zustand (PKG-S01).
+ */
+function useCreateSession(
+  client: ApiClient,
+): UseMutationResult<SessionResponse, Error, CreateSessionBody> {
+  const queryClient = useQueryClient();
+
+  return useMutation<SessionResponse, Error, CreateSessionBody>({
+    mutationFn: async (body: CreateSessionBody): Promise<SessionResponse> => {
+      const result = await createSession(client, body);
+
+      if (result.error !== undefined) {
+        if (result.error instanceof Error) {
+          throw result.error;
+        }
+        throw new Error(
+          typeof result.error === 'string' ? result.error : 'Failed to create session',
+        );
+      }
+
+      if (result.data === undefined) {
+        throw new Error('No data returned from createSession');
+      }
+
+      return result.data;
+    },
+    onSuccess: async (): Promise<void> => {
+      await queryClient.invalidateQueries({ queryKey: ['sessions'] });
+    },
+  });
+}
+
+export { useCreateSession };

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -6,3 +6,4 @@ export { startTimer, stopTimer } from './timer/timer-driver.js';
 export { createQueryClient } from './query-client.js';
 export { QueryProvider } from './providers.js';
 export { useSessions, sessionsQueryOptions } from './hooks/use-sessions.js';
+export { useCreateSession } from './hooks/use-create-session.js';


### PR DESCRIPTION
## Summary

- Implements `useCreateSession()` TanStack Query mutation hook that calls `createSession()` from `@pomofocus/data-access` and invalidates the sessions query cache on success (PKG-S07)
- Follows server-state-in-TanStack-Query pattern (PKG-S01) -- no Zustand involvement for session data
- Full test coverage: mutation call, success data, cache invalidation, and error handling

Closes #119

## Test plan

- [x] `pnpm nx test @pomofocus/state` passes
- [ ] Human review of mutation hook implementation and test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)