### PR TITLE
feat: compose main page with timer and session list (#126)

### DIFF
--- a/apps/web/app/index.tsx
+++ b/apps/web/app/index.tsx
@@ -1,9 +1,27 @@
+import { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { createApiClient } from '@pomofocus/data-access';
+import { TimerDisplay } from './components/timer-display';
+import { TimerControls } from './components/timer-controls';
+import { SessionList } from './components/session-list';
+
+const API_BASE_URL: string =
+  process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8787';
 
 export default function HomeScreen(): React.JSX.Element {
+  const client = useMemo(() => createApiClient(API_BASE_URL), []);
+
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>PomoFocus</Text>
+      <View style={styles.timerSection}>
+        <Text style={styles.title}>PomoFocus</Text>
+        <TimerDisplay />
+        <TimerControls />
+      </View>
+      <View style={styles.sessionsSection}>
+        <Text style={styles.sectionHeading}>Sessions</Text>
+        <SessionList client={client} />
+      </View>
     </View>
   );
 }
@@ -11,10 +29,24 @@ export default function HomeScreen(): React.JSX.Element {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    padding: 16,
   },
-  text: {
+  timerSection: {
+    alignItems: 'center',
+    paddingVertical: 24,
+  },
+  title: {
     fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 16,
+  },
+  sessionsSection: {
+    flex: 1,
+    paddingTop: 16,
+  },
+  sectionHeading: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 8,
   },
 });


### PR DESCRIPTION
## Summary

- Wires together `TimerDisplay`, `TimerControls`, and `SessionList` components into the main page (`apps/web/app/index.tsx`), completing sub-item 1.5 of the walking skeleton client
- Full end-to-end flow: Start timer → countdown → Complete → session saved to API → session appears in list
- Minimal functional layout with timer section at top and session list below

Closes #126

## Test plan

- [ ] Run `pnpm nx start @pomofocus/web` and open browser
- [ ] Click "Start" — timer counts down from 25:00
- [ ] Click "Complete" — session is saved
- [ ] Verify session appears in the session list below the timer
- [ ] Refresh page — session list still shows the completed session

🤖 Generated with [Claude Code](https://claude.com/claude-code)