### PR TITLE
chore: set up app providers with QueryClient and timer store (#122)

### DIFF
--- a/apps/web/app/_layout.tsx
+++ b/apps/web/app/_layout.tsx
@@ -1,5 +1,10 @@
 import { Slot } from 'expo-router';
+import { AppProviders } from './providers';
 
 export default function RootLayout(): React.JSX.Element {
-  return <Slot />;
+  return (
+    <AppProviders>
+      <Slot />
+    </AppProviders>
+  );
 }

--- a/apps/web/app/env.d.ts
+++ b/apps/web/app/env.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Type declarations for Expo environment variables.
+ * Metro replaces process.env.EXPO_PUBLIC_* at build time.
+ */
+declare const process: {
+  env: {
+    EXPO_PUBLIC_API_URL?: string;
+  };
+};

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+import { useMemo } from 'react';
+import { QueryProvider, createQueryClient } from '@pomofocus/state';
+
+/**
+ * API base URL read from environment variable.
+ * Expo convention: EXPO_PUBLIC_ prefix makes it available client-side.
+ */
+export const API_BASE_URL: string =
+  process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8787';
+
+type AppProvidersProps = {
+  readonly children: ReactNode;
+};
+
+export function AppProviders({ children }: AppProvidersProps): ReactNode {
+  const queryClient = useMemo(() => createQueryClient(), []);
+
+  return <QueryProvider client={queryClient}>{children}</QueryProvider>;
+}


### PR DESCRIPTION
## Summary

- Set up `AppProviders` component in `apps/web/app/providers.tsx` composing `QueryProvider` from `@pomofocus/state` with a memoized `QueryClient`
- Wrap root layout (`_layout.tsx`) with `AppProviders` so all routes have access to TanStack Query and Zustand stores
- Configure API base URL from `EXPO_PUBLIC_API_URL` environment variable (defaults to `http://localhost:8787`)
- Add `env.d.ts` type declarations for Expo environment variables

Closes #122

## Test plan

- [ ] `pnpm nx start @pomofocus/web` — app renders in browser without errors
- [ ] No console errors about missing providers
- [ ] `useTimerStore` is accessible from any component under the provider tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)