### PR TITLE
feat: add LED state indicator driver for timer FSM

### DIFF
--- a/firmware/device/src/feedback.cpp
+++ b/firmware/device/src/feedback.cpp
@@ -1,0 +1,69 @@
+// PomoFocus LED state indicator driver — implementation.
+// Non-blocking blink/pulse using millis() timing (no delay, no interrupts).
+
+#include "feedback.h"
+
+// Module-level blink state — shared across blink modes so that a state
+// transition resets cleanly (no leftover toggle from the previous mode).
+// Named with underscore prefix to avoid collision with Adafruit BSP's
+// ledOn(uint32_t) function in wiring_digital.h.
+static uint32_t lastToggle = 0;
+static bool ledIsOn = false;
+
+void initLed() {
+  pinMode(PIN_LED_INDICATOR, OUTPUT);
+  digitalWrite(PIN_LED_INDICATOR, LOW);
+}
+
+// Non-blocking blink: toggles LED on/off at the given period.
+// Called every loop() iteration — returns immediately when not yet time.
+static void blinkWithPeriod(uint32_t periodMs) {
+  const uint32_t now = millis();
+  const uint32_t halfPeriod = periodMs / 2;
+
+  if (now - lastToggle >= halfPeriod) {
+    lastToggle = now;
+    ledIsOn = !ledIsOn;
+    digitalWrite(PIN_LED_INDICATOR, ledIsOn ? HIGH : LOW);
+  }
+}
+
+void updateLed(TimerStatus status) {
+  // Track previous status to reset blink timing on state transitions.
+  static TimerStatus prevStatus = TimerStatus::IDLE;
+
+  if (status != prevStatus) {
+    prevStatus = status;
+    // Reset blink state so the new mode starts from a clean off state.
+    ledIsOn = false;
+    lastToggle = millis();
+    digitalWrite(PIN_LED_INDICATOR, LOW);
+  }
+
+  switch (status) {
+    case TimerStatus::FOCUSING:
+      // Steady on
+      digitalWrite(PIN_LED_INDICATOR, HIGH);
+      break;
+
+    case TimerStatus::PAUSED:
+    case TimerStatus::BREAK_PAUSED:
+      // Blink ~1Hz (500ms on / 500ms off)
+      blinkWithPeriod(BLINK_PERIOD_MS);
+      break;
+
+    case TimerStatus::SHORT_BREAK:
+    case TimerStatus::LONG_BREAK:
+      // Slow pulse ~0.5Hz (1000ms on / 1000ms off)
+      blinkWithPeriod(PULSE_PERIOD_MS);
+      break;
+
+    case TimerStatus::IDLE:
+    case TimerStatus::REFLECTION:
+    case TimerStatus::COMPLETED:
+    case TimerStatus::ABANDONED:
+      // LED off
+      digitalWrite(PIN_LED_INDICATOR, LOW);
+      break;
+  }
+}

--- a/firmware/device/src/feedback.h
+++ b/firmware/device/src/feedback.h
@@ -1,0 +1,45 @@
+// PomoFocus LED state indicator driver.
+// Maps timer FSM states to LED behavior (steady, blink, pulse, off).
+// See ADR-010 for hardware: D9, simple on/off for v1 (no PWM).
+
+#ifndef POMOFOCUS_FEEDBACK_H
+#define POMOFOCUS_FEEDBACK_H
+
+#include <Arduino.h>
+
+// LED pin assignment — Arduino pin 9 (D9 on XIAO nRF52840, see design doc pin table).
+// The feather_nrf52840_express variant maps pin 9 to P0.26 via g_ADigitalPinMap.
+constexpr uint8_t PIN_LED_INDICATOR = 9;
+
+// Timer states — direct mirror of packages/core/src/timer/types.ts TIMER_STATUS (NAT-F04).
+// Using enum class to avoid polluting the global namespace.
+enum class TimerStatus : uint8_t {
+  IDLE,
+  FOCUSING,
+  PAUSED,
+  SHORT_BREAK,
+  LONG_BREAK,
+  BREAK_PAUSED,
+  REFLECTION,
+  COMPLETED,
+  ABANDONED,
+};
+
+// Blink timing constants
+constexpr uint32_t BLINK_PERIOD_MS = 1000;   // 1Hz blink for paused states
+constexpr uint32_t PULSE_PERIOD_MS = 2000;   // 0.5Hz pulse for break states
+
+// Initialize LED GPIO pin as OUTPUT and turn off.
+void initLed();
+
+// Update LED output based on current timer state.
+// Must be called from loop() — uses millis() for non-blocking blink/pulse.
+//
+// Behavior:
+//   FOCUSING           -> steady on
+//   PAUSED, BREAK_PAUSED -> blink ~1Hz (500ms on / 500ms off)
+//   SHORT_BREAK, LONG_BREAK -> slow pulse ~0.5Hz (1000ms on / 1000ms off)
+//   IDLE, REFLECTION, COMPLETED, ABANDONED -> off
+void updateLed(TimerStatus status);
+
+#endif // POMOFOCUS_FEEDBACK_H


### PR DESCRIPTION
## Summary
- Add LED state indicator driver in `firmware/device/src/feedback.{h,cpp}` that maps timer FSM states to LED behavior: steady on during focusing, ~1Hz blink during paused states, ~0.5Hz slow pulse during break states, and off during idle/completed/abandoned
- Non-blocking implementation using `millis()` timing — no delays or interrupts
- Simple on/off GPIO control (no PWM for v1)

Closes #219

## Test plan
- [ ] `pio run` compiles successfully
- [ ] Manual: set timer to focusing state, verify LED steady on
- [ ] Manual: set timer to paused/break_paused, verify LED blinks ~1Hz
- [ ] Manual: set timer to break states, verify LED slow pulse ~0.5Hz
- [ ] Manual: set timer to idle/completed/abandoned, verify LED off
- [ ] Verify non-blocking — other firmware functions continue during blink

🤖 Generated with [Claude Code](https://claude.com/claude-code)