### PR TITLE
feat: add get_user_id() SQL function migration (#282)

### DIFF
--- a/supabase/migrations/20260322000000_get_user_id_function.sql
+++ b/supabase/migrations/20260322000000_get_user_id_function.sql
@@ -1,0 +1,12 @@
+-- Migration: Create get_user_id() helper function
+-- Issue: #282
+-- Depends on: #36 (profiles table must exist)
+-- Reference: ADR-005, ADR-002, ADR-012
+
+-- Maps auth.uid() to profiles.id for use in RLS policies.
+-- All RLS policies use get_user_id() instead of inlining the auth lookup,
+-- providing a single point of change if the auth-to-profile mapping evolves.
+
+CREATE OR REPLACE FUNCTION get_user_id() RETURNS uuid AS $$
+  SELECT id FROM profiles WHERE auth_user_id = auth.uid()
+$$ LANGUAGE sql SECURITY DEFINER STABLE;


### PR DESCRIPTION
## Summary

- Creates the `get_user_id()` SQL helper function that maps `auth.uid()` to `profiles.id`, used by all RLS policies as a clean abstraction layer (per ADR-005)
- Function is `SECURITY DEFINER` and `STABLE` for query planner optimization
- Returns NULL defensively if no matching profile exists

Closes #282

## Test plan

- [ ] `supabase db reset` succeeds with migration applied
- [ ] `SELECT get_user_id()` returns correct profile UUID for authenticated user
- [ ] `get_user_id()` returns NULL for unauthenticated request

🤖 Generated with [Claude Code](https://claude.com/claude-code)