### PR TITLE
chore: move Supabase credentials to CF Workers secrets

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -2,7 +2,9 @@ name = "pomofocus-api"
 main = "src/index.ts"
 compatibility_date = "2026-03-14"
 
+# SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are set as CF Workers secrets
+# via `wrangler secret put` — never stored in this file.
+# See: https://developers.cloudflare.com/workers/configuration/secrets/
+
 [vars]
-SUPABASE_URL = ""
-SUPABASE_SERVICE_ROLE_KEY = ""
 ALLOWED_ORIGINS = ""


### PR DESCRIPTION
## Summary

- Move `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` from `wrangler.toml` `[vars]` to CF Workers secrets (via `wrangler secret put`), preventing credentials from being committed to the repo
- Add documentation comments in `wrangler.toml` explaining the secrets approach

Closes #128

## Test plan

- [ ] `wrangler deploy` from `apps/api/` deploys successfully
- [ ] `curl https://[api-url]/health` returns 200
- [ ] Verify `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are set via `wrangler secret put`
- [ ] Sessions endpoints functional against production Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)