### PR TITLE
feat: RLS policies for devices and device_sync_log (#290)

### DIFF
--- a/supabase/migrations/20260322000000_rls_devices.sql
+++ b/supabase/migrations/20260322000000_rls_devices.sql
@@ -1,0 +1,40 @@
+-- Migration: Granular RLS policies for devices and device_sync_log
+-- Issue: #290
+-- Depends on: #41 (get_user_id() helper and initial RLS policies)
+-- Reference: ADR-005, ADR-012, ADR-013
+
+-- Drop the broad FOR ALL policies created in 20260311000006
+DROP POLICY IF EXISTS "devices_all_own" ON devices;
+DROP POLICY IF EXISTS "sync_log_all_own" ON device_sync_log;
+
+-- ---- devices (per-operation policies) ----
+
+-- SELECT: users can see their own devices
+CREATE POLICY "devices_select_own" ON devices
+  FOR SELECT TO authenticated USING (user_id = (SELECT get_user_id()));
+
+-- INSERT: enforces user_id = get_user_id() — prevents registering under another user
+CREATE POLICY "devices_insert_own" ON devices
+  FOR INSERT TO authenticated WITH CHECK (user_id = (SELECT get_user_id()));
+
+-- UPDATE: users can update their own devices
+CREATE POLICY "devices_update_own" ON devices
+  FOR UPDATE TO authenticated USING (user_id = (SELECT get_user_id()));
+
+-- DELETE: users can delete their own devices
+CREATE POLICY "devices_delete_own" ON devices
+  FOR DELETE TO authenticated USING (user_id = (SELECT get_user_id()));
+
+-- ---- device_sync_log (SELECT + INSERT only — no UPDATE/DELETE needed) ----
+
+-- SELECT: users can see sync logs for their own devices
+CREATE POLICY "sync_log_select_own" ON device_sync_log
+  FOR SELECT TO authenticated USING (
+    device_id IN (SELECT id FROM devices WHERE user_id = (SELECT get_user_id()))
+  );
+
+-- INSERT: users can create sync logs for their own devices
+CREATE POLICY "sync_log_insert_own" ON device_sync_log
+  FOR INSERT TO authenticated WITH CHECK (
+    device_id IN (SELECT id FROM devices WHERE user_id = (SELECT get_user_id()))
+  );


### PR DESCRIPTION
## Summary

- Add granular Row-Level Security policies for `devices` and `device_sync_log` tables
- `devices`: users can SELECT, INSERT, UPDATE, DELETE only their own devices (enforced via `get_user_id()` helper)
- `device_sync_log`: users can SELECT and INSERT logs only for devices they own (ownership verified via subquery)
- INSERT policies enforce `user_id = get_user_id()` to prevent registering devices under another user's ID

Closes #290

## Test plan

- [ ] `supabase db reset` succeeds with the new migration applied
- [ ] SQL test: user A can INSERT their own device
- [ ] SQL test: user A cannot SELECT user B's devices
- [ ] SQL test: user A can INSERT sync_log for their own device
- [ ] SQL test: user A cannot see sync_logs for user B's devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)