### PR TITLE
feat: implement sync outbox queue types and state transitions

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,5 +22,15 @@ export type {
   TimerState,
   TimerEvent,
 } from './timer/index.js';
-export type { QueueItemState, SyncEvent, RetryPolicy, SyncableEntityType } from './sync/index.js';
+export { QUEUE_ITEM_STATUS, SYNC_EVENT_TYPE, processQueue, createEmptyQueue } from './sync/index.js';
+export type {
+  QueueItemStatus,
+  QueueItemState,
+  SyncEventType,
+  SyncEvent,
+  SyncableEntityType,
+  OutboxEntry,
+  OutboxQueue,
+  RetryPolicy,
+} from './sync/index.js';
 export type { SessionData, SessionReflection } from './session/index.js';

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -1,1 +1,12 @@
-export type { QueueItemState, SyncEvent, RetryPolicy, SyncableEntityType } from './types.js';
+export { QUEUE_ITEM_STATUS, SYNC_EVENT_TYPE } from './types.js';
+export type {
+  QueueItemStatus,
+  QueueItemState,
+  SyncEventType,
+  SyncEvent,
+  SyncableEntityType,
+  OutboxEntry,
+  OutboxQueue,
+  RetryPolicy,
+} from './types.js';
+export { processQueue, createEmptyQueue } from './transition.js';

--- a/packages/core/src/sync/transition.test.ts
+++ b/packages/core/src/sync/transition.test.ts
@@ -1,0 +1,534 @@
+import { describe, it, expect } from 'vitest';
+import { processQueue, createEmptyQueue } from './transition.js';
+import { SYNC_EVENT_TYPE, QUEUE_ITEM_STATUS } from './types.js';
+import type { OutboxQueue, OutboxEntry, SyncEvent } from './types.js';
+
+// ── Helpers ──
+
+function makePendingEntry(overrides?: Partial<OutboxEntry>): OutboxEntry {
+  return {
+    id: 'entry-1',
+    entityType: 'sessions',
+    entityId: 'session-abc',
+    state: { type: QUEUE_ITEM_STATUS.PENDING },
+    retryCount: 0,
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeUploadingEntry(overrides?: Partial<OutboxEntry>): OutboxEntry {
+  return {
+    id: 'entry-1',
+    entityType: 'sessions',
+    entityId: 'session-abc',
+    state: { type: QUEUE_ITEM_STATUS.UPLOADING },
+    retryCount: 0,
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeFailedEntry(overrides?: Partial<OutboxEntry>): OutboxEntry {
+  return {
+    id: 'entry-1',
+    entityType: 'sessions',
+    entityId: 'session-abc',
+    state: { type: QUEUE_ITEM_STATUS.FAILED, errorMessage: 'network error' },
+    retryCount: 1,
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeConfirmedEntry(overrides?: Partial<OutboxEntry>): OutboxEntry {
+  return {
+    id: 'entry-1',
+    entityType: 'sessions',
+    entityId: 'session-abc',
+    state: { type: QUEUE_ITEM_STATUS.CONFIRMED },
+    retryCount: 0,
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+// ── createEmptyQueue ──
+
+describe('createEmptyQueue', () => {
+  it('returns a queue with no entries', () => {
+    const queue = createEmptyQueue();
+    expect(queue.entries).toEqual([]);
+  });
+});
+
+// ── ENQUEUE ──
+
+describe('processQueue — ENQUEUE event', () => {
+  it('adds a new entry to an empty queue in pending state', () => {
+    const queue = createEmptyQueue();
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.ENQUEUE,
+      entryId: 'entry-1',
+      entityType: 'sessions',
+      entityId: 'session-abc',
+      createdAt: 1000,
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toEqual({
+      id: 'entry-1',
+      entityType: 'sessions',
+      entityId: 'session-abc',
+      state: { type: 'pending' },
+      retryCount: 0,
+      createdAt: 1000,
+    });
+  });
+
+  it('appends to existing entries', () => {
+    const existing = makePendingEntry({ id: 'entry-1' });
+    const queue: OutboxQueue = { entries: [existing] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.ENQUEUE,
+      entryId: 'entry-2',
+      entityType: 'breaks',
+      entityId: 'break-def',
+      createdAt: 2000,
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries[0]).toBe(existing);
+    expect(result.entries[1]?.entityType).toBe('breaks');
+  });
+
+  it('preserves order of existing entries', () => {
+    const first = makePendingEntry({ id: 'entry-1', createdAt: 1000 });
+    const second = makePendingEntry({ id: 'entry-2', createdAt: 2000 });
+    const queue: OutboxQueue = { entries: [first, second] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.ENQUEUE,
+      entryId: 'entry-3',
+      entityType: 'user_preferences',
+      entityId: 'pref-ghi',
+      createdAt: 3000,
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result.entries).toHaveLength(3);
+    expect(result.entries[0]?.id).toBe('entry-1');
+    expect(result.entries[1]?.id).toBe('entry-2');
+    expect(result.entries[2]?.id).toBe('entry-3');
+  });
+});
+
+// ── UPLOAD_START ──
+
+describe('processQueue — UPLOAD_START event', () => {
+  it('transitions a pending entry to uploading', () => {
+    const entry = makePendingEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.UPLOAD_START,
+      entryId: 'entry-1',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result.entries[0]?.state).toEqual({ type: 'uploading' });
+  });
+
+  it('does not modify other entries', () => {
+    const entry1 = makePendingEntry({ id: 'entry-1' });
+    const entry2 = makePendingEntry({ id: 'entry-2' });
+    const queue: OutboxQueue = { entries: [entry1, entry2] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.UPLOAD_START,
+      entryId: 'entry-1',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result.entries[0]?.state.type).toBe('uploading');
+    expect(result.entries[1]).toBe(entry2);
+  });
+
+  it('returns queue unchanged when entry not found', () => {
+    const entry = makePendingEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.UPLOAD_START,
+      entryId: 'nonexistent',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result).toBe(queue);
+  });
+
+  it('returns queue unchanged when entry is not pending', () => {
+    const entry = makeUploadingEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.UPLOAD_START,
+      entryId: 'entry-1',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result).toBe(queue);
+  });
+});
+
+// ── UPLOAD_SUCCESS ──
+
+describe('processQueue — UPLOAD_SUCCESS event', () => {
+  it('transitions an uploading entry to confirmed', () => {
+    const entry = makeUploadingEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.UPLOAD_SUCCESS,
+      entryId: 'entry-1',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result.entries[0]?.state).toEqual({ type: 'confirmed' });
+  });
+
+  it('returns queue unchanged when entry is not uploading', () => {
+    const entry = makePendingEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.UPLOAD_SUCCESS,
+      entryId: 'entry-1',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result).toBe(queue);
+  });
+
+  it('returns queue unchanged when entry not found', () => {
+    const entry = makeUploadingEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.UPLOAD_SUCCESS,
+      entryId: 'nonexistent',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result).toBe(queue);
+  });
+});
+
+// ── UPLOAD_FAILURE ──
+
+describe('processQueue — UPLOAD_FAILURE event', () => {
+  it('transitions an uploading entry to failed with error message and increments retryCount', () => {
+    const entry = makeUploadingEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.UPLOAD_FAILURE,
+      entryId: 'entry-1',
+      errorMessage: 'timeout',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result.entries[0]?.state).toEqual({
+      type: 'failed',
+      errorMessage: 'timeout',
+    });
+    expect(result.entries[0]?.retryCount).toBe(1);
+  });
+
+  it('increments retryCount on repeated failures', () => {
+    const entry: OutboxEntry = {
+      id: 'entry-1',
+      entityType: 'sessions',
+      entityId: 'session-abc',
+      state: { type: QUEUE_ITEM_STATUS.FAILED, errorMessage: 'first error' },
+      retryCount: 2,
+      createdAt: 1000,
+    };
+    // Retry moves back to pending
+    const retried = processQueue({ entries: [entry] }, { type: SYNC_EVENT_TYPE.RETRY, entryId: 'entry-1' });
+    // Start upload
+    const uploading = processQueue(retried, { type: SYNC_EVENT_TYPE.UPLOAD_START, entryId: 'entry-1' });
+    // Fail again — retryCount should be 3
+    const failed = processQueue(uploading, {
+      type: SYNC_EVENT_TYPE.UPLOAD_FAILURE,
+      entryId: 'entry-1',
+      errorMessage: 'second error',
+    });
+
+    expect(failed.entries[0]?.state).toEqual({
+      type: 'failed',
+      errorMessage: 'second error',
+    });
+    expect(failed.entries[0]?.retryCount).toBe(3);
+  });
+
+  it('returns queue unchanged when entry is not uploading', () => {
+    const entry = makePendingEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.UPLOAD_FAILURE,
+      entryId: 'entry-1',
+      errorMessage: 'error',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result).toBe(queue);
+  });
+
+  it('returns queue unchanged when entry not found', () => {
+    const entry = makeUploadingEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.UPLOAD_FAILURE,
+      entryId: 'nonexistent',
+      errorMessage: 'error',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result).toBe(queue);
+  });
+});
+
+// ── RETRY ──
+
+describe('processQueue — RETRY event', () => {
+  it('transitions a failed entry back to pending', () => {
+    const entry = makeFailedEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.RETRY,
+      entryId: 'entry-1',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result.entries[0]?.state).toEqual({ type: 'pending' });
+  });
+
+  it('preserves retryCount when transitioning to pending', () => {
+    const entry = makeFailedEntry({ retryCount: 3 });
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.RETRY,
+      entryId: 'entry-1',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result.entries[0]?.retryCount).toBe(3);
+  });
+
+  it('returns queue unchanged when entry is not failed', () => {
+    const entry = makePendingEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.RETRY,
+      entryId: 'entry-1',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result).toBe(queue);
+  });
+
+  it('returns queue unchanged when entry not found', () => {
+    const entry = makeFailedEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.RETRY,
+      entryId: 'nonexistent',
+    };
+
+    const result = processQueue(queue, event);
+
+    expect(result).toBe(queue);
+  });
+});
+
+// ── NETWORK_AVAILABLE ──
+
+describe('processQueue — NETWORK_AVAILABLE event', () => {
+  it('transitions all failed entries back to pending', () => {
+    const failed1 = makeFailedEntry({ id: 'entry-1' });
+    const failed2 = makeFailedEntry({ id: 'entry-2' });
+    const queue: OutboxQueue = { entries: [failed1, failed2] };
+    const event: SyncEvent = { type: SYNC_EVENT_TYPE.NETWORK_AVAILABLE };
+
+    const result = processQueue(queue, event);
+
+    expect(result.entries[0]?.state).toEqual({ type: 'pending' });
+    expect(result.entries[1]?.state).toEqual({ type: 'pending' });
+  });
+
+  it('does not modify non-failed entries', () => {
+    const pending = makePendingEntry({ id: 'entry-1' });
+    const uploading = makeUploadingEntry({ id: 'entry-2' });
+    const confirmed = makeConfirmedEntry({ id: 'entry-3' });
+    const failed = makeFailedEntry({ id: 'entry-4' });
+    const queue: OutboxQueue = { entries: [pending, uploading, confirmed, failed] };
+    const event: SyncEvent = { type: SYNC_EVENT_TYPE.NETWORK_AVAILABLE };
+
+    const result = processQueue(queue, event);
+
+    expect(result.entries[0]).toBe(pending);
+    expect(result.entries[1]).toBe(uploading);
+    expect(result.entries[2]).toBe(confirmed);
+    expect(result.entries[3]?.state).toEqual({ type: 'pending' });
+  });
+
+  it('returns queue unchanged when no failed entries exist', () => {
+    const pending = makePendingEntry();
+    const queue: OutboxQueue = { entries: [pending] };
+    const event: SyncEvent = { type: SYNC_EVENT_TYPE.NETWORK_AVAILABLE };
+
+    const result = processQueue(queue, event);
+
+    expect(result).toBe(queue);
+  });
+
+  it('returns queue unchanged when queue is empty', () => {
+    const queue = createEmptyQueue();
+    const event: SyncEvent = { type: SYNC_EVENT_TYPE.NETWORK_AVAILABLE };
+
+    const result = processQueue(queue, event);
+
+    expect(result).toBe(queue);
+  });
+});
+
+// ── Edge Cases ──
+
+describe('processQueue — edge cases', () => {
+  it('does not mutate the original queue', () => {
+    const entry = makePendingEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+    const event: SyncEvent = {
+      type: SYNC_EVENT_TYPE.UPLOAD_START,
+      entryId: 'entry-1',
+    };
+
+    processQueue(queue, event);
+
+    expect(queue.entries[0]?.state.type).toBe('pending');
+  });
+
+  it('handles full lifecycle: enqueue -> upload_start -> upload_success', () => {
+    let queue = createEmptyQueue();
+
+    queue = processQueue(queue, {
+      type: SYNC_EVENT_TYPE.ENQUEUE,
+      entryId: 'entry-1',
+      entityType: 'sessions',
+      entityId: 'session-abc',
+      createdAt: 1000,
+    });
+    expect(queue.entries[0]?.state.type).toBe('pending');
+
+    queue = processQueue(queue, {
+      type: SYNC_EVENT_TYPE.UPLOAD_START,
+      entryId: 'entry-1',
+    });
+    expect(queue.entries[0]?.state.type).toBe('uploading');
+
+    queue = processQueue(queue, {
+      type: SYNC_EVENT_TYPE.UPLOAD_SUCCESS,
+      entryId: 'entry-1',
+    });
+    expect(queue.entries[0]?.state.type).toBe('confirmed');
+  });
+
+  it('handles failure and retry lifecycle: pending -> uploading -> failed -> pending', () => {
+    let queue: OutboxQueue = { entries: [makePendingEntry()] };
+
+    queue = processQueue(queue, {
+      type: SYNC_EVENT_TYPE.UPLOAD_START,
+      entryId: 'entry-1',
+    });
+    expect(queue.entries[0]?.state.type).toBe('uploading');
+
+    queue = processQueue(queue, {
+      type: SYNC_EVENT_TYPE.UPLOAD_FAILURE,
+      entryId: 'entry-1',
+      errorMessage: 'network error',
+    });
+    expect(queue.entries[0]?.state.type).toBe('failed');
+    expect(queue.entries[0]?.retryCount).toBe(1);
+
+    queue = processQueue(queue, {
+      type: SYNC_EVENT_TYPE.RETRY,
+      entryId: 'entry-1',
+    });
+    expect(queue.entries[0]?.state.type).toBe('pending');
+    expect(queue.entries[0]?.retryCount).toBe(1);
+  });
+
+  it('confirmed entries are not affected by any targeted event', () => {
+    const entry = makeConfirmedEntry();
+    const queue: OutboxQueue = { entries: [entry] };
+
+    const afterStart = processQueue(queue, { type: SYNC_EVENT_TYPE.UPLOAD_START, entryId: 'entry-1' });
+    expect(afterStart).toBe(queue);
+
+    const afterSuccess = processQueue(queue, { type: SYNC_EVENT_TYPE.UPLOAD_SUCCESS, entryId: 'entry-1' });
+    expect(afterSuccess).toBe(queue);
+
+    const afterFailure = processQueue(queue, {
+      type: SYNC_EVENT_TYPE.UPLOAD_FAILURE,
+      entryId: 'entry-1',
+      errorMessage: 'err',
+    });
+    expect(afterFailure).toBe(queue);
+
+    const afterRetry = processQueue(queue, { type: SYNC_EVENT_TYPE.RETRY, entryId: 'entry-1' });
+    expect(afterRetry).toBe(queue);
+  });
+
+  it('retryCount accumulates across multiple failure cycles', () => {
+    let queue: OutboxQueue = { entries: [makePendingEntry()] };
+
+    // First failure cycle
+    queue = processQueue(queue, { type: SYNC_EVENT_TYPE.UPLOAD_START, entryId: 'entry-1' });
+    queue = processQueue(queue, {
+      type: SYNC_EVENT_TYPE.UPLOAD_FAILURE,
+      entryId: 'entry-1',
+      errorMessage: 'err1',
+    });
+    expect(queue.entries[0]?.retryCount).toBe(1);
+
+    // Retry and second failure cycle
+    queue = processQueue(queue, { type: SYNC_EVENT_TYPE.RETRY, entryId: 'entry-1' });
+    queue = processQueue(queue, { type: SYNC_EVENT_TYPE.UPLOAD_START, entryId: 'entry-1' });
+    queue = processQueue(queue, {
+      type: SYNC_EVENT_TYPE.UPLOAD_FAILURE,
+      entryId: 'entry-1',
+      errorMessage: 'err2',
+    });
+    expect(queue.entries[0]?.retryCount).toBe(2);
+
+    // Retry and third failure cycle
+    queue = processQueue(queue, { type: SYNC_EVENT_TYPE.RETRY, entryId: 'entry-1' });
+    queue = processQueue(queue, { type: SYNC_EVENT_TYPE.UPLOAD_START, entryId: 'entry-1' });
+    queue = processQueue(queue, {
+      type: SYNC_EVENT_TYPE.UPLOAD_FAILURE,
+      entryId: 'entry-1',
+      errorMessage: 'err3',
+    });
+    expect(queue.entries[0]?.retryCount).toBe(3);
+  });
+});

--- a/packages/core/src/sync/transition.ts
+++ b/packages/core/src/sync/transition.ts
@@ -1,0 +1,150 @@
+import { SYNC_EVENT_TYPE, QUEUE_ITEM_STATUS } from './types.js';
+import type { OutboxQueue, OutboxEntry, SyncEvent, QueueItemState } from './types.js';
+
+/** Creates an empty outbox queue. */
+export function createEmptyQueue(): OutboxQueue {
+  return { entries: [] };
+}
+
+/**
+ * Pure state machine: processQueue(queue, event) -> newQueue.
+ * Mirrors the timer pattern from ADR-004. No IO, no side effects.
+ */
+export function processQueue(queue: OutboxQueue, event: SyncEvent): OutboxQueue {
+  switch (event.type) {
+    case SYNC_EVENT_TYPE.ENQUEUE:
+      return handleEnqueue(queue, event);
+    case SYNC_EVENT_TYPE.UPLOAD_START:
+      return handleUploadStart(queue, event);
+    case SYNC_EVENT_TYPE.UPLOAD_SUCCESS:
+      return handleUploadSuccess(queue, event);
+    case SYNC_EVENT_TYPE.UPLOAD_FAILURE:
+      return handleUploadFailure(queue, event);
+    case SYNC_EVENT_TYPE.RETRY:
+      return handleRetry(queue, event);
+    case SYNC_EVENT_TYPE.NETWORK_AVAILABLE:
+      return handleNetworkAvailable(queue);
+    default: {
+      const _exhaustive: never = event;
+      return _exhaustive;
+    }
+  }
+}
+
+// ── Event Handlers ──
+
+function handleEnqueue(
+  queue: OutboxQueue,
+  event: Extract<SyncEvent, { type: typeof SYNC_EVENT_TYPE.ENQUEUE }>,
+): OutboxQueue {
+  const newEntry: OutboxEntry = {
+    id: event.entryId,
+    entityType: event.entityType,
+    entityId: event.entityId,
+    state: { type: QUEUE_ITEM_STATUS.PENDING },
+    retryCount: 0,
+    createdAt: event.createdAt,
+  };
+  return { entries: [...queue.entries, newEntry] };
+}
+
+function handleUploadStart(
+  queue: OutboxQueue,
+  event: Extract<SyncEvent, { type: typeof SYNC_EVENT_TYPE.UPLOAD_START }>,
+): OutboxQueue {
+  return updateEntry(queue, event.entryId, (entry) => {
+    if (entry.state.type !== QUEUE_ITEM_STATUS.PENDING) {
+      return entry;
+    }
+    return { ...entry, state: { type: QUEUE_ITEM_STATUS.UPLOADING } };
+  });
+}
+
+function handleUploadSuccess(
+  queue: OutboxQueue,
+  event: Extract<SyncEvent, { type: typeof SYNC_EVENT_TYPE.UPLOAD_SUCCESS }>,
+): OutboxQueue {
+  return updateEntry(queue, event.entryId, (entry) => {
+    if (entry.state.type !== QUEUE_ITEM_STATUS.UPLOADING) {
+      return entry;
+    }
+    return { ...entry, state: { type: QUEUE_ITEM_STATUS.CONFIRMED } };
+  });
+}
+
+function handleUploadFailure(
+  queue: OutboxQueue,
+  event: Extract<SyncEvent, { type: typeof SYNC_EVENT_TYPE.UPLOAD_FAILURE }>,
+): OutboxQueue {
+  return updateEntry(queue, event.entryId, (entry) => {
+    if (entry.state.type !== QUEUE_ITEM_STATUS.UPLOADING) {
+      return entry;
+    }
+    const failedState: QueueItemState = {
+      type: QUEUE_ITEM_STATUS.FAILED,
+      errorMessage: event.errorMessage,
+    };
+    return { ...entry, state: failedState, retryCount: entry.retryCount + 1 };
+  });
+}
+
+function handleRetry(
+  queue: OutboxQueue,
+  event: Extract<SyncEvent, { type: typeof SYNC_EVENT_TYPE.RETRY }>,
+): OutboxQueue {
+  return updateEntry(queue, event.entryId, (entry) => {
+    if (entry.state.type !== QUEUE_ITEM_STATUS.FAILED) {
+      return entry;
+    }
+    return { ...entry, state: { type: QUEUE_ITEM_STATUS.PENDING } };
+  });
+}
+
+function handleNetworkAvailable(queue: OutboxQueue): OutboxQueue {
+  const hasFailedEntries = queue.entries.some(
+    (entry) => entry.state.type === QUEUE_ITEM_STATUS.FAILED,
+  );
+  if (!hasFailedEntries) {
+    return queue;
+  }
+
+  return {
+    entries: queue.entries.map((entry) => {
+      if (entry.state.type !== QUEUE_ITEM_STATUS.FAILED) {
+        return entry;
+      }
+      return { ...entry, state: { type: QUEUE_ITEM_STATUS.PENDING } as const };
+    }),
+  };
+}
+
+// ── Internal Helpers ──
+
+/**
+ * Finds an entry by id and applies the updater function.
+ * Returns the original queue if the entry is not found or not modified.
+ */
+function updateEntry(
+  queue: OutboxQueue,
+  entryId: string,
+  updater: (entry: OutboxEntry) => OutboxEntry,
+): OutboxQueue {
+  const index = queue.entries.findIndex((entry) => entry.id === entryId);
+  if (index === -1) {
+    return queue;
+  }
+
+  const entry = queue.entries[index];
+  if (entry === undefined) {
+    return queue;
+  }
+
+  const updated = updater(entry);
+  if (updated === entry) {
+    return queue;
+  }
+
+  const newEntries = [...queue.entries];
+  newEntries[index] = updated;
+  return { entries: newEntries };
+}

--- a/packages/core/src/sync/types.ts
+++ b/packages/core/src/sync/types.ts
@@ -1,5 +1,5 @@
-// Placeholder types for the outbox queue state machine (ADR-006).
-// Implementation comes in Phase 2 — these are type definitions only.
+// Outbox queue state machine types (ADR-006).
+// Pure types — no IO, no React, no Supabase imports.
 
 // ── Syncable Entities ──
 
@@ -12,7 +12,18 @@ export type SyncableEntityType =
   | 'long_term_goals'
   | 'process_goals';
 
-// ── Queue Item States ──
+// ── Queue Item Status (as const object per U-010) ──
+
+export const QUEUE_ITEM_STATUS = {
+  PENDING: 'pending',
+  UPLOADING: 'uploading',
+  CONFIRMED: 'confirmed',
+  FAILED: 'failed',
+} as const;
+
+export type QueueItemStatus = (typeof QUEUE_ITEM_STATUS)[keyof typeof QUEUE_ITEM_STATUS];
+
+// ── Queue Item States (discriminated union) ──
 
 /** Discriminated union for the state of a single outbox entry. */
 export type QueueItemState =
@@ -21,21 +32,58 @@ export type QueueItemState =
   | { readonly type: 'confirmed' }
   | { readonly type: 'failed'; readonly errorMessage: string };
 
-// ── Sync Events ──
+// ── Outbox Entry ──
+
+/** A single entry in the outbox queue. */
+export type OutboxEntry = {
+  readonly id: string;
+  readonly entityType: SyncableEntityType;
+  readonly entityId: string;
+  readonly state: QueueItemState;
+  readonly retryCount: number;
+  readonly createdAt: number;
+};
+
+// ── Outbox Queue ──
+
+/** The full outbox queue — an ordered list of entries. */
+export type OutboxQueue = {
+  readonly entries: readonly OutboxEntry[];
+};
+
+// ── Sync Event Type (as const object per U-010) ──
+
+export const SYNC_EVENT_TYPE = {
+  ENQUEUE: 'ENQUEUE',
+  UPLOAD_START: 'UPLOAD_START',
+  UPLOAD_SUCCESS: 'UPLOAD_SUCCESS',
+  UPLOAD_FAILURE: 'UPLOAD_FAILURE',
+  RETRY: 'RETRY',
+  NETWORK_AVAILABLE: 'NETWORK_AVAILABLE',
+} as const;
+
+export type SyncEventType = (typeof SYNC_EVENT_TYPE)[keyof typeof SYNC_EVENT_TYPE];
+
+// ── Sync Events (discriminated union) ──
 
 /** Discriminated union for outbox queue state machine events. */
 export type SyncEvent =
   | {
-      readonly type: 'ENQUEUE';
+      readonly type: typeof SYNC_EVENT_TYPE.ENQUEUE;
       readonly entryId: string;
       readonly entityType: SyncableEntityType;
       readonly entityId: string;
+      readonly createdAt: number;
     }
-  | { readonly type: 'UPLOAD_START'; readonly entryId: string }
-  | { readonly type: 'UPLOAD_SUCCESS'; readonly entryId: string }
-  | { readonly type: 'UPLOAD_FAILURE'; readonly entryId: string; readonly errorMessage: string }
-  | { readonly type: 'RETRY'; readonly entryId: string }
-  | { readonly type: 'NETWORK_AVAILABLE' };
+  | { readonly type: typeof SYNC_EVENT_TYPE.UPLOAD_START; readonly entryId: string }
+  | { readonly type: typeof SYNC_EVENT_TYPE.UPLOAD_SUCCESS; readonly entryId: string }
+  | {
+      readonly type: typeof SYNC_EVENT_TYPE.UPLOAD_FAILURE;
+      readonly entryId: string;
+      readonly errorMessage: string;
+    }
+  | { readonly type: typeof SYNC_EVENT_TYPE.RETRY; readonly entryId: string }
+  | { readonly type: typeof SYNC_EVENT_TYPE.NETWORK_AVAILABLE };
 
 // ── Retry Policy ──
 


### PR DESCRIPTION
## Summary

Implements the pure outbox queue state machine for offline-first sync (ADR-006) in `packages/core/src/sync/`.

- Adds `OutboxEntry`, `SyncEvent` discriminated union, and `OutboxQueue` types with `as const` status values (U-010)
- Implements `processQueue(queue, event)` transition function with exhaustive switch (U-008) covering states: pending → uploading → confirmed, failed → pending (retry)
- Supports events: ENQUEUE, UPLOAD_START, UPLOAD_SUCCESS, UPLOAD_FAILURE, RETRY, NETWORK_AVAILABLE
- 534-line test suite covering all state transitions, edge cases, and error paths
- Pure functions only — no IO, no network calls, no platform imports (PKG-C01)

Closes #179

## Test plan

- [x] `pnpm nx test @pomofocus/core` — all sync transition tests pass
- [ ] Human review of state machine transitions against ADR-006 spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)