### PR TITLE
feat: vibration motor driver with non-blocking pattern support

### DIFF
--- a/firmware/device/src/feedback.cpp
+++ b/firmware/device/src/feedback.cpp
@@ -1,12 +1,13 @@
-// PomoFocus LED state indicator driver — implementation.
-// Non-blocking blink/pulse using millis() timing (no delay, no interrupts).
+// PomoFocus — Feedback drivers implementation (LED + vibration motor)
+// Non-blocking timing using millis() (no delay, no interrupts).
+// Call updateLed() and Feedback::update() from loop().
 
 #include "feedback.h"
 
+// ==================== LED indicator ====================
+
 // Module-level blink state — shared across blink modes so that a state
 // transition resets cleanly (no leftover toggle from the previous mode).
-// Named with underscore prefix to avoid collision with Adafruit BSP's
-// ledOn(uint32_t) function in wiring_digital.h.
 static uint32_t lastToggle = 0;
 static bool ledIsOn = false;
 
@@ -66,4 +67,112 @@ void updateLed(TimerStatus status) {
       digitalWrite(PIN_LED_INDICATOR, LOW);
       break;
   }
+}
+
+// ==================== Vibration motor ====================
+
+// Pattern definitions — static const, zero heap allocation (NAT-F01).
+
+// Short buzz: 100ms on
+constexpr PatternStep PATTERN_SHORT_BUZZ[] = {
+  {100, true},
+};
+constexpr uint8_t PATTERN_SHORT_BUZZ_COUNT = 1;
+
+// Long buzz: 400ms on
+constexpr PatternStep PATTERN_LONG_BUZZ[] = {
+  {400, true},
+};
+constexpr uint8_t PATTERN_LONG_BUZZ_COUNT = 1;
+
+// Double buzz: 100ms on, 100ms off, 100ms on
+constexpr PatternStep PATTERN_DOUBLE_BUZZ[] = {
+  {100, true},
+  {100, false},
+  {100, true},
+};
+constexpr uint8_t PATTERN_DOUBLE_BUZZ_COUNT = 3;
+
+// Timer end: 3 short buzzes (100ms) with 200ms gaps
+// on 100ms -> off 200ms -> on 100ms -> off 200ms -> on 100ms
+constexpr PatternStep PATTERN_TIMER_END[] = {
+  {100, true},
+  {200, false},
+  {100, true},
+  {200, false},
+  {100, true},
+};
+constexpr uint8_t PATTERN_TIMER_END_COUNT = 5;
+
+void Feedback::begin() {
+  pinMode(MOTOR_PIN, OUTPUT);
+  setMotor(false);
+}
+
+void Feedback::vibrate(uint32_t durationMs) {
+  steps_[0] = {durationMs, true};
+  stepCount_ = 1;
+  currentStep_ = 0;
+  stepStartMs_ = millis();
+  active_ = true;
+  setMotor(true);
+}
+
+void Feedback::vibratePattern(VibrationPattern pattern) {
+  switch (pattern) {
+    case VibrationPattern::SHORT_BUZZ:
+      loadPattern(PATTERN_SHORT_BUZZ, PATTERN_SHORT_BUZZ_COUNT);
+      break;
+    case VibrationPattern::LONG_BUZZ:
+      loadPattern(PATTERN_LONG_BUZZ, PATTERN_LONG_BUZZ_COUNT);
+      break;
+    case VibrationPattern::DOUBLE_BUZZ:
+      loadPattern(PATTERN_DOUBLE_BUZZ, PATTERN_DOUBLE_BUZZ_COUNT);
+      break;
+    case VibrationPattern::TIMER_END:
+      loadPattern(PATTERN_TIMER_END, PATTERN_TIMER_END_COUNT);
+      break;
+  }
+}
+
+void Feedback::update() {
+  if (!active_) {
+    return;
+  }
+
+  uint32_t elapsed = millis() - stepStartMs_;
+  if (elapsed >= steps_[currentStep_].durationMs) {
+    advanceStep();
+  }
+}
+
+bool Feedback::isActive() const {
+  return active_;
+}
+
+void Feedback::setMotor(bool on) {
+  digitalWrite(MOTOR_PIN, on ? HIGH : LOW);
+}
+
+void Feedback::loadPattern(const PatternStep* steps, uint8_t count) {
+  uint8_t safeCount = (count > MAX_PATTERN_STEPS) ? MAX_PATTERN_STEPS : count;
+  for (uint8_t i = 0; i < safeCount; ++i) {
+    steps_[i] = steps[i];
+  }
+  stepCount_ = safeCount;
+  currentStep_ = 0;
+  stepStartMs_ = millis();
+  active_ = true;
+  setMotor(steps_[0].motorOn);
+}
+
+void Feedback::advanceStep() {
+  ++currentStep_;
+  if (currentStep_ >= stepCount_) {
+    active_ = false;
+    setMotor(false);
+    return;
+  }
+  stepStartMs_ = millis();
+  setMotor(steps_[currentStep_].motorOn);
 }

--- a/firmware/device/src/feedback.h
+++ b/firmware/device/src/feedback.h
@@ -1,11 +1,17 @@
-// PomoFocus LED state indicator driver.
-// Maps timer FSM states to LED behavior (steady, blink, pulse, off).
-// See ADR-010 for hardware: D9, simple on/off for v1 (no PWM).
+// PomoFocus — Feedback drivers (LED + vibration motor)
+// LED: Maps timer FSM states to LED behavior (steady, blink, pulse, off).
+//   See ADR-010 for hardware: D9, simple on/off for v1 (no PWM).
+// Vibration motor: Drives a coin vibration motor via 2N2222 NPN transistor.
+//   Circuit: GPIO -> 1K resistor -> 2N2222 base, motor between V+ and collector,
+//   1N4148 flyback diode across motor terminals (cathode to V+).
+//   See ADR-010 for hardware details.
 
 #ifndef POMOFOCUS_FEEDBACK_H
 #define POMOFOCUS_FEEDBACK_H
 
 #include <Arduino.h>
+
+// ---------- LED indicator ----------
 
 // LED pin assignment — Arduino pin 9 (D9 on XIAO nRF52840, see design doc pin table).
 // The feather_nrf52840_express variant maps pin 9 to P0.26 via g_ADigitalPinMap.
@@ -41,5 +47,50 @@ void initLed();
 //   SHORT_BREAK, LONG_BREAK -> slow pulse ~0.5Hz (1000ms on / 1000ms off)
 //   IDLE, REFLECTION, COMPLETED, ABANDONED -> off
 void updateLed(TimerStatus status);
+
+// ---------- Vibration motor ----------
+
+// GPIO pin connected to 2N2222 base through 1K resistor.
+// Arduino pin 2 on Adafruit nRF52 BSP (feather_nrf52840_express variant).
+// Actual GPIO mapping depends on variant's g_ADigitalPinMap — confirm with
+// hardware wiring. Pin must not conflict with EN04 display SPI or encoder.
+constexpr uint8_t MOTOR_PIN = 2;
+
+// Maximum number of steps in a vibration pattern (on/off pairs).
+// Longest pattern is timer-end: 3 buzzes + 2 gaps + trailing off = 6 steps.
+// Allocate 12 for headroom without dynamic allocation (NAT-F01).
+constexpr uint8_t MAX_PATTERN_STEPS = 12;
+
+enum class VibrationPattern : uint8_t {
+  SHORT_BUZZ,
+  LONG_BUZZ,
+  DOUBLE_BUZZ,
+  TIMER_END,
+};
+
+struct PatternStep {
+  uint32_t durationMs;
+  bool motorOn;
+};
+
+class Feedback {
+public:
+  void begin();
+  void vibrate(uint32_t durationMs);
+  void vibratePattern(VibrationPattern pattern);
+  void update();
+  bool isActive() const;
+
+private:
+  void setMotor(bool on);
+  void loadPattern(const PatternStep* steps, uint8_t count);
+  void advanceStep();
+
+  PatternStep steps_[MAX_PATTERN_STEPS] = {};
+  uint8_t stepCount_ = 0;
+  uint8_t currentStep_ = 0;
+  uint32_t stepStartMs_ = 0;
+  bool active_ = false;
+};
 
 #endif // POMOFOCUS_FEEDBACK_H


### PR DESCRIPTION
## Summary

- Adds a non-blocking vibration motor driver (`Feedback` class) for the EN04 device firmware
- Drives a coin vibration motor via 2N2222 NPN transistor with 1N4148 flyback diode protection and 1K base resistor (per ADR-010)
- Supports four vibration patterns: short buzz (100ms), long buzz (400ms), double buzz, and timer-end (3 short buzzes with 200ms gaps)
- Uses `millis()` timing for non-blocking operation — no `delay()` calls

## Test plan

- [ ] `pio run` compiles successfully
- [ ] Manual: trigger each vibration pattern and verify motor response
- [ ] Verify non-blocking behavior (other loop tasks not delayed during vibration)

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)