### PR TITLE
feat: implement Tier 2 analytics — completion rate and focus quality

### DIFF
--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,3 +1,6 @@
 // Component metrics: completion rate, focus quality, consistency, streaks, trends.
 // Pure functions only — no IO, no React, no Supabase.
 export { weeklyConsistency } from './tier1/index.js';
+export { completionRate } from './tier2/completion-rate.js';
+export { focusQualityDistribution } from './tier2/focus-quality.js';
+export type { FocusQualityDistributionResult } from './tier2/focus-quality.js';

--- a/packages/analytics/src/tier2/completion-rate.test.ts
+++ b/packages/analytics/src/tier2/completion-rate.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import type { Session } from '@pomofocus/types';
+import { completionRate } from './completion-rate.js';
+
+function makeSession(
+  overrides: Partial<Session> = {},
+): Session {
+  return {
+    id: 'session-1',
+    user_id: 'user-1',
+    process_goal_id: 'goal-1',
+    intention_text: null,
+    started_at: '2026-03-22T09:00:00Z',
+    ended_at: '2026-03-22T09:25:00Z',
+    completed: true,
+    abandonment_reason: null,
+    focus_quality: null,
+    distraction_type: null,
+    device_id: null,
+    created_at: '2026-03-22T09:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('completionRate', () => {
+  it('returns 0 for empty sessions array', () => {
+    expect(completionRate([])).toBe(0);
+  });
+
+  it('returns 1 when all sessions are completed', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true }),
+      makeSession({ id: 's2', completed: true }),
+      makeSession({ id: 's3', completed: true }),
+    ];
+    expect(completionRate(sessions)).toBe(1);
+  });
+
+  it('returns 0 when no sessions are completed', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: false, abandonment_reason: 'gave_up' }),
+      makeSession({ id: 's2', completed: false, abandonment_reason: 'gave_up' }),
+    ];
+    expect(completionRate(sessions)).toBe(0);
+  });
+
+  it('excludes had_to_stop sessions from the denominator', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true }),
+      makeSession({ id: 's2', completed: false, abandonment_reason: 'had_to_stop' }),
+      makeSession({ id: 's3', completed: false, abandonment_reason: 'gave_up' }),
+    ];
+    // denominator = 3 - 1 (had_to_stop) = 2
+    // completed = 1
+    // rate = 1/2 = 0.5
+    expect(completionRate(sessions)).toBe(0.5);
+  });
+
+  it('treats NULL abandonment_reason as gave_up (counts against)', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true }),
+      makeSession({ id: 's2', completed: false, abandonment_reason: null }),
+    ];
+    // NULL reason is NOT had_to_stop, so it stays in denominator
+    // denominator = 2, completed = 1, rate = 0.5
+    expect(completionRate(sessions)).toBe(0.5);
+  });
+
+  it('returns 0 when all sessions are had_to_stop (denominator is 0)', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: false, abandonment_reason: 'had_to_stop' }),
+      makeSession({ id: 's2', completed: false, abandonment_reason: 'had_to_stop' }),
+    ];
+    expect(completionRate(sessions)).toBe(0);
+  });
+
+  it('returns value in 0-1 range for mixed sessions', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true }),
+      makeSession({ id: 's2', completed: true }),
+      makeSession({ id: 's3', completed: false, abandonment_reason: 'gave_up' }),
+      makeSession({ id: 's4', completed: false, abandonment_reason: 'had_to_stop' }),
+      makeSession({ id: 's5', completed: false, abandonment_reason: null }),
+    ];
+    // denominator = 5 - 1 (had_to_stop) = 4
+    // completed = 2
+    // rate = 2/4 = 0.5
+    expect(completionRate(sessions)).toBe(0.5);
+  });
+
+  it('returns 1 when single completed session exists', () => {
+    const sessions = [makeSession({ id: 's1', completed: true })];
+    expect(completionRate(sessions)).toBe(1);
+  });
+
+  it('handles mix of had_to_stop and completed sessions', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true }),
+      makeSession({ id: 's2', completed: true }),
+      makeSession({ id: 's3', completed: false, abandonment_reason: 'had_to_stop' }),
+    ];
+    // denominator = 3 - 1 = 2, completed = 2, rate = 1
+    expect(completionRate(sessions)).toBe(1);
+  });
+
+  it('returns a number between 0 and 1 inclusive', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true }),
+      makeSession({ id: 's2', completed: false, abandonment_reason: 'gave_up' }),
+      makeSession({ id: 's3', completed: false, abandonment_reason: null }),
+    ];
+    const rate = completionRate(sessions);
+    expect(rate).toBeGreaterThanOrEqual(0);
+    expect(rate).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/analytics/src/tier2/completion-rate.ts
+++ b/packages/analytics/src/tier2/completion-rate.ts
@@ -1,0 +1,24 @@
+import type { Session } from '@pomofocus/types';
+
+/**
+ * Completion rate: completed / (total - had_to_stop).
+ * Returns 0 when denominator is 0 (cold start or all had_to_stop).
+ * NULL abandonment_reason on incomplete sessions is treated as gave_up
+ * (counts against completion rate).
+ * Range: 0-1.
+ */
+export function completionRate(sessions: readonly Session[]): number {
+  const hadToStopCount = sessions.filter(
+    (s) => s.abandonment_reason === 'had_to_stop',
+  ).length;
+
+  const denominator = sessions.length - hadToStopCount;
+
+  if (denominator <= 0) {
+    return 0;
+  }
+
+  const completedCount = sessions.filter((s) => s.completed).length;
+
+  return completedCount / denominator;
+}

--- a/packages/analytics/src/tier2/focus-quality.test.ts
+++ b/packages/analytics/src/tier2/focus-quality.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import type { Session } from '@pomofocus/types';
+import { focusQualityDistribution } from './focus-quality.js';
+
+function makeSession(
+  overrides: Partial<Session> = {},
+): Session {
+  return {
+    id: 'session-1',
+    user_id: 'user-1',
+    process_goal_id: 'goal-1',
+    intention_text: null,
+    started_at: '2026-03-22T09:00:00Z',
+    ended_at: '2026-03-22T09:25:00Z',
+    completed: true,
+    abandonment_reason: null,
+    focus_quality: null,
+    distraction_type: null,
+    device_id: null,
+    created_at: '2026-03-22T09:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('focusQualityDistribution', () => {
+  it('returns all zeros for empty sessions array', () => {
+    expect(focusQualityDistribution([])).toEqual({
+      lockedIn: 0,
+      decent: 0,
+      struggled: 0,
+    });
+  });
+
+  it('returns all zeros when no sessions are completed', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: false, abandonment_reason: 'gave_up', focus_quality: 'locked_in' }),
+      makeSession({ id: 's2', completed: false, abandonment_reason: 'gave_up', focus_quality: 'decent' }),
+    ];
+    expect(focusQualityDistribution(sessions)).toEqual({
+      lockedIn: 0,
+      decent: 0,
+      struggled: 0,
+    });
+  });
+
+  it('returns all zeros when completed sessions have no reflection data', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true, focus_quality: null }),
+      makeSession({ id: 's2', completed: true, focus_quality: null }),
+    ];
+    expect(focusQualityDistribution(sessions)).toEqual({
+      lockedIn: 0,
+      decent: 0,
+      struggled: 0,
+    });
+  });
+
+  it('counts locked_in sessions correctly', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true, focus_quality: 'locked_in' }),
+      makeSession({ id: 's2', completed: true, focus_quality: 'locked_in' }),
+    ];
+    expect(focusQualityDistribution(sessions)).toEqual({
+      lockedIn: 2,
+      decent: 0,
+      struggled: 0,
+    });
+  });
+
+  it('counts decent sessions correctly', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true, focus_quality: 'decent' }),
+    ];
+    expect(focusQualityDistribution(sessions)).toEqual({
+      lockedIn: 0,
+      decent: 1,
+      struggled: 0,
+    });
+  });
+
+  it('counts struggled sessions correctly', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true, focus_quality: 'struggled' }),
+      makeSession({ id: 's2', completed: true, focus_quality: 'struggled' }),
+      makeSession({ id: 's3', completed: true, focus_quality: 'struggled' }),
+    ];
+    expect(focusQualityDistribution(sessions)).toEqual({
+      lockedIn: 0,
+      decent: 0,
+      struggled: 3,
+    });
+  });
+
+  it('distributes across all quality levels', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true, focus_quality: 'locked_in' }),
+      makeSession({ id: 's2', completed: true, focus_quality: 'decent' }),
+      makeSession({ id: 's3', completed: true, focus_quality: 'struggled' }),
+      makeSession({ id: 's4', completed: true, focus_quality: 'locked_in' }),
+      makeSession({ id: 's5', completed: true, focus_quality: 'decent' }),
+    ];
+    expect(focusQualityDistribution(sessions)).toEqual({
+      lockedIn: 2,
+      decent: 2,
+      struggled: 1,
+    });
+  });
+
+  it('excludes incomplete sessions even with focus_quality data', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true, focus_quality: 'locked_in' }),
+      makeSession({ id: 's2', completed: false, abandonment_reason: 'gave_up', focus_quality: 'struggled' }),
+      makeSession({ id: 's3', completed: true, focus_quality: 'decent' }),
+    ];
+    expect(focusQualityDistribution(sessions)).toEqual({
+      lockedIn: 1,
+      decent: 1,
+      struggled: 0,
+    });
+  });
+
+  it('excludes completed sessions without reflection data (focus_quality null)', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true, focus_quality: 'locked_in' }),
+      makeSession({ id: 's2', completed: true, focus_quality: null }),
+      makeSession({ id: 's3', completed: true, focus_quality: 'decent' }),
+    ];
+    expect(focusQualityDistribution(sessions)).toEqual({
+      lockedIn: 1,
+      decent: 1,
+      struggled: 0,
+    });
+  });
+
+  it('handles mixed scenario with had_to_stop, gave_up, null reason, and completed', () => {
+    const sessions = [
+      makeSession({ id: 's1', completed: true, focus_quality: 'locked_in' }),
+      makeSession({ id: 's2', completed: true, focus_quality: 'decent' }),
+      makeSession({ id: 's3', completed: true, focus_quality: null }),
+      makeSession({ id: 's4', completed: false, abandonment_reason: 'had_to_stop' }),
+      makeSession({ id: 's5', completed: false, abandonment_reason: 'gave_up' }),
+      makeSession({ id: 's6', completed: false, abandonment_reason: null }),
+      makeSession({ id: 's7', completed: true, focus_quality: 'struggled' }),
+    ];
+    expect(focusQualityDistribution(sessions)).toEqual({
+      lockedIn: 1,
+      decent: 1,
+      struggled: 1,
+    });
+  });
+});

--- a/packages/analytics/src/tier2/focus-quality.ts
+++ b/packages/analytics/src/tier2/focus-quality.ts
@@ -1,0 +1,42 @@
+import type { Session } from '@pomofocus/types';
+
+export type FocusQualityDistributionResult = {
+  readonly lockedIn: number;
+  readonly decent: number;
+  readonly struggled: number;
+};
+
+/**
+ * Focus quality distribution: count per focus_quality enum value.
+ * Only includes completed sessions that have reflection data (focus_quality !== null).
+ * Returns { lockedIn: 0, decent: 0, struggled: 0 } when no qualifying sessions exist.
+ */
+export function focusQualityDistribution(
+  sessions: readonly Session[],
+): FocusQualityDistributionResult {
+  const result = { lockedIn: 0, decent: 0, struggled: 0 };
+
+  for (const session of sessions) {
+    if (!session.completed || session.focus_quality === null) {
+      continue;
+    }
+
+    switch (session.focus_quality) {
+      case 'locked_in':
+        result.lockedIn++;
+        break;
+      case 'decent':
+        result.decent++;
+        break;
+      case 'struggled':
+        result.struggled++;
+        break;
+      default: {
+        const _exhaustive: never = session.focus_quality;
+        return _exhaustive;
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/analytics/src/tier2/index.ts
+++ b/packages/analytics/src/tier2/index.ts
@@ -1,0 +1,3 @@
+export { completionRate } from './completion-rate.js';
+export { focusQualityDistribution } from './focus-quality.js';
+export type { FocusQualityDistributionResult } from './focus-quality.js';


### PR DESCRIPTION
## Summary

- Implements `completionRate()` and `focusQualityDistribution()` pure functions in `packages/analytics/src/tier2/`
- `completionRate`: completed / (total - had_to_stop), returns 0 when denominator is 0; NULL abandonment_reason treated as gave_up per ADR-014
- `focusQualityDistribution`: counts per focus_quality enum value for completed sessions with reflection data

Closes #193

## Test plan

- [x] `completionRate` excludes `had_to_stop` sessions from denominator
- [x] `completionRate` treats NULL abandonment_reason as `gave_up` (counts against)
- [x] `completionRate` returns 0-1 range
- [x] `focusQualityDistribution` returns counts for each quality level
- [x] `focusQualityDistribution` only includes completed sessions with reflection data
- [x] Cold-start: returns 0 / empty when no sessions exist
- [x] All tests pass: `pnpm nx test @pomofocus/analytics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)