### PR TITLE
feat: implement Tier 1 weekly continuity dots analytics

### DIFF
--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,3 +1,3 @@
 // Component metrics: completion rate, focus quality, consistency, streaks, trends.
 // Pure functions only — no IO, no React, no Supabase.
-export {};
+export { weeklyConsistency } from './tier1/index.js';

--- a/packages/analytics/src/tier1/index.ts
+++ b/packages/analytics/src/tier1/index.ts
@@ -1,0 +1,1 @@
+export { weeklyConsistency } from './weekly-dots.js';

--- a/packages/analytics/src/tier1/weekly-dots.test.ts
+++ b/packages/analytics/src/tier1/weekly-dots.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'vitest';
+import { weeklyConsistency } from './weekly-dots.js';
+import type { Session } from '@pomofocus/types';
+
+type MinimalSession = Pick<Session, 'started_at' | 'completed'>;
+
+function makeSession(startedAt: string, completed: boolean): MinimalSession {
+  return { started_at: startedAt, completed };
+}
+
+// Helper: get Unix ms from ISO string
+function ms(iso: string): number {
+  return new Date(iso).getTime();
+}
+
+describe('weeklyConsistency', () => {
+  // Reference week: Monday 2026-03-16 through Sunday 2026-03-22
+  // nowTimestamp = Wednesday 2026-03-18 12:00:00 UTC
+  const tz = 'UTC';
+  const wed = ms('2026-03-18T12:00:00Z');
+
+  describe('basic behavior', () => {
+    it('returns 7 booleans', () => {
+      const result = weeklyConsistency([], tz, wed);
+      expect(result).toHaveLength(7);
+    });
+
+    it('returns all false for empty sessions', () => {
+      expect(weeklyConsistency([], tz, wed)).toEqual([
+        false, false, false, false, false, false, false,
+      ]);
+    });
+
+    it('returns true for day with one completed session', () => {
+      const sessions = [
+        makeSession('2026-03-18T10:00:00Z', true), // Wednesday
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        false, false, true, false, false, false, false,
+      ]);
+    });
+
+    it('returns true for Monday (index 0)', () => {
+      const sessions = [
+        makeSession('2026-03-16T08:00:00Z', true), // Monday
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        true, false, false, false, false, false, false,
+      ]);
+    });
+
+    it('returns true for Sunday (index 6)', () => {
+      const sessions = [
+        makeSession('2026-03-22T20:00:00Z', true), // Sunday
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        false, false, false, false, false, false, true,
+      ]);
+    });
+
+    it('returns true for multiple days with completed sessions', () => {
+      const sessions = [
+        makeSession('2026-03-16T09:00:00Z', true), // Monday
+        makeSession('2026-03-18T14:00:00Z', true), // Wednesday
+        makeSession('2026-03-20T11:00:00Z', true), // Friday
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        true, false, true, false, true, false, false,
+      ]);
+    });
+
+    it('returns all true when every day has a completed session', () => {
+      const sessions = [
+        makeSession('2026-03-16T08:00:00Z', true), // Mon
+        makeSession('2026-03-17T08:00:00Z', true), // Tue
+        makeSession('2026-03-18T08:00:00Z', true), // Wed
+        makeSession('2026-03-19T08:00:00Z', true), // Thu
+        makeSession('2026-03-20T08:00:00Z', true), // Fri
+        makeSession('2026-03-21T08:00:00Z', true), // Sat
+        makeSession('2026-03-22T08:00:00Z', true), // Sun
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        true, true, true, true, true, true, true,
+      ]);
+    });
+  });
+
+  describe('only counts completed sessions', () => {
+    it('returns false for days with only abandoned sessions', () => {
+      const sessions = [
+        makeSession('2026-03-18T10:00:00Z', false), // Wednesday, not completed
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        false, false, false, false, false, false, false,
+      ]);
+    });
+
+    it('returns true when at least one session on the day is completed', () => {
+      const sessions = [
+        makeSession('2026-03-18T09:00:00Z', false), // abandoned
+        makeSession('2026-03-18T11:00:00Z', true),  // completed
+        makeSession('2026-03-18T14:00:00Z', false), // abandoned
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        false, false, true, false, false, false, false,
+      ]);
+    });
+
+    it('ignores all non-completed sessions across multiple days', () => {
+      const sessions = [
+        makeSession('2026-03-16T10:00:00Z', false), // Mon abandoned
+        makeSession('2026-03-17T10:00:00Z', true),  // Tue completed
+        makeSession('2026-03-18T10:00:00Z', false), // Wed abandoned
+        makeSession('2026-03-19T10:00:00Z', true),  // Thu completed
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        false, true, false, true, false, false, false,
+      ]);
+    });
+  });
+
+  describe('multiple sessions per day', () => {
+    it('still returns true (not double-counted)', () => {
+      const sessions = [
+        makeSession('2026-03-18T08:00:00Z', true),
+        makeSession('2026-03-18T12:00:00Z', true),
+        makeSession('2026-03-18T16:00:00Z', true),
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        false, false, true, false, false, false, false,
+      ]);
+    });
+  });
+
+  describe('sessions outside the current week are ignored', () => {
+    it('ignores sessions from the previous week', () => {
+      const sessions = [
+        makeSession('2026-03-15T23:59:59Z', true), // Sunday of previous week
+        makeSession('2026-03-09T10:00:00Z', true),  // Monday of previous week
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        false, false, false, false, false, false, false,
+      ]);
+    });
+
+    it('ignores sessions from the next week', () => {
+      const sessions = [
+        makeSession('2026-03-23T00:00:01Z', true), // Monday of next week
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        false, false, false, false, false, false, false,
+      ]);
+    });
+  });
+
+  describe('week boundaries', () => {
+    it('Monday at midnight belongs to the current week', () => {
+      const sessions = [
+        makeSession('2026-03-16T00:00:00Z', true), // Monday 00:00:00
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        true, false, false, false, false, false, false,
+      ]);
+    });
+
+    it('Sunday at 23:59:59 belongs to the current week', () => {
+      const sessions = [
+        makeSession('2026-03-22T23:59:59Z', true), // Sunday 23:59:59
+      ];
+      expect(weeklyConsistency(sessions, tz, wed)).toEqual([
+        false, false, false, false, false, false, true,
+      ]);
+    });
+
+    it('nowTimestamp on Monday returns the correct week', () => {
+      const monday = ms('2026-03-16T00:00:00Z');
+      const sessions = [
+        makeSession('2026-03-16T10:00:00Z', true), // Monday
+        makeSession('2026-03-22T10:00:00Z', true), // Sunday
+      ];
+      expect(weeklyConsistency(sessions, tz, monday)).toEqual([
+        true, false, false, false, false, false, true,
+      ]);
+    });
+
+    it('nowTimestamp on Sunday returns the correct week', () => {
+      const sunday = ms('2026-03-22T23:59:59Z');
+      const sessions = [
+        makeSession('2026-03-16T10:00:00Z', true), // Monday
+        makeSession('2026-03-22T10:00:00Z', true), // Sunday
+      ];
+      expect(weeklyConsistency(sessions, tz, sunday)).toEqual([
+        true, false, false, false, false, false, true,
+      ]);
+    });
+  });
+
+  describe('timezone handling', () => {
+    it('uses timezone for day boundary (session near midnight UTC in US/Eastern)', () => {
+      // 2026-03-18 at 03:00 UTC = 2026-03-17 at 23:00 US/Eastern (EDT, UTC-4)
+      // In UTC this is Wednesday, but in US/Eastern it's still Tuesday
+      const sessions = [
+        makeSession('2026-03-18T03:00:00Z', true),
+      ];
+      // In US/Eastern, this session belongs to Tuesday (index 1)
+      expect(weeklyConsistency(sessions, 'America/New_York', wed)).toEqual([
+        false, true, false, false, false, false, false,
+      ]);
+    });
+
+    it('session at 23:00 UTC on Tuesday is Wednesday in Asia/Tokyo (UTC+9)', () => {
+      // 2026-03-17T23:00Z = 2026-03-18T08:00 JST → Wednesday in Tokyo
+      const sessions = [
+        makeSession('2026-03-17T23:00:00Z', true),
+      ];
+      expect(weeklyConsistency(sessions, 'Asia/Tokyo', wed)).toEqual([
+        false, false, true, false, false, false, false,
+      ]);
+    });
+
+    it('nowTimestamp timezone affects which week is current', () => {
+      // 2026-03-23T01:00Z in UTC is Monday (next week)
+      // But in US/Pacific (UTC-7) it's still 2026-03-22 18:00 → Sunday (current week)
+      const nowInUtc = ms('2026-03-23T01:00:00Z');
+
+      const sessions = [
+        makeSession('2026-03-16T10:00:00Z', true), // Monday
+      ];
+
+      // In UTC: now is next Monday → the current week is Mar 23-29 → Monday Mar 16 is last week
+      expect(weeklyConsistency(sessions, 'UTC', nowInUtc)).toEqual([
+        false, false, false, false, false, false, false,
+      ]);
+
+      // In US/Pacific: now is still Sunday Mar 22 → current week is Mar 16-22 → Monday Mar 16 is this week
+      expect(weeklyConsistency(sessions, 'America/Los_Angeles', nowInUtc)).toEqual([
+        true, false, false, false, false, false, false,
+      ]);
+    });
+  });
+
+  describe('no Date constructor for current time', () => {
+    it('does not depend on system clock — same inputs always produce same output', () => {
+      const sessions = [
+        makeSession('2026-03-18T10:00:00Z', true),
+      ];
+      const result1 = weeklyConsistency(sessions, tz, wed);
+      const result2 = weeklyConsistency(sessions, tz, wed);
+      expect(result1).toEqual(result2);
+    });
+  });
+});

--- a/packages/analytics/src/tier1/weekly-dots.ts
+++ b/packages/analytics/src/tier1/weekly-dots.ts
@@ -1,0 +1,125 @@
+import type { Session } from '@pomofocus/types';
+
+/**
+ * Returns the day-of-week index (0=Monday .. 6=Sunday, ISO 8601) and
+ * the calendar date string (YYYY-MM-DD) for a given UTC-millisecond
+ * timestamp, interpreted in the supplied IANA timezone.
+ */
+function dayInfoInTimezone(
+  timestampMs: number,
+  timezone: string,
+): { dayIndex: number; dateKey: string } {
+  const d = new Date(timestampMs);
+
+  // Get year, month, day in the target timezone
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(d);
+
+  const year = parts.find((p) => p.type === 'year')?.value ?? '1970';
+  const month = parts.find((p) => p.type === 'month')?.value ?? '01';
+  const day = parts.find((p) => p.type === 'day')?.value ?? '01';
+  const dateKey = `${year}-${month}-${day}`;
+
+  // Get the JS weekday (0=Sunday .. 6=Saturday) in the target timezone
+  const weekdayPart = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    weekday: 'short',
+  }).format(d);
+
+  const jsWeekdayMap: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+  const jsWeekday = jsWeekdayMap[weekdayPart] ?? 0;
+
+  // Convert JS weekday (0=Sun) to ISO weekday index (0=Mon .. 6=Sun)
+  const isoIndex = jsWeekday === 0 ? 6 : jsWeekday - 1;
+
+  return { dayIndex: isoIndex, dateKey };
+}
+
+/**
+ * Returns the Monday 00:00 date-key for the ISO week containing
+ * the given timestamp in the supplied timezone.
+ */
+function mondayDateKeyForWeek(
+  timestampMs: number,
+  timezone: string,
+): string {
+  const { dayIndex, dateKey } = dayInfoInTimezone(timestampMs, timezone);
+  // Subtract dayIndex days from the current date to get Monday
+  const [y, m, d] = dateKey.split('-').map(Number) as [number, number, number];
+  const utcDate = Date.UTC(y, m - 1, d);
+  const mondayMs = utcDate - dayIndex * 86_400_000;
+  const mondayDate = new Date(mondayMs);
+  const my = mondayDate.getUTCFullYear();
+  const mm = String(mondayDate.getUTCMonth() + 1).padStart(2, '0');
+  const md = String(mondayDate.getUTCDate()).padStart(2, '0');
+  return `${String(my)}-${mm}-${md}`;
+}
+
+/**
+ * Weekly continuity dots — Tier 1 analytics (ADR-014).
+ *
+ * Returns `boolean[7]` for Monday through Sunday (ISO 8601 week).
+ * `true` at index N means at least one **completed** session exists
+ * on that day (midnight-to-midnight in the given timezone).
+ *
+ * Index mapping: 0=Monday, 1=Tuesday, ... 6=Sunday.
+ *
+ * Pure function — receives the current time as `nowTimestamp` (Unix ms),
+ * never reads `Date.now()`.
+ */
+export function weeklyConsistency(
+  sessions: readonly Pick<Session, 'started_at' | 'completed'>[],
+  timezone: string,
+  nowTimestamp: number,
+): [boolean, boolean, boolean, boolean, boolean, boolean, boolean] {
+  const result: [boolean, boolean, boolean, boolean, boolean, boolean, boolean] =
+    [false, false, false, false, false, false, false];
+
+  const mondayKey = mondayDateKeyForWeek(nowTimestamp, timezone);
+
+  // Build the set of date keys for each day of the current week (Mon-Sun)
+  const [my, mm, md] = mondayKey.split('-').map(Number) as [number, number, number];
+  const mondayMs = Date.UTC(my, mm - 1, md);
+  const weekDateKeys: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    const dayMs = mondayMs + i * 86_400_000;
+    const dayDate = new Date(dayMs);
+    const dy = dayDate.getUTCFullYear();
+    const dm = String(dayDate.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(dayDate.getUTCDate()).padStart(2, '0');
+    weekDateKeys.push(`${String(dy)}-${dm}-${dd}`);
+  }
+
+  // Build a Set of date keys that have at least one completed session
+  const completedDateKeys = new Set<string>();
+  for (const session of sessions) {
+    if (!session.completed) {
+      continue;
+    }
+    const sessionMs = new Date(session.started_at).getTime();
+    const { dateKey } = dayInfoInTimezone(sessionMs, timezone);
+    completedDateKeys.add(dateKey);
+  }
+
+  // Map completed date keys to the boolean array
+  for (let i = 0; i < 7; i++) {
+    const key = weekDateKeys[i];
+    if (key !== undefined && completedDateKeys.has(key)) {
+      result[i] = true;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Implements `weeklyConsistency()` pure function in `packages/analytics/src/tier1/weekly-dots.ts` returning `boolean[7]` (Mon-Sun, ISO 8601) indicating days with at least one completed session
- Handles timezone-aware day boundaries (midnight-to-midnight in user timezone) and ignores abandoned sessions
- Comprehensive test suite (252 lines) covering basic behavior, completion filtering, timezone handling, week boundaries, and determinism

Closes #191

## Test plan
- [ ] `pnpm nx test @pomofocus/analytics` passes all tests
- [ ] Weekly dots return correct boolean array for completed sessions only
- [ ] Timezone boundary cases handled correctly (e.g., session near midnight UTC categorized to correct local day)
- [ ] Sessions outside current ISO week are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)