### PR TITLE
feat: implement abandonment state transition and partial duration

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,3 +34,4 @@ export type {
   RetryPolicy,
 } from './sync/index.js';
 export type { SessionData, SessionReflection } from './session/index.js';
+export { calculatePartialDuration } from './session/index.js';

--- a/packages/core/src/session/duration.test.ts
+++ b/packages/core/src/session/duration.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { calculatePartialDuration } from './duration.js';
+
+describe('calculatePartialDuration', () => {
+  it('returns the difference between abandonedAt and startedAt', () => {
+    expect(calculatePartialDuration(1000, 2500)).toBe(1500);
+  });
+
+  it('returns zero when startedAt equals abandonedAt', () => {
+    expect(calculatePartialDuration(5000, 5000)).toBe(0);
+  });
+
+  it('returns zero when abandonedAt is before startedAt (clamps negative)', () => {
+    expect(calculatePartialDuration(3000, 1000)).toBe(0);
+  });
+
+  it('handles large timestamps (realistic epoch ms)', () => {
+    const startedAt = 1711100000000; // realistic epoch ms
+    const abandonedAt = 1711100900000; // 900 seconds later
+    expect(calculatePartialDuration(startedAt, abandonedAt)).toBe(900_000);
+  });
+
+  it('returns correct duration for a short focus session', () => {
+    // 5 minutes of focus = 300_000 ms
+    expect(calculatePartialDuration(0, 300_000)).toBe(300_000);
+  });
+});

--- a/packages/core/src/session/duration.ts
+++ b/packages/core/src/session/duration.ts
@@ -1,0 +1,11 @@
+/**
+ * Calculates the actual focus time for an abandoned session.
+ *
+ * Both timestamps are epoch milliseconds, injected by the caller
+ * (no Date.now() — PKG-C04).
+ *
+ * @returns Elapsed focus time in milliseconds (non-negative).
+ */
+export function calculatePartialDuration(startedAt: number, abandonedAt: number): number {
+  return Math.max(0, abandonedAt - startedAt);
+}

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -1,1 +1,2 @@
 export type { SessionData, SessionReflection } from './types.js';
+export { calculatePartialDuration } from './duration.js';

--- a/packages/core/src/timer/transition.test.ts
+++ b/packages/core/src/timer/transition.test.ts
@@ -1546,20 +1546,14 @@ describe('transition — ABANDON event', () => {
     });
   });
 
-  it('transitions from reflection to abandoned with abandonedAt and sessionNumber', () => {
+  it('returns state unchanged when ABANDON from reflection', () => {
     const state: TimerState = {
       status: TIMER_STATUS.REFLECTION,
       sessionNumber: 3,
       config: defaultConfig,
     };
-    const now = 5000;
-    const result = transition(state, { type: TIMER_EVENT_TYPE.ABANDON }, now);
-    expect(result).toEqual({
-      status: 'abandoned',
-      sessionNumber: 3,
-      abandonedAt: now,
-      config: defaultConfig,
-    });
+    const result = transition(state, { type: TIMER_EVENT_TYPE.ABANDON }, 5000);
+    expect(result).toBe(state);
   });
 
   it('returns state unchanged when ABANDON from idle', () => {

--- a/packages/core/src/timer/transition.ts
+++ b/packages/core/src/timer/transition.ts
@@ -289,19 +289,13 @@ export function transition(state: TimerState, event: TimerEvent, now: number): T
             sessionNumber: state.sessionNumber,
             config: state.config,
           };
-        case TIMER_EVENT_TYPE.ABANDON:
-          return {
-            status: TIMER_STATUS.ABANDONED,
-            sessionNumber: state.sessionNumber,
-            abandonedAt: now,
-            config: state.config,
-          };
         case TIMER_EVENT_TYPE.START:
         case TIMER_EVENT_TYPE.PAUSE:
         case TIMER_EVENT_TYPE.RESUME:
         case TIMER_EVENT_TYPE.TICK:
         case TIMER_EVENT_TYPE.TIMER_DONE:
         case TIMER_EVENT_TYPE.SKIP_BREAK:
+        case TIMER_EVENT_TYPE.ABANDON:
         case TIMER_EVENT_TYPE.RESET:
           return state;
         default: {


### PR DESCRIPTION
## Summary

Closes #187

- Fix ABANDON event handling from reflection state to correctly reject (return state unchanged) per ADR-004 design doc — only 5 active states (focusing, paused, short_break, long_break, break_paused) are valid ABANDON sources
- Add `calculatePartialDuration(startedAt, abandonedAt)` pure function in `packages/core/src/session/duration.ts` for computing actual focus time on abandoned sessions
- Export `calculatePartialDuration` from session and core index barrels
- Update transition tests to match corrected reflection ABANDON behavior

## Test plan

- [x] ABANDON from all 5 active states transitions to `abandoned` with `abandonedAt` timestamp
- [x] Invalid ABANDON from idle, completed, abandoned, and reflection states is rejected
- [x] `calculatePartialDuration` returns correct millisecond duration
- [x] `calculatePartialDuration` returns 0 when abandonedAt equals startedAt
- [x] `calculatePartialDuration` returns 0 for negative durations (abandonedAt before startedAt)
- [ ] `pnpm nx test @pomofocus/core` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)