### PR TITLE
feat: implement RLS policies for sessions and breaks (#289)

### DIFF
--- a/supabase/migrations/20260322000000_rls_sessions_breaks.sql
+++ b/supabase/migrations/20260322000000_rls_sessions_breaks.sql
@@ -1,0 +1,57 @@
+-- Migration: Replace FOR ALL policies on sessions/breaks with per-operation policies
+-- Issue: #289
+-- Depends on: #41 (get_user_id() helper and skeleton RLS policies)
+-- Reference: ADR-005, ADR-012, ADR-018
+
+-- ============================================================
+-- Drop existing FOR ALL policies (created in migration 000006)
+-- ============================================================
+
+DROP POLICY IF EXISTS "sessions_all_own" ON sessions;
+DROP POLICY IF EXISTS "breaks_all_own" ON breaks;
+
+-- ============================================================
+-- sessions — per-operation policies using (SELECT get_user_id())
+-- ============================================================
+
+-- RLS is already enabled (migration 000004). Re-stating for safety.
+ALTER TABLE sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "sessions_select_own" ON sessions
+  FOR SELECT TO authenticated
+  USING (user_id = (SELECT get_user_id()));
+
+CREATE POLICY "sessions_insert_own" ON sessions
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = (SELECT get_user_id()));
+
+CREATE POLICY "sessions_update_own" ON sessions
+  FOR UPDATE TO authenticated
+  USING (user_id = (SELECT get_user_id()));
+
+CREATE POLICY "sessions_delete_own" ON sessions
+  FOR DELETE TO authenticated
+  USING (user_id = (SELECT get_user_id()));
+
+-- ============================================================
+-- breaks — per-operation policies using (SELECT get_user_id())
+-- ============================================================
+
+-- RLS is already enabled (migration 000004). Re-stating for safety.
+ALTER TABLE breaks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "breaks_select_own" ON breaks
+  FOR SELECT TO authenticated
+  USING (user_id = (SELECT get_user_id()));
+
+CREATE POLICY "breaks_insert_own" ON breaks
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = (SELECT get_user_id()));
+
+CREATE POLICY "breaks_update_own" ON breaks
+  FOR UPDATE TO authenticated
+  USING (user_id = (SELECT get_user_id()));
+
+CREATE POLICY "breaks_delete_own" ON breaks
+  FOR DELETE TO authenticated
+  USING (user_id = (SELECT get_user_id()));


### PR DESCRIPTION
## Summary

- Adds per-operation RLS policies for `sessions` and `breaks` tables using the `get_user_id()` helper function
- Users can only SELECT, INSERT, UPDATE, and DELETE their own rows — no cross-user visibility
- No RLS exceptions for friends — social visibility is handled by scoped functions per ADR-005/ADR-018

Closes #289

## Details

Creates migration `20260322000000_rls_sessions_breaks.sql` that:
- Enables RLS on both `sessions` and `breaks` tables
- Adds separate policies for each CRUD operation (SELECT, INSERT, UPDATE, DELETE)
- INSERT policies enforce `user_id = get_user_id()` to prevent impersonation
- All policies use the `get_user_id()` helper (not raw `auth.uid()`) per ADR-002

## Test plan

- [ ] `supabase db reset` succeeds with the new migration
- [ ] User A can INSERT/SELECT/UPDATE/DELETE own sessions
- [ ] User A cannot SELECT user B's sessions
- [ ] User A can INSERT/SELECT/UPDATE/DELETE own breaks
- [ ] User A cannot see user B's breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)