### PR TITLE
fix: correct RLS policies for social tables (#291)

### DIFF
--- a/supabase/migrations/20260322000000_rls_social.sql
+++ b/supabase/migrations/20260322000000_rls_social.sql
@@ -1,0 +1,42 @@
+-- Migration: Correct RLS policies for social tables
+-- Issue: #291
+-- Depends on: #41 (initial RLS policies in 20260311000006)
+-- Reference: ADR-005, ADR-018, ADR-012
+--
+-- Fixes:
+--   1. friend_requests DELETE: restrict to sender only (was sender OR recipient)
+--   2. friendships: remove direct INSERT/DELETE (managed by accept/unfriend functions)
+--   3. encouragement_taps SELECT: allow sender OR recipient (was recipient only)
+--   4. encouragement_taps INSERT: remove RLS friendship check (enforced in API per ADR-018)
+
+-- ---- friend_requests: restrict DELETE to sender only ----
+
+DROP POLICY "fr_delete" ON friend_requests;
+
+CREATE POLICY "fr_delete" ON friend_requests
+  FOR DELETE TO authenticated USING (
+    sender_id = (SELECT get_user_id())
+  );
+
+-- ---- friendships: remove direct INSERT/DELETE (managed by DB functions) ----
+
+DROP POLICY "friendships_insert" ON friendships;
+DROP POLICY "friendships_delete_own" ON friendships;
+
+-- ---- encouragement_taps: allow both sender and recipient to SELECT ----
+
+DROP POLICY "taps_select_received" ON encouragement_taps;
+
+CREATE POLICY "taps_select" ON encouragement_taps
+  FOR SELECT TO authenticated USING (
+    sender_id = (SELECT get_user_id()) OR recipient_id = (SELECT get_user_id())
+  );
+
+-- ---- encouragement_taps: simplify INSERT (friendship enforced in API per ADR-018) ----
+
+DROP POLICY "taps_insert" ON encouragement_taps;
+
+CREATE POLICY "taps_insert" ON encouragement_taps
+  FOR INSERT TO authenticated WITH CHECK (
+    sender_id = (SELECT get_user_id())
+  );


### PR DESCRIPTION
## Summary

- Corrects RLS policies for `friend_requests`, `friendships`, and `encouragement_taps` tables to match ADR-005 and ADR-018 specifications
- Restricts `friend_requests` DELETE to sender only (was allowing recipient to delete)
- Removes direct INSERT/DELETE on `friendships` (managed by accept/unfriend DB functions)
- Allows both sender and recipient to SELECT `encouragement_taps` (was recipient-only)
- Simplifies `encouragement_taps` INSERT by removing RLS friendship check (enforced in API per ADR-018)

Closes #291

## Test plan

- [ ] `supabase db reset` succeeds with the new migration
- [ ] SQL test: user can see friend requests they sent and received
- [ ] SQL test: user cannot see friend requests between other users
- [ ] SQL test: user can only delete friend requests they sent
- [ ] SQL test: user can see their own friendships but not others'
- [ ] SQL test: user cannot directly insert/delete friendships
- [ ] SQL test: both sender and recipient can see encouragement taps

🤖 Generated with [Claude Code](https://claude.com/claude-code)