### PR TITLE
feat: Arduino setup/loop skeleton for EN04 firmware (#202)

### DIFF
--- a/firmware/device/src/main.cpp
+++ b/firmware/device/src/main.cpp
@@ -1,8 +1,32 @@
-// Minimal entry point for PlatformIO config validation.
-// Actual firmware implementation is a separate issue.
+// PomoFocus Device Firmware — EN04 (nRF52840 Plus)
+// Arduino setup/loop skeleton. See ADR-010 and ADR-015.
 
 #include <Arduino.h>
 
-void setup() {}
+// Serial baud rate for debug output (matches monitor_speed in platformio.ini)
+constexpr uint32_t SERIAL_BAUD = 115200;
 
-void loop() {}
+// LED blink duration in milliseconds
+constexpr uint32_t LED_BLINK_MS = 500;
+
+void setup() {
+  Serial.begin(SERIAL_BAUD);
+
+  // Wait briefly for serial connection on USB-native boards
+  delay(1000);
+
+  Serial.println("PomoFocus booting");
+
+  // Blink built-in LED once to confirm firmware is running.
+  // XIAO nRF52840 LED is active LOW: LOW = on, HIGH = off.
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+  delay(LED_BLINK_MS);
+  digitalWrite(LED_BUILTIN, HIGH);
+
+  Serial.println("Setup complete");
+}
+
+void loop() {
+  // Empty placeholder — timer driver added in issue 7A.3.
+}


### PR DESCRIPTION
## Summary

- Replaces the minimal PlatformIO config-validation stub in `firmware/device/src/main.cpp` with a working Arduino setup/loop skeleton for the EN04 board (nRF52840 Plus)
- `setup()` initializes serial at 115200 baud, prints "PomoFocus booting", and blinks the built-in LED once to confirm firmware is running
- `loop()` is an empty placeholder for the future timer driver (issue 7A.3)

Closes #202

## Test plan

- [ ] `cd firmware/device && pio run` compiles without errors
- [ ] `pio run -t upload` uploads to EN04 board (manual verification)
- [ ] Serial monitor shows "PomoFocus booting" and "Setup complete"
- [ ] Board LED blinks once on power-up

Generated with [Claude Code](https://claude.com/claude-code)
