### PR TITLE
feat: implement Tier 3 monthly trend analytics functions

### DIFF
--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -9,3 +9,15 @@ export { peakFocusWindow } from './tier2/index.js';
 export type { PeakFocusWindowResult } from './tier2/index.js';
 export { perGoalBreakdown } from './tier2/index.js';
 export type { GoalBreakdownEntry } from './tier2/index.js';
+
+// ── Tier 3: Monthly trends ──
+export type { TrendResult, DistractionPattern, GoalBreakdown } from './tier3/index.js';
+export {
+  consistencyTrend,
+  completionTrend,
+  focusQualityTrend,
+  totalTimeTrend,
+  monthlyTrends,
+  distractionPatterns,
+  perGoalBreakdown as perGoalMonthlyBreakdown,
+} from './tier3/index.js';

--- a/packages/analytics/src/tier3/distractions.test.ts
+++ b/packages/analytics/src/tier3/distractions.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import type { Session } from '@pomofocus/types';
+import { distractionPatterns, perGoalBreakdown } from './distractions.js';
+
+/** Helper to create a minimal session with overrides. */
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-1',
+    user_id: 'user-1',
+    process_goal_id: 'goal-1',
+    intention_text: null,
+    started_at: '2026-03-10T09:00:00Z',
+    ended_at: '2026-03-10T09:25:00Z',
+    completed: true,
+    abandonment_reason: null,
+    focus_quality: 'locked_in',
+    distraction_type: null,
+    device_id: null,
+    created_at: '2026-03-10T09:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('distractionPatterns', () => {
+  it('returns the most common distraction type among struggled sessions', () => {
+    const sessions = [
+      makeSession({
+        focus_quality: 'struggled',
+        distraction_type: 'phone',
+      }),
+      makeSession({
+        focus_quality: 'struggled',
+        distraction_type: 'phone',
+      }),
+      makeSession({
+        focus_quality: 'struggled',
+        distraction_type: 'thoughts_wandering',
+      }),
+    ];
+
+    const result = distractionPatterns(sessions);
+    expect(result).toEqual({ type: 'phone', count: 2 });
+  });
+
+  it('returns null when no struggled sessions exist', () => {
+    const sessions = [
+      makeSession({ focus_quality: 'locked_in', distraction_type: null }),
+      makeSession({ focus_quality: 'decent', distraction_type: null }),
+    ];
+
+    const result = distractionPatterns(sessions);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty sessions', () => {
+    const result = distractionPatterns([]);
+    expect(result).toBeNull();
+  });
+
+  it('ignores struggled sessions with null distraction_type', () => {
+    const sessions = [
+      makeSession({
+        focus_quality: 'struggled',
+        distraction_type: null,
+      }),
+    ];
+
+    const result = distractionPatterns(sessions);
+    expect(result).toBeNull();
+  });
+
+  it('ignores non-struggled sessions even with distraction_type', () => {
+    const sessions = [
+      makeSession({
+        focus_quality: 'decent',
+        distraction_type: 'phone',
+      }),
+      makeSession({
+        focus_quality: 'struggled',
+        distraction_type: 'people',
+      }),
+    ];
+
+    const result = distractionPatterns(sessions);
+    expect(result).toEqual({ type: 'people', count: 1 });
+  });
+
+  it('picks the type with highest count when multiple exist', () => {
+    const sessions = [
+      makeSession({ focus_quality: 'struggled', distraction_type: 'phone' }),
+      makeSession({ focus_quality: 'struggled', distraction_type: 'got_stuck' }),
+      makeSession({ focus_quality: 'struggled', distraction_type: 'got_stuck' }),
+      makeSession({ focus_quality: 'struggled', distraction_type: 'got_stuck' }),
+      makeSession({ focus_quality: 'struggled', distraction_type: 'phone' }),
+    ];
+
+    const result = distractionPatterns(sessions);
+    expect(result).toEqual({ type: 'got_stuck', count: 3 });
+  });
+});
+
+describe('perGoalBreakdown', () => {
+  it('groups completed sessions by goal with time in minutes', () => {
+    const sessions = [
+      makeSession({
+        process_goal_id: 'goal-a',
+        completed: true,
+        started_at: '2026-03-10T09:00:00Z',
+        ended_at: '2026-03-10T09:25:00Z', // 25 min
+      }),
+      makeSession({
+        process_goal_id: 'goal-a',
+        completed: true,
+        started_at: '2026-03-11T09:00:00Z',
+        ended_at: '2026-03-11T09:30:00Z', // 30 min
+      }),
+      makeSession({
+        process_goal_id: 'goal-b',
+        completed: true,
+        started_at: '2026-03-10T14:00:00Z',
+        ended_at: '2026-03-10T14:25:00Z', // 25 min
+      }),
+    ];
+
+    const result = perGoalBreakdown(sessions);
+    expect(result).toHaveLength(2);
+
+    const goalA = result.find((g) => g.goalId === 'goal-a');
+    expect(goalA).toEqual(
+      expect.objectContaining({ sessions: 2 }),
+    );
+    expect(goalA?.focusMinutes).toBeCloseTo(55);
+
+    const goalB = result.find((g) => g.goalId === 'goal-b');
+    expect(goalB).toEqual(
+      expect.objectContaining({ sessions: 1 }),
+    );
+    expect(goalB?.focusMinutes).toBeCloseTo(25);
+  });
+
+  it('excludes non-completed sessions', () => {
+    const sessions = [
+      makeSession({
+        process_goal_id: 'goal-a',
+        completed: true,
+        started_at: '2026-03-10T09:00:00Z',
+        ended_at: '2026-03-10T09:25:00Z',
+      }),
+      makeSession({
+        process_goal_id: 'goal-a',
+        completed: false,
+        started_at: '2026-03-11T09:00:00Z',
+        ended_at: '2026-03-11T09:30:00Z',
+      }),
+    ];
+
+    const result = perGoalBreakdown(sessions);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(
+      expect.objectContaining({ sessions: 1 }),
+    );
+  });
+
+  it('excludes sessions without ended_at', () => {
+    const sessions = [
+      makeSession({
+        completed: true,
+        started_at: '2026-03-10T09:00:00Z',
+        ended_at: null,
+      }),
+    ];
+
+    const result = perGoalBreakdown(sessions);
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array for empty input', () => {
+    const result = perGoalBreakdown([]);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/analytics/src/tier3/distractions.ts
+++ b/packages/analytics/src/tier3/distractions.ts
@@ -1,0 +1,72 @@
+import type { DistractionType, Session } from '@pomofocus/types';
+import type { DistractionPattern, GoalBreakdown } from './types.js';
+
+/**
+ * Find the most common distraction type among struggled sessions.
+ *
+ * Only considers sessions where focus_quality = 'struggled' and
+ * distraction_type is not null. Returns null when no such sessions exist.
+ */
+export function distractionPatterns(
+  sessions: readonly Session[],
+): DistractionPattern {
+  const counts = new Map<DistractionType, number>();
+
+  for (const s of sessions) {
+    if (s.focus_quality === 'struggled' && s.distraction_type !== null) {
+      const current = counts.get(s.distraction_type) ?? 0;
+      counts.set(s.distraction_type, current + 1);
+    }
+  }
+
+  if (counts.size === 0) {
+    return null;
+  }
+
+  let topEntry: { type: DistractionType; count: number } | null = null;
+
+  for (const [type, count] of counts) {
+    if (topEntry === null || count > topEntry.count) {
+      topEntry = { type, count };
+    }
+  }
+
+  return topEntry;
+}
+
+/**
+ * Per-goal breakdown: sessions count and total focus minutes per process goal.
+ *
+ * Only counts completed sessions with both started_at and ended_at.
+ */
+export function perGoalBreakdown(
+  sessions: readonly Session[],
+): readonly GoalBreakdown[] {
+  const goalMap = new Map<string, { sessions: number; focusMs: number }>();
+
+  for (const s of sessions) {
+    if (s.completed && s.started_at && s.ended_at) {
+      const existing = goalMap.get(s.process_goal_id) ?? {
+        sessions: 0,
+        focusMs: 0,
+      };
+      const start = new Date(s.started_at).getTime();
+      const end = new Date(s.ended_at).getTime();
+      goalMap.set(s.process_goal_id, {
+        sessions: existing.sessions + 1,
+        focusMs: existing.focusMs + (end - start),
+      });
+    }
+  }
+
+  const result: GoalBreakdown[] = [];
+  for (const [goalId, data] of goalMap) {
+    result.push({
+      goalId,
+      sessions: data.sessions,
+      focusMinutes: data.focusMs / (1000 * 60),
+    });
+  }
+
+  return result;
+}

--- a/packages/analytics/src/tier3/index.ts
+++ b/packages/analytics/src/tier3/index.ts
@@ -1,0 +1,9 @@
+export type { TrendResult, DistractionPattern, GoalBreakdown } from './types.js';
+export {
+  consistencyTrend,
+  completionTrend,
+  focusQualityTrend,
+  totalTimeTrend,
+  monthlyTrends,
+} from './trends.js';
+export { distractionPatterns, perGoalBreakdown } from './distractions.js';

--- a/packages/analytics/src/tier3/trends.test.ts
+++ b/packages/analytics/src/tier3/trends.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from 'vitest';
+import type { Session } from '@pomofocus/types';
+import {
+  consistencyTrend,
+  completionTrend,
+  focusQualityTrend,
+  totalTimeTrend,
+  monthlyTrends,
+} from './trends.js';
+
+/** Helper to create a minimal session with overrides. */
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-1',
+    user_id: 'user-1',
+    process_goal_id: 'goal-1',
+    intention_text: null,
+    started_at: '2026-03-10T09:00:00Z',
+    ended_at: '2026-03-10T09:25:00Z',
+    completed: true,
+    abandonment_reason: null,
+    focus_quality: 'locked_in',
+    distraction_type: null,
+    device_id: null,
+    created_at: '2026-03-10T09:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('consistencyTrend', () => {
+  it('returns ratio of days with completed sessions', () => {
+    const current = [
+      makeSession({ started_at: '2026-03-01T09:00:00Z' }),
+      makeSession({ started_at: '2026-03-02T09:00:00Z' }),
+      makeSession({ started_at: '2026-03-02T14:00:00Z' }), // same day
+    ];
+    const previous = [
+      makeSession({ started_at: '2026-02-05T09:00:00Z' }),
+    ];
+
+    const result = consistencyTrend(current, previous, 31, 28);
+    expect(result.current).toBeCloseTo(2 / 31);
+    expect(result.previous).toBeCloseTo(1 / 28);
+  });
+
+  it('returns 0 for months with no sessions', () => {
+    const result = consistencyTrend([], [], 31, 28);
+    expect(result).toEqual({ current: 0, previous: 0 });
+  });
+
+  it('excludes non-completed sessions from day count', () => {
+    const current = [
+      makeSession({ started_at: '2026-03-01T09:00:00Z', completed: false }),
+      makeSession({ started_at: '2026-03-02T09:00:00Z', completed: true }),
+    ];
+    const result = consistencyTrend(current, [], 31, 28);
+    expect(result.current).toBeCloseTo(1 / 31);
+  });
+
+  it('handles 0 total days without division error', () => {
+    const result = consistencyTrend([], [], 0, 0);
+    expect(result).toEqual({ current: 0, previous: 0 });
+  });
+});
+
+describe('completionTrend', () => {
+  it('computes completion rate excluding had_to_stop sessions', () => {
+    const current = [
+      makeSession({ completed: true }),
+      makeSession({ completed: false, abandonment_reason: 'gave_up' }),
+      makeSession({ completed: false, abandonment_reason: 'had_to_stop' }),
+    ];
+    // had_to_stop excluded: 1 completed / (3 - 1 had_to_stop) = 1/2
+    const previous = [
+      makeSession({ completed: true }),
+      makeSession({ completed: true }),
+    ];
+    // 2 completed / 2 total = 1.0
+
+    const result = completionTrend(current, previous);
+    expect(result.current).toBeCloseTo(0.5);
+    expect(result.previous).toBeCloseTo(1.0);
+  });
+
+  it('returns 0 when all sessions are had_to_stop', () => {
+    const sessions = [
+      makeSession({ completed: false, abandonment_reason: 'had_to_stop' }),
+    ];
+    const result = completionTrend(sessions, []);
+    expect(result.current).toBe(0);
+    expect(result.previous).toBe(0);
+  });
+
+  it('returns 0 for empty sessions', () => {
+    const result = completionTrend([], []);
+    expect(result).toEqual({ current: 0, previous: 0 });
+  });
+
+  it('treats null abandonment_reason as gave_up (not excluded)', () => {
+    const sessions = [
+      makeSession({ completed: false, abandonment_reason: null }),
+      makeSession({ completed: true }),
+    ];
+    // 1 completed / (2 total - 0 had_to_stop) = 0.5
+    const result = completionTrend(sessions, []);
+    expect(result.current).toBeCloseTo(0.5);
+  });
+});
+
+describe('focusQualityTrend', () => {
+  it('computes percentage of locked_in among completed sessions', () => {
+    const current = [
+      makeSession({ completed: true, focus_quality: 'locked_in' }),
+      makeSession({ completed: true, focus_quality: 'decent' }),
+      makeSession({ completed: true, focus_quality: 'struggled' }),
+    ];
+    const previous = [
+      makeSession({ completed: true, focus_quality: 'locked_in' }),
+      makeSession({ completed: true, focus_quality: 'locked_in' }),
+    ];
+
+    const result = focusQualityTrend(current, previous);
+    expect(result.current).toBeCloseTo(1 / 3);
+    expect(result.previous).toBeCloseTo(1.0);
+  });
+
+  it('returns 0 when no completed sessions', () => {
+    const sessions = [makeSession({ completed: false })];
+    const result = focusQualityTrend(sessions, []);
+    expect(result.current).toBe(0);
+    expect(result.previous).toBe(0);
+  });
+
+  it('ignores non-completed sessions', () => {
+    const sessions = [
+      makeSession({ completed: true, focus_quality: 'locked_in' }),
+      makeSession({ completed: false, focus_quality: 'locked_in' }),
+    ];
+    const result = focusQualityTrend(sessions, []);
+    // 1 locked_in / 1 completed = 1.0
+    expect(result.current).toBeCloseTo(1.0);
+  });
+});
+
+describe('totalTimeTrend', () => {
+  it('computes total hours from completed sessions', () => {
+    const current = [
+      makeSession({
+        completed: true,
+        started_at: '2026-03-10T09:00:00Z',
+        ended_at: '2026-03-10T09:30:00Z',
+      }),
+      makeSession({
+        completed: true,
+        started_at: '2026-03-11T10:00:00Z',
+        ended_at: '2026-03-11T10:30:00Z',
+      }),
+    ];
+    const previous = [
+      makeSession({
+        completed: true,
+        started_at: '2026-02-10T09:00:00Z',
+        ended_at: '2026-02-10T10:00:00Z',
+      }),
+    ];
+
+    const result = totalTimeTrend(current, previous);
+    expect(result.current).toBeCloseTo(1.0); // 30min + 30min = 1h
+    expect(result.previous).toBeCloseTo(1.0); // 60min = 1h
+  });
+
+  it('excludes non-completed sessions', () => {
+    const sessions = [
+      makeSession({
+        completed: true,
+        started_at: '2026-03-10T09:00:00Z',
+        ended_at: '2026-03-10T09:30:00Z',
+      }),
+      makeSession({
+        completed: false,
+        started_at: '2026-03-11T10:00:00Z',
+        ended_at: '2026-03-11T11:00:00Z',
+      }),
+    ];
+    const result = totalTimeTrend(sessions, []);
+    expect(result.current).toBeCloseTo(0.5); // only 30min
+  });
+
+  it('excludes sessions without ended_at', () => {
+    const sessions = [
+      makeSession({
+        completed: true,
+        started_at: '2026-03-10T09:00:00Z',
+        ended_at: null,
+      }),
+    ];
+    const result = totalTimeTrend(sessions, []);
+    expect(result.current).toBe(0);
+  });
+
+  it('returns 0 for empty sessions', () => {
+    const result = totalTimeTrend([], []);
+    expect(result).toEqual({ current: 0, previous: 0 });
+  });
+});
+
+describe('monthlyTrends', () => {
+  it('returns all trends when both months have completed sessions', () => {
+    const current = [
+      makeSession({
+        completed: true,
+        started_at: '2026-03-10T09:00:00Z',
+        ended_at: '2026-03-10T09:25:00Z',
+        focus_quality: 'locked_in',
+      }),
+    ];
+    const previous = [
+      makeSession({
+        completed: true,
+        started_at: '2026-02-10T09:00:00Z',
+        ended_at: '2026-02-10T09:25:00Z',
+        focus_quality: 'decent',
+      }),
+    ];
+
+    const result = monthlyTrends(current, previous, 31, 28);
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('consistency');
+    expect(result).toHaveProperty('completionRate');
+    expect(result).toHaveProperty('focusQuality');
+    expect(result).toHaveProperty('totalHours');
+  });
+
+  it('returns null when current month has no completed sessions (cold-start)', () => {
+    const current: Session[] = [];
+    const previous = [makeSession({ completed: true })];
+
+    const result = monthlyTrends(current, previous, 31, 28);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when previous month has no completed sessions (cold-start)', () => {
+    const current = [makeSession({ completed: true })];
+    const previous: Session[] = [];
+
+    const result = monthlyTrends(current, previous, 31, 28);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when both months have no completed sessions', () => {
+    const result = monthlyTrends([], [], 31, 28);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when sessions exist but none are completed', () => {
+    const current = [makeSession({ completed: false })];
+    const previous = [makeSession({ completed: false })];
+
+    const result = monthlyTrends(current, previous, 31, 28);
+    expect(result).toBeNull();
+  });
+
+  it('trend values are correct for known inputs', () => {
+    const current = [
+      makeSession({
+        completed: true,
+        started_at: '2026-03-01T09:00:00Z',
+        ended_at: '2026-03-01T09:30:00Z',
+        focus_quality: 'locked_in',
+      }),
+      makeSession({
+        completed: true,
+        started_at: '2026-03-02T09:00:00Z',
+        ended_at: '2026-03-02T09:30:00Z',
+        focus_quality: 'decent',
+      }),
+    ];
+    const previous = [
+      makeSession({
+        completed: true,
+        started_at: '2026-02-15T09:00:00Z',
+        ended_at: '2026-02-15T10:00:00Z',
+        focus_quality: 'locked_in',
+      }),
+    ];
+
+    const result = monthlyTrends(current, previous, 31, 28);
+    if (result === null) {
+      expect.unreachable('expected non-null result');
+      return;
+    }
+
+    // consistency: current 2 days / 31, previous 1 day / 28
+    expect(result.consistency.current).toBeCloseTo(2 / 31);
+    expect(result.consistency.previous).toBeCloseTo(1 / 28);
+
+    // completion: current 2/2 = 1.0, previous 1/1 = 1.0
+    expect(result.completionRate.current).toBeCloseTo(1.0);
+    expect(result.completionRate.previous).toBeCloseTo(1.0);
+
+    // focus quality: current 1 locked_in / 2 completed = 0.5, previous 1/1 = 1.0
+    expect(result.focusQuality.current).toBeCloseTo(0.5);
+    expect(result.focusQuality.previous).toBeCloseTo(1.0);
+
+    // total hours: current 30+30 = 60min = 1h, previous 60min = 1h
+    expect(result.totalHours.current).toBeCloseTo(1.0);
+    expect(result.totalHours.previous).toBeCloseTo(1.0);
+  });
+});

--- a/packages/analytics/src/tier3/trends.ts
+++ b/packages/analytics/src/tier3/trends.ts
@@ -1,0 +1,166 @@
+import type { Session } from '@pomofocus/types';
+import type { TrendResult } from './types.js';
+
+/**
+ * Count distinct calendar days (YYYY-MM-DD in UTC) that have at least one
+ * completed session.
+ */
+function daysWithSessions(sessions: readonly Session[]): number {
+  const days = new Set<string>();
+  for (const s of sessions) {
+    if (s.completed && s.started_at) {
+      days.add(s.started_at.slice(0, 10));
+    }
+  }
+  return days.size;
+}
+
+/**
+ * Consistency trend: proportion of days with sessions in each month.
+ *
+ * Returns `{ current, previous }` where each value is 0-1 representing
+ * days_with_sessions / total_days_in_month.
+ */
+export function consistencyTrend(
+  currentMonthSessions: readonly Session[],
+  prevMonthSessions: readonly Session[],
+  currentMonthDays: number,
+  prevMonthDays: number,
+): TrendResult {
+  const current = currentMonthDays > 0
+    ? daysWithSessions(currentMonthSessions) / currentMonthDays
+    : 0;
+  const previous = prevMonthDays > 0
+    ? daysWithSessions(prevMonthSessions) / prevMonthDays
+    : 0;
+  return { current, previous };
+}
+
+/**
+ * Compute the completion rate for a set of sessions.
+ *
+ * Formula: completed / (total - had_to_stop). Returns 0 when denominator is 0.
+ * Sessions with abandonment_reason = null are treated as gave_up (not excluded).
+ */
+function completionRate(sessions: readonly Session[]): number {
+  const hadToStopCount = sessions.filter(
+    (s) => s.abandonment_reason === 'had_to_stop',
+  ).length;
+  const denominator = sessions.length - hadToStopCount;
+  if (denominator === 0) return 0;
+  const completedCount = sessions.filter((s) => s.completed).length;
+  return completedCount / denominator;
+}
+
+/**
+ * Completion trend: completion rate for current month vs previous month.
+ *
+ * Returns `{ current, previous }` where each value is 0-1.
+ */
+export function completionTrend(
+  currentMonthSessions: readonly Session[],
+  prevMonthSessions: readonly Session[],
+): TrendResult {
+  return {
+    current: completionRate(currentMonthSessions),
+    previous: completionRate(prevMonthSessions),
+  };
+}
+
+/**
+ * Compute the percentage of completed sessions with focus_quality = 'locked_in'.
+ */
+function lockedInPercentage(sessions: readonly Session[]): number {
+  const completed = sessions.filter((s) => s.completed);
+  if (completed.length === 0) return 0;
+  const lockedIn = completed.filter(
+    (s) => s.focus_quality === 'locked_in',
+  ).length;
+  return lockedIn / completed.length;
+}
+
+/**
+ * Focus quality trend: percentage of locked_in sessions, current vs previous month.
+ *
+ * Returns `{ current, previous }` where each value is 0-1.
+ */
+export function focusQualityTrend(
+  currentMonthSessions: readonly Session[],
+  prevMonthSessions: readonly Session[],
+): TrendResult {
+  return {
+    current: lockedInPercentage(currentMonthSessions),
+    previous: lockedInPercentage(prevMonthSessions),
+  };
+}
+
+/**
+ * Compute total focus time in hours for completed sessions.
+ */
+function totalHours(sessions: readonly Session[]): number {
+  let totalMs = 0;
+  for (const s of sessions) {
+    if (s.completed && s.started_at && s.ended_at) {
+      const start = new Date(s.started_at).getTime();
+      const end = new Date(s.ended_at).getTime();
+      totalMs += end - start;
+    }
+  }
+  return totalMs / (1000 * 60 * 60);
+}
+
+/**
+ * Total time trend: total focus hours, current vs previous month.
+ *
+ * Returns `{ current, previous }` where each value is in hours.
+ */
+export function totalTimeTrend(
+  currentMonthSessions: readonly Session[],
+  prevMonthSessions: readonly Session[],
+): TrendResult {
+  return {
+    current: totalHours(currentMonthSessions),
+    previous: totalHours(prevMonthSessions),
+  };
+}
+
+/**
+ * Aggregate all monthly trends. Returns null when cold-start conditions
+ * are not met (requires >= 2 calendar months with data).
+ *
+ * Cold-start check: both currentMonthSessions and prevMonthSessions must
+ * contain at least one completed session each.
+ */
+export function monthlyTrends(
+  currentMonthSessions: readonly Session[],
+  prevMonthSessions: readonly Session[],
+  currentMonthDays: number,
+  prevMonthDays: number,
+): {
+  consistency: TrendResult;
+  completionRate: TrendResult;
+  focusQuality: TrendResult;
+  totalHours: TrendResult;
+} | null {
+  const currentHasData = currentMonthSessions.some((s) => s.completed);
+  const prevHasData = prevMonthSessions.some((s) => s.completed);
+
+  if (!currentHasData || !prevHasData) {
+    return null;
+  }
+
+  return {
+    consistency: consistencyTrend(
+      currentMonthSessions,
+      prevMonthSessions,
+      currentMonthDays,
+      prevMonthDays,
+    ),
+    completionRate: completionTrend(currentMonthSessions, prevMonthSessions),
+    focusQuality: focusQualityTrend(
+      currentMonthSessions,
+      prevMonthSessions,
+    ),
+    totalHours: totalTimeTrend(currentMonthSessions, prevMonthSessions),
+  };
+}

--- a/packages/analytics/src/tier3/types.ts
+++ b/packages/analytics/src/tier3/types.ts
@@ -1,0 +1,20 @@
+import type { DistractionType } from '@pomofocus/types';
+
+/** Result shape for a month-over-month trend comparison. */
+export type TrendResult = {
+  readonly current: number;
+  readonly previous: number;
+};
+
+/** Top distraction pattern for a month, or null when no struggled sessions exist. */
+export type DistractionPattern = {
+  readonly type: DistractionType;
+  readonly count: number;
+} | null;
+
+/** Per-goal breakdown for a given time period. */
+export type GoalBreakdown = {
+  readonly goalId: string;
+  readonly sessions: number;
+  readonly focusMinutes: number;
+};


### PR DESCRIPTION
## Summary

- Implement Tier 3 analytics pure functions in `packages/analytics/src/tier3/`: monthly trends (consistency, completion rate, focus quality, total time), distraction pattern analysis, and per-goal breakdowns
- Cold-start guard returns `null` when fewer than 2 calendar months have completed session data, per ADR-014
- Comprehensive test coverage (490 lines of tests) covering edge cases: empty inputs, null fields, `had_to_stop` exclusion, same-day deduplication, and cold-start conditions

Closes #196

## Test plan

- [x] `pnpm nx test @pomofocus/analytics` — all Tier 3 tests pass
- [ ] Verify `consistencyTrend` counts unique days correctly
- [ ] Verify `completionTrend` excludes `had_to_stop` sessions from denominator
- [ ] Verify `focusQualityTrend` only considers completed sessions
- [ ] Verify `distractionPatterns` returns `null` when no struggled sessions
- [ ] Verify `monthlyTrends` returns `null` for cold-start (< 2 months data)
- [ ] Verify `perGoalBreakdown` excludes incomplete sessions and sessions without `ended_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)