### PR TITLE
feat: implement Apple Sign-In flow

### DIFF
--- a/packages/data-access/src/auth/oauth.test.ts
+++ b/packages/data-access/src/auth/oauth.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient, AuthError } from '@supabase/supabase-js';
+import {
+  signInWithApple,
+  extractAppleUserProfile,
+  isApplePrivateRelayEmail,
+} from './oauth';
+
+function createMockSupabaseClient(
+  mockSignInWithOAuth: ReturnType<typeof vi.fn>,
+): SupabaseClient {
+  return {
+    auth: {
+      signInWithOAuth: mockSignInWithOAuth,
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe('signInWithApple', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls Supabase with apple provider and correct scopes', async () => {
+    const mockSignIn = vi.fn().mockResolvedValue({
+      data: { provider: 'apple', url: 'https://appleid.apple.com/auth/authorize?...' },
+      error: null,
+    });
+    const client = createMockSupabaseClient(mockSignIn);
+
+    await signInWithApple(client);
+
+    expect(mockSignIn).toHaveBeenCalledWith({
+      provider: 'apple',
+      options: { scopes: 'name email' },
+    });
+  });
+
+  it('returns provider and url on success', async () => {
+    const oauthUrl = 'https://appleid.apple.com/auth/authorize?client_id=test';
+    const mockSignIn = vi.fn().mockResolvedValue({
+      data: { provider: 'apple', url: oauthUrl },
+      error: null,
+    });
+    const client = createMockSupabaseClient(mockSignIn);
+
+    const result = await signInWithApple(client);
+
+    expect(result.data.provider).toBe('apple');
+    expect(result.data.url).toBe(oauthUrl);
+    expect(result.error).toBeNull();
+  });
+
+  it('passes redirectTo when provided', async () => {
+    const mockSignIn = vi.fn().mockResolvedValue({
+      data: { provider: 'apple', url: 'https://appleid.apple.com/auth/authorize?...' },
+      error: null,
+    });
+    const client = createMockSupabaseClient(mockSignIn);
+
+    await signInWithApple(client, 'pomofocus://auth/callback');
+
+    expect(mockSignIn).toHaveBeenCalledWith({
+      provider: 'apple',
+      options: {
+        scopes: 'name email',
+        redirectTo: 'pomofocus://auth/callback',
+      },
+    });
+  });
+
+  it('supports web callback URLs', async () => {
+    const mockSignIn = vi.fn().mockResolvedValue({
+      data: { provider: 'apple', url: 'https://appleid.apple.com/auth/authorize?...' },
+      error: null,
+    });
+    const client = createMockSupabaseClient(mockSignIn);
+
+    await signInWithApple(client, 'https://pomofocus.app/auth/callback');
+
+    expect(mockSignIn).toHaveBeenCalledWith({
+      provider: 'apple',
+      options: {
+        scopes: 'name email',
+        redirectTo: 'https://pomofocus.app/auth/callback',
+      },
+    });
+  });
+
+  it('returns error when Supabase auth fails', async () => {
+    const authError = { name: 'AuthError', message: 'Provider not enabled', status: 400 } as AuthError;
+    const mockSignIn = vi.fn().mockResolvedValue({
+      data: { provider: 'apple', url: null },
+      error: authError,
+    });
+    const client = createMockSupabaseClient(mockSignIn);
+
+    const result = await signInWithApple(client);
+
+    expect(result.data.provider).toBe('apple');
+    expect(result.data.url).toBeNull();
+    expect(result.error).toBe(authError);
+  });
+
+  it('does not include redirectTo in options when undefined', async () => {
+    const mockSignIn = vi.fn().mockResolvedValue({
+      data: { provider: 'apple', url: 'https://appleid.apple.com/auth/authorize?...' },
+      error: null,
+    });
+    const client = createMockSupabaseClient(mockSignIn);
+
+    await signInWithApple(client, undefined);
+
+    const firstCall = mockSignIn.mock.calls[0] as
+      | [{ provider: string; options?: Record<string, unknown> }]
+      | undefined;
+    const calledOptions = firstCall?.[0]?.options;
+    expect(calledOptions).toBeDefined();
+    expect('redirectTo' in (calledOptions ?? {})).toBe(false);
+  });
+
+  it('returns typed result without throwing', async () => {
+    const mockSignIn = vi.fn().mockResolvedValue({
+      data: { provider: 'apple', url: null },
+      error: { name: 'AuthError', message: 'Network error', status: 500 } as AuthError,
+    });
+    const client = createMockSupabaseClient(mockSignIn);
+
+    // Should NOT throw — returns error in result
+    const result = await signInWithApple(client);
+    expect(result.error).not.toBeNull();
+  });
+});
+
+describe('extractAppleUserProfile', () => {
+  it('extracts email and display name from first login', () => {
+    const identityData = {
+      email: 'user@example.com',
+      full_name: { firstName: 'John', lastName: 'Doe' },
+      sub: 'apple-user-id-123',
+    };
+
+    const profile = extractAppleUserProfile(identityData);
+
+    expect(profile.email).toBe('user@example.com');
+    expect(profile.displayName).toBe('John Doe');
+    expect(profile.isPrivateRelay).toBe(false);
+  });
+
+  it('detects Apple private relay email', () => {
+    const identityData = {
+      email: 'abc123@privaterelay.appleid.com',
+      full_name: { firstName: 'John', lastName: 'Doe' },
+    };
+
+    const profile = extractAppleUserProfile(identityData);
+
+    expect(profile.email).toBe('abc123@privaterelay.appleid.com');
+    expect(profile.isPrivateRelay).toBe(true);
+  });
+
+  it('returns undefined displayName for returning user (no name sent)', () => {
+    const identityData = {
+      email: 'user@example.com',
+      sub: 'apple-user-id-123',
+    };
+
+    const profile = extractAppleUserProfile(identityData);
+
+    expect(profile.email).toBe('user@example.com');
+    expect(profile.displayName).toBeUndefined();
+    expect(profile.isPrivateRelay).toBe(false);
+  });
+
+  it('handles first name only', () => {
+    const identityData = {
+      email: 'user@example.com',
+      full_name: { firstName: 'John' },
+    };
+
+    const profile = extractAppleUserProfile(identityData);
+
+    expect(profile.displayName).toBe('John');
+  });
+
+  it('handles last name only', () => {
+    const identityData = {
+      email: 'user@example.com',
+      full_name: { lastName: 'Doe' },
+    };
+
+    const profile = extractAppleUserProfile(identityData);
+
+    expect(profile.displayName).toBe('Doe');
+  });
+
+  it('falls back to top-level name field', () => {
+    const identityData = {
+      email: 'user@example.com',
+      name: 'Jane Smith',
+    };
+
+    const profile = extractAppleUserProfile(identityData);
+
+    expect(profile.displayName).toBe('Jane Smith');
+  });
+
+  it('returns undefined for all fields when identityData is undefined', () => {
+    const profile = extractAppleUserProfile(undefined);
+
+    expect(profile.email).toBeUndefined();
+    expect(profile.displayName).toBeUndefined();
+    expect(profile.isPrivateRelay).toBe(false);
+  });
+
+  it('handles empty identity data object', () => {
+    const profile = extractAppleUserProfile({});
+
+    expect(profile.email).toBeUndefined();
+    expect(profile.displayName).toBeUndefined();
+    expect(profile.isPrivateRelay).toBe(false);
+  });
+
+  it('handles non-string email', () => {
+    const identityData = {
+      email: 42,
+    };
+
+    const profile = extractAppleUserProfile(identityData);
+
+    expect(profile.email).toBeUndefined();
+    expect(profile.isPrivateRelay).toBe(false);
+  });
+
+  it('handles full_name with non-string values', () => {
+    const identityData = {
+      email: 'user@example.com',
+      full_name: { firstName: 123, lastName: true },
+    };
+
+    const profile = extractAppleUserProfile(identityData);
+
+    expect(profile.displayName).toBeUndefined();
+  });
+
+  it('ignores empty name string fallback', () => {
+    const identityData = {
+      email: 'user@example.com',
+      name: '',
+    };
+
+    const profile = extractAppleUserProfile(identityData);
+
+    expect(profile.displayName).toBeUndefined();
+  });
+});
+
+describe('isApplePrivateRelayEmail', () => {
+  it('returns true for private relay email', () => {
+    expect(isApplePrivateRelayEmail('abc123@privaterelay.appleid.com')).toBe(true);
+  });
+
+  it('returns false for regular email', () => {
+    expect(isApplePrivateRelayEmail('user@example.com')).toBe(false);
+  });
+
+  it('returns false for icloud email', () => {
+    expect(isApplePrivateRelayEmail('user@icloud.com')).toBe(false);
+  });
+
+  it('returns false for partial match', () => {
+    expect(isApplePrivateRelayEmail('user@fakeprivaterelay.appleid.com')).toBe(false);
+  });
+
+  it('returns true for relay with long local part', () => {
+    expect(isApplePrivateRelayEmail('very.long.email.address.12345@privaterelay.appleid.com')).toBe(true);
+  });
+});

--- a/packages/data-access/src/auth/oauth.ts
+++ b/packages/data-access/src/auth/oauth.ts
@@ -1,0 +1,124 @@
+import type { SupabaseClient, AuthError } from '@supabase/supabase-js';
+
+/**
+ * Apple's private relay email domain. When users choose "Hide My Email"
+ * during Apple Sign-In, Apple generates a unique @privaterelay.appleid.com
+ * address that forwards to their real email.
+ */
+const APPLE_PRIVATE_RELAY_DOMAIN = 'privaterelay.appleid.com';
+
+type AppleSignInResult = {
+  readonly data: { readonly provider: 'apple'; readonly url: string };
+  readonly error: null;
+} | {
+  readonly data: { readonly provider: 'apple'; readonly url: null };
+  readonly error: AuthError;
+};
+
+type AppleUserProfile = {
+  readonly email: string | undefined;
+  readonly displayName: string | undefined;
+  readonly isPrivateRelay: boolean;
+};
+
+function isApplePrivateRelayEmail(email: string): boolean {
+  return email.endsWith(`@${APPLE_PRIVATE_RELAY_DOMAIN}`);
+}
+
+/**
+ * Initiates Apple Sign-In via Supabase OAuth.
+ *
+ * Scopes are limited to `name email` per ADR-012 (minimum OAuth data).
+ * Apple only returns the user's name on the FIRST sign-in — after that,
+ * the identity provider no longer includes it. The caller must cache the
+ * display name immediately via `extractAppleUserProfile` after the
+ * redirect callback.
+ */
+async function signInWithApple(
+  client: SupabaseClient,
+  redirectTo?: string,
+): Promise<AppleSignInResult> {
+  const options: { readonly scopes: string; readonly redirectTo?: string } =
+    redirectTo !== undefined
+      ? { scopes: 'name email', redirectTo }
+      : { scopes: 'name email' };
+
+  const { data, error } = await client.auth.signInWithOAuth({
+    provider: 'apple',
+    options,
+  });
+
+  if (error !== null) {
+    return {
+      data: { provider: 'apple', url: null },
+      error,
+    };
+  }
+
+  return {
+    data: { provider: 'apple', url: data.url },
+    error: null,
+  };
+}
+
+/**
+ * Extracts the user profile from the Supabase auth session after an
+ * Apple Sign-In callback completes. Detects private relay emails and
+ * extracts the display name from Apple's identity data.
+ *
+ * Apple only sends the user's full name on the FIRST login. On subsequent
+ * logins, `displayName` will be `undefined`. The caller is responsible for
+ * caching the name in the `profiles` table on first login.
+ */
+function extractAppleUserProfile(
+  identityData: Record<string, unknown> | undefined,
+): AppleUserProfile {
+  if (identityData === undefined) {
+    return { email: undefined, displayName: undefined, isPrivateRelay: false };
+  }
+
+  const email = typeof identityData['email'] === 'string'
+    ? identityData['email']
+    : undefined;
+
+  const isPrivateRelay = email !== undefined
+    ? isApplePrivateRelayEmail(email)
+    : false;
+
+  const fullName = identityData['full_name'];
+  const displayName = extractDisplayName(fullName, identityData);
+
+  return { email, displayName, isPrivateRelay };
+}
+
+function extractDisplayName(
+  fullName: unknown,
+  identityData: Record<string, unknown>,
+): string | undefined {
+  // Apple sends name as a structured object: { firstName, lastName }
+  if (typeof fullName === 'object' && fullName !== null) {
+    const nameObj = fullName as Record<string, unknown>;
+    const firstName = typeof nameObj['firstName'] === 'string' ? nameObj['firstName'] : undefined;
+    const lastName = typeof nameObj['lastName'] === 'string' ? nameObj['lastName'] : undefined;
+
+    if (firstName !== undefined && lastName !== undefined) {
+      return `${firstName} ${lastName}`;
+    }
+    if (firstName !== undefined) {
+      return firstName;
+    }
+    if (lastName !== undefined) {
+      return lastName;
+    }
+  }
+
+  // Fallback: some Supabase versions put name at the top level
+  if (typeof identityData['name'] === 'string' && identityData['name'].length > 0) {
+    return identityData['name'];
+  }
+
+  return undefined;
+}
+
+export { signInWithApple, extractAppleUserProfile, isApplePrivateRelayEmail };
+export type { AppleSignInResult, AppleUserProfile };

--- a/packages/data-access/src/index.ts
+++ b/packages/data-access/src/index.ts
@@ -33,3 +33,9 @@ export type {
   AuthStateChangeCallback,
   Unsubscribe,
 } from './auth';
+export {
+  signInWithApple,
+  extractAppleUserProfile,
+  isApplePrivateRelayEmail,
+} from './auth/oauth';
+export type { AppleSignInResult, AppleUserProfile } from './auth/oauth';


### PR DESCRIPTION
## Summary

- Implements `signInWithApple()` function that initiates Apple OAuth via Supabase Auth with `name email` scopes per ADR-012
- Adds `extractAppleUserProfile()` to parse identity data after callback, handling Apple's first-login-only name behavior and private relay emails
- Exports `isApplePrivateRelayEmail()` utility for detecting `@privaterelay.appleid.com` addresses
- Returns typed results (no thrown exceptions) — all functions return discriminated union results

Closes #278

## Test plan

- [x] `signInWithApple()` calls Supabase with correct provider (`apple`) and scopes (`name email`)
- [x] `redirectTo` parameter forwarded to Supabase options when provided, omitted when undefined
- [x] Auth errors returned in typed result, not thrown
- [x] `extractAppleUserProfile()` extracts email and display name from first-login identity data
- [x] Returning users (no name in identity data) get `undefined` displayName
- [x] Private relay emails (`@privaterelay.appleid.com`) correctly detected
- [x] Handles edge cases: empty identity data, non-string values, first-name-only, last-name-only
- [x] 278 lines of tests covering all acceptance criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)