### PR TITLE
feat: implement auth module in packages/data-access

### DIFF
--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -12,8 +12,9 @@
     }
   },
   "dependencies": {
-    "@pomofocus/types": "workspace:*",
     "@pomofocus/core": "workspace:*",
+    "@pomofocus/types": "workspace:*",
+    "@supabase/supabase-js": "^2.99.1",
     "openapi-fetch": "^0.14.0"
   },
   "devDependencies": {

--- a/packages/data-access/src/auth/client.test.ts
+++ b/packages/data-access/src/auth/client.test.ts
@@ -1,0 +1,513 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  signUp,
+  signIn,
+  signOut,
+  signInWithOAuth,
+  getSession,
+  getAccessToken,
+  onAuthStateChange,
+  createAuthClient,
+} from './client';
+import type { AuthClientConfig } from './client';
+import type {
+  AuthSession,
+  AuthResult,
+  OAuthProvider,
+  Unsubscribe,
+} from './types';
+
+function makeSession(overrides?: Partial<{
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+  user: {
+    id: string;
+    email: string;
+    user_metadata: Record<string, unknown>;
+  };
+}>): {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+  user: {
+    id: string;
+    email: string;
+    user_metadata: Record<string, unknown>;
+  };
+} {
+  return {
+    access_token: 'eyJ-access-token',
+    refresh_token: 'eyJ-refresh-token',
+    expires_at: 1700000000,
+    user: {
+      id: 'user-123',
+      email: 'test@example.com',
+      user_metadata: { full_name: 'Test User' },
+    },
+    ...overrides,
+  };
+}
+
+function makeSupabaseError(
+  message: string,
+  status: number,
+): { message: string; status: number; name: string; __isAuthError: boolean } {
+  return { message, status, name: 'AuthError', __isAuthError: true };
+}
+
+type MockAuth = {
+  signUp: ReturnType<typeof vi.fn>;
+  signInWithPassword: ReturnType<typeof vi.fn>;
+  signOut: ReturnType<typeof vi.fn>;
+  signInWithOAuth: ReturnType<typeof vi.fn>;
+  getSession: ReturnType<typeof vi.fn>;
+  onAuthStateChange: ReturnType<typeof vi.fn>;
+};
+
+function createMockClient(authOverrides?: Partial<MockAuth>): {
+  client: SupabaseClient;
+  auth: MockAuth;
+} {
+  const auth: MockAuth = {
+    signUp: vi.fn(),
+    signInWithPassword: vi.fn(),
+    signOut: vi.fn(),
+    signInWithOAuth: vi.fn(),
+    getSession: vi.fn(),
+    onAuthStateChange: vi.fn(),
+    ...authOverrides,
+  };
+
+  const client = { auth } as unknown as SupabaseClient;
+  return { client, auth };
+}
+
+describe('createAuthClient', () => {
+  it('returns a SupabaseClient instance', () => {
+    const config: AuthClientConfig = {
+      supabaseUrl: 'https://example.supabase.co',
+      supabaseAnonKey: 'test-anon-key',
+    };
+
+    const client = createAuthClient(config);
+    expect(client).toBeDefined();
+    expect(client.auth).toBeDefined();
+  });
+});
+
+describe('signUp', () => {
+  let client: SupabaseClient;
+  let auth: MockAuth;
+
+  beforeEach(() => {
+    ({ client, auth } = createMockClient());
+  });
+
+  it('returns mapped session on successful signup', async () => {
+    const session = makeSession();
+    auth.signUp.mockResolvedValue({
+      data: { user: session.user, session },
+      error: null,
+    });
+
+    const result: AuthResult<AuthSession> = await signUp(client, 'test@example.com', 'password123');
+
+    expect(result.error).toBeUndefined();
+    expect(result.data).toBeDefined();
+    expect(result.data?.accessToken).toBe('eyJ-access-token');
+    expect(result.data?.refreshToken).toBe('eyJ-refresh-token');
+    expect(result.data?.expiresAt).toBe(1700000000);
+    expect(result.data?.user.id).toBe('user-123');
+    expect(result.data?.user.email).toBe('test@example.com');
+    expect(result.data?.user.displayName).toBe('Test User');
+  });
+
+  it('returns error on signup failure', async () => {
+    auth.signUp.mockResolvedValue({
+      data: { user: null, session: null },
+      error: makeSupabaseError('Email already registered', 422),
+    });
+
+    const result: AuthResult<AuthSession> = await signUp(client, 'existing@example.com', 'password123');
+
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toBe('Email already registered');
+    expect(result.error?.status).toBe(422);
+  });
+
+  it('returns undefined data when signup requires email confirmation', async () => {
+    auth.signUp.mockResolvedValue({
+      data: {
+        user: { id: 'user-123', email: 'test@example.com', user_metadata: {} },
+        session: null,
+      },
+      error: null,
+    });
+
+    const result: AuthResult<AuthSession> = await signUp(client, 'test@example.com', 'password123');
+
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeUndefined();
+  });
+});
+
+describe('signIn', () => {
+  let client: SupabaseClient;
+  let auth: MockAuth;
+
+  beforeEach(() => {
+    ({ client, auth } = createMockClient());
+  });
+
+  it('returns mapped session on successful sign in', async () => {
+    const session = makeSession();
+    auth.signInWithPassword.mockResolvedValue({
+      data: { user: session.user, session },
+      error: null,
+    });
+
+    const result: AuthResult<AuthSession> = await signIn(client, 'test@example.com', 'password123');
+
+    expect(result.error).toBeUndefined();
+    expect(result.data).toBeDefined();
+    expect(result.data?.accessToken).toBe('eyJ-access-token');
+    expect(result.data?.user.email).toBe('test@example.com');
+  });
+
+  it('returns error on invalid credentials', async () => {
+    auth.signInWithPassword.mockResolvedValue({
+      data: { user: null, session: null },
+      error: makeSupabaseError('Invalid login credentials', 400),
+    });
+
+    const result: AuthResult<AuthSession> = await signIn(client, 'test@example.com', 'wrong');
+
+    expect(result.data).toBeUndefined();
+    expect(result.error?.message).toBe('Invalid login credentials');
+    expect(result.error?.status).toBe(400);
+  });
+});
+
+describe('signOut', () => {
+  let client: SupabaseClient;
+  let auth: MockAuth;
+
+  beforeEach(() => {
+    ({ client, auth } = createMockClient());
+  });
+
+  it('returns no error on successful sign out', async () => {
+    auth.signOut.mockResolvedValue({ error: null });
+
+    const result: AuthResult<undefined> = await signOut(client);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data).toBeUndefined();
+  });
+
+  it('returns error on sign out failure', async () => {
+    auth.signOut.mockResolvedValue({
+      error: makeSupabaseError('Session not found', 400),
+    });
+
+    const result: AuthResult<undefined> = await signOut(client);
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toBe('Session not found');
+  });
+});
+
+describe('signInWithOAuth', () => {
+  let client: SupabaseClient;
+  let auth: MockAuth;
+
+  beforeEach(() => {
+    ({ client, auth } = createMockClient());
+  });
+
+  it('returns OAuth URL on success', async () => {
+    auth.signInWithOAuth.mockResolvedValue({
+      data: { provider: 'google', url: 'https://accounts.google.com/o/oauth2/v2/auth?...' },
+      error: null,
+    });
+
+    const provider: OAuthProvider = 'google';
+    const result: AuthResult<{ url: string }> = await signInWithOAuth(client, provider);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data?.url).toContain('https://accounts.google.com');
+  });
+
+  it('returns error when OAuth fails', async () => {
+    auth.signInWithOAuth.mockResolvedValue({
+      data: { provider: 'google', url: '' },
+      error: makeSupabaseError('Provider not configured', 400),
+    });
+
+    const result: AuthResult<{ url: string }> = await signInWithOAuth(client, 'google');
+
+    expect(result.data).toBeUndefined();
+    expect(result.error?.message).toBe('Provider not configured');
+  });
+
+  it('returns error when OAuth URL is empty', async () => {
+    auth.signInWithOAuth.mockResolvedValue({
+      data: { provider: 'google', url: '' },
+      error: null,
+    });
+
+    const result: AuthResult<{ url: string }> = await signInWithOAuth(client, 'google');
+
+    expect(result.data).toBeUndefined();
+    expect(result.error?.message).toBe('OAuth URL not returned');
+  });
+});
+
+describe('getSession', () => {
+  let client: SupabaseClient;
+  let auth: MockAuth;
+
+  beforeEach(() => {
+    ({ client, auth } = createMockClient());
+  });
+
+  it('returns mapped session when session exists', async () => {
+    const session = makeSession();
+    auth.getSession.mockResolvedValue({
+      data: { session },
+      error: null,
+    });
+
+    const result: AuthResult<AuthSession> = await getSession(client);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data?.accessToken).toBe('eyJ-access-token');
+    expect(result.data?.user.id).toBe('user-123');
+  });
+
+  it('returns undefined data when no session exists', async () => {
+    auth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    const result: AuthResult<AuthSession> = await getSession(client);
+
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns error when session retrieval fails', async () => {
+    auth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: makeSupabaseError('Session expired', 401),
+    });
+
+    const result: AuthResult<AuthSession> = await getSession(client);
+
+    expect(result.data).toBeUndefined();
+    expect(result.error?.message).toBe('Session expired');
+    expect(result.error?.status).toBe(401);
+  });
+});
+
+describe('getAccessToken', () => {
+  let client: SupabaseClient;
+  let auth: MockAuth;
+
+  beforeEach(() => {
+    ({ client, auth } = createMockClient());
+  });
+
+  it('returns the access token when session exists', async () => {
+    const session = makeSession({ access_token: 'my-jwt-token' });
+    auth.getSession.mockResolvedValue({
+      data: { session },
+      error: null,
+    });
+
+    const token: string | undefined = await getAccessToken(client);
+
+    expect(token).toBe('my-jwt-token');
+  });
+
+  it('returns undefined when no session exists', async () => {
+    auth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    const token: string | undefined = await getAccessToken(client);
+
+    expect(token).toBeUndefined();
+  });
+
+  it('returns undefined when session retrieval fails', async () => {
+    auth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: makeSupabaseError('Auth error', 500),
+    });
+
+    const token: string | undefined = await getAccessToken(client);
+
+    expect(token).toBeUndefined();
+  });
+});
+
+describe('onAuthStateChange', () => {
+  it('calls callback with mapped session on state change', () => {
+    const unsubscribeFn = vi.fn();
+    const { client, auth } = createMockClient({
+      onAuthStateChange: vi.fn().mockReturnValue({
+        data: {
+          subscription: { unsubscribe: unsubscribeFn },
+        },
+      }),
+    });
+
+    const events: { event: string; session: AuthSession | undefined }[] = [];
+
+    onAuthStateChange(client, (event, session) => {
+      events.push({ event, session });
+    });
+
+    const registeredCallback = auth.onAuthStateChange.mock.calls[0]?.[0] as
+      | ((event: string, session: unknown) => void)
+      | undefined;
+    expect(registeredCallback).toBeDefined();
+
+    const session = makeSession();
+    registeredCallback?.('SIGNED_IN', session);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.event).toBe('SIGNED_IN');
+    expect(events[0]?.session?.accessToken).toBe('eyJ-access-token');
+    expect(events[0]?.session?.user.id).toBe('user-123');
+  });
+
+  it('calls callback with undefined session on sign out', () => {
+    const unsubscribeFn = vi.fn();
+    const { client, auth } = createMockClient({
+      onAuthStateChange: vi.fn().mockReturnValue({
+        data: {
+          subscription: { unsubscribe: unsubscribeFn },
+        },
+      }),
+    });
+
+    const events: { event: string; session: AuthSession | undefined }[] = [];
+
+    onAuthStateChange(client, (event, session) => {
+      events.push({ event, session });
+    });
+
+    const registeredCallback = auth.onAuthStateChange.mock.calls[0]?.[0] as
+      | ((event: string, session: unknown) => void)
+      | undefined;
+    registeredCallback?.('SIGNED_OUT', null);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.event).toBe('SIGNED_OUT');
+    expect(events[0]?.session).toBeUndefined();
+  });
+
+  it('returns an unsubscribe function', () => {
+    const unsubscribeFn = vi.fn();
+    const { client } = createMockClient({
+      onAuthStateChange: vi.fn().mockReturnValue({
+        data: {
+          subscription: { unsubscribe: unsubscribeFn },
+        },
+      }),
+    });
+
+    const result: Unsubscribe = onAuthStateChange(client, () => {
+      // no-op
+    });
+
+    expect(result.unsubscribe).toBeDefined();
+    result.unsubscribe();
+    expect(unsubscribeFn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('user mapping', () => {
+  let client: SupabaseClient;
+  let auth: MockAuth;
+
+  beforeEach(() => {
+    ({ client, auth } = createMockClient());
+  });
+
+  it('maps name from user_metadata.name when full_name is absent', async () => {
+    const session = makeSession({
+      user: {
+        id: 'user-456',
+        email: 'name@example.com',
+        user_metadata: { name: 'Name Only' },
+      },
+    });
+
+    auth.getSession.mockResolvedValue({
+      data: { session },
+      error: null,
+    });
+
+    const result = await getSession(client);
+    expect(result.data?.user.displayName).toBe('Name Only');
+  });
+
+  it('prefers full_name over name in user_metadata', async () => {
+    const session = makeSession({
+      user: {
+        id: 'user-789',
+        email: 'both@example.com',
+        user_metadata: { full_name: 'Full Name', name: 'Short Name' },
+      },
+    });
+
+    auth.getSession.mockResolvedValue({
+      data: { session },
+      error: null,
+    });
+
+    const result = await getSession(client);
+    expect(result.data?.user.displayName).toBe('Full Name');
+  });
+
+  it('returns undefined displayName when neither full_name nor name exists', async () => {
+    const session = makeSession({
+      user: {
+        id: 'user-000',
+        email: 'no-name@example.com',
+        user_metadata: {},
+      },
+    });
+
+    auth.getSession.mockResolvedValue({
+      data: { session },
+      error: null,
+    });
+
+    const result = await getSession(client);
+    expect(result.data?.user.displayName).toBeUndefined();
+  });
+});
+
+describe('auth module exports', () => {
+  it('exports all required functions from the module entry point', async () => {
+    const authModule = await import('./index');
+
+    expect(typeof authModule.createAuthClient).toBe('function');
+    expect(typeof authModule.signUp).toBe('function');
+    expect(typeof authModule.signIn).toBe('function');
+    expect(typeof authModule.signOut).toBe('function');
+    expect(typeof authModule.signInWithOAuth).toBe('function');
+    expect(typeof authModule.getSession).toBe('function');
+    expect(typeof authModule.getAccessToken).toBe('function');
+    expect(typeof authModule.onAuthStateChange).toBe('function');
+  });
+});

--- a/packages/data-access/src/auth/client.ts
+++ b/packages/data-access/src/auth/client.ts
@@ -1,0 +1,188 @@
+import { createClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  AuthUser,
+  AuthSession,
+  AuthError,
+  AuthResult,
+  OAuthProvider,
+  AuthStateChangeCallback,
+  Unsubscribe,
+} from './types';
+
+type AuthClientConfig = {
+  readonly supabaseUrl: string;
+  readonly supabaseAnonKey: string;
+};
+
+function createAuthClient(config: AuthClientConfig): SupabaseClient {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- createClient generic defaults to `any` database schema
+  return createClient(config.supabaseUrl, config.supabaseAnonKey);
+}
+
+function mapUser(
+  user: { id: string; email?: string | undefined; user_metadata?: Record<string, unknown> },
+): AuthUser {
+  const metadata = user.user_metadata ?? {};
+  const displayName = typeof metadata['full_name'] === 'string'
+    ? metadata['full_name']
+    : typeof metadata['name'] === 'string'
+      ? metadata['name']
+      : undefined;
+
+  const provider = typeof metadata['iss'] === 'string'
+    ? metadata['iss']
+    : undefined;
+
+  return {
+    id: user.id,
+    email: user.email ?? undefined,
+    displayName,
+    provider,
+  };
+}
+
+function mapError(error: { message: string; status: number | undefined }): AuthError {
+  return {
+    message: error.message,
+    status: error.status,
+  };
+}
+
+function mapSession(
+  session: {
+    access_token: string;
+    refresh_token: string;
+    expires_at?: number;
+    user: { id: string; email?: string | undefined; user_metadata?: Record<string, unknown> };
+  },
+): AuthSession {
+  return {
+    accessToken: session.access_token,
+    refreshToken: session.refresh_token,
+    expiresAt: session.expires_at ?? undefined,
+    user: mapUser(session.user),
+  };
+}
+
+async function signUp(
+  client: SupabaseClient,
+  email: string,
+  password: string,
+): Promise<AuthResult<AuthSession>> {
+  const { data, error } = await client.auth.signUp({ email, password });
+
+  if (error !== null) {
+    return { data: undefined, error: mapError(error) };
+  }
+
+  if (data.session === null) {
+    return { data: undefined, error: undefined };
+  }
+
+  return { data: mapSession(data.session), error: undefined };
+}
+
+async function signIn(
+  client: SupabaseClient,
+  email: string,
+  password: string,
+): Promise<AuthResult<AuthSession>> {
+  const { data, error } = await client.auth.signInWithPassword({ email, password });
+
+  if (error !== null) {
+    return { data: undefined, error: mapError(error) };
+  }
+
+  return { data: mapSession(data.session), error: undefined };
+}
+
+async function signOut(client: SupabaseClient): Promise<AuthResult<undefined>> {
+  const { error } = await client.auth.signOut();
+
+  if (error !== null) {
+    return { data: undefined, error: mapError(error) };
+  }
+
+  return { data: undefined, error: undefined };
+}
+
+async function signInWithOAuth(
+  client: SupabaseClient,
+  provider: OAuthProvider,
+): Promise<AuthResult<{ url: string }>> {
+  const { data, error } = await client.auth.signInWithOAuth({ provider });
+
+  if (error !== null) {
+    return { data: undefined, error: mapError(error) };
+  }
+
+  if (data.url.length === 0) {
+    return {
+      data: undefined,
+      error: { message: 'OAuth URL not returned', status: undefined },
+    };
+  }
+
+  return { data: { url: data.url }, error: undefined };
+}
+
+async function getSession(
+  client: SupabaseClient,
+): Promise<AuthResult<AuthSession>> {
+  const { data, error } = await client.auth.getSession();
+
+  if (error !== null) {
+    return { data: undefined, error: mapError(error) };
+  }
+
+  if (data.session === null) {
+    return { data: undefined, error: undefined };
+  }
+
+  return { data: mapSession(data.session), error: undefined };
+}
+
+async function getAccessToken(
+  client: SupabaseClient,
+): Promise<string | undefined> {
+  const { data, error } = await client.auth.getSession();
+
+  if (error !== null) {
+    return undefined;
+  }
+
+  if (data.session === null) {
+    return undefined;
+  }
+
+  return data.session.access_token;
+}
+
+function onAuthStateChange(
+  client: SupabaseClient,
+  callback: AuthStateChangeCallback,
+): Unsubscribe {
+  const { data } = client.auth.onAuthStateChange((event, session) => {
+    const mappedSession = session !== null ? mapSession(session) : undefined;
+    callback(event, mappedSession);
+  });
+
+  return {
+    unsubscribe: () => {
+      data.subscription.unsubscribe();
+    },
+  };
+}
+
+export {
+  createAuthClient,
+  signUp,
+  signIn,
+  signOut,
+  signInWithOAuth,
+  getSession,
+  getAccessToken,
+  onAuthStateChange,
+};
+export type { AuthClientConfig };

--- a/packages/data-access/src/auth/index.ts
+++ b/packages/data-access/src/auth/index.ts
@@ -1,0 +1,20 @@
+export {
+  createAuthClient,
+  signUp,
+  signIn,
+  signOut,
+  signInWithOAuth,
+  getSession,
+  getAccessToken,
+  onAuthStateChange,
+} from './client';
+export type { AuthClientConfig } from './client';
+export type {
+  AuthUser,
+  AuthSession,
+  AuthError,
+  AuthResult,
+  OAuthProvider,
+  AuthStateChangeCallback,
+  Unsubscribe,
+} from './types';

--- a/packages/data-access/src/auth/types.ts
+++ b/packages/data-access/src/auth/types.ts
@@ -1,0 +1,46 @@
+import type { Provider } from '@supabase/supabase-js';
+
+type AuthUser = {
+  readonly id: string;
+  readonly email: string | undefined;
+  readonly displayName: string | undefined;
+  readonly provider: string | undefined;
+};
+
+type AuthSession = {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly expiresAt: number | undefined;
+  readonly user: AuthUser;
+};
+
+type AuthError = {
+  readonly message: string;
+  readonly status: number | undefined;
+};
+
+type AuthResult<T> = {
+  readonly data: T | undefined;
+  readonly error: AuthError | undefined;
+};
+
+type OAuthProvider = Provider;
+
+type AuthStateChangeCallback = (
+  event: string,
+  session: AuthSession | undefined,
+) => void;
+
+type Unsubscribe = {
+  readonly unsubscribe: () => void;
+};
+
+export type {
+  AuthUser,
+  AuthSession,
+  AuthError,
+  AuthResult,
+  OAuthProvider,
+  AuthStateChangeCallback,
+  Unsubscribe,
+};

--- a/packages/data-access/src/index.ts
+++ b/packages/data-access/src/index.ts
@@ -13,3 +13,23 @@ export type {
   CreateSessionResult,
   GetSessionsResult,
 } from './sessions';
+export {
+  createAuthClient,
+  signUp,
+  signIn,
+  signOut,
+  signInWithOAuth,
+  getSession,
+  getAccessToken,
+  onAuthStateChange,
+} from './auth';
+export type {
+  AuthClientConfig,
+  AuthUser,
+  AuthSession,
+  AuthError,
+  AuthResult,
+  OAuthProvider,
+  AuthStateChangeCallback,
+  Unsubscribe,
+} from './auth';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       '@pomofocus/types':
         specifier: workspace:*
         version: link:../types
+      '@supabase/supabase-js':
+        specifier: ^2.99.1
+        version: 2.99.1
       openapi-fetch:
         specifier: ^0.14.0
         version: 0.14.1


### PR DESCRIPTION
## Summary

- Implements the auth module (`packages/data-access/src/auth/`) that wraps Supabase Auth SDK calls, providing `signUp`, `signIn`, `signOut`, `signInWithOAuth`, `getSession`, `getAccessToken`, and `onAuthStateChange`
- Defines mapped auth types (`AuthUser`, `AuthSession`, `AuthError`, `AuthResult`) that decouple the rest of the codebase from Supabase Auth internals (ADR-002)
- Adds comprehensive unit tests (513 lines) covering all auth functions, error paths, session mapping, and user metadata resolution

Closes #275

## Test plan

- [ ] `pnpm nx test @pomofocus/data-access` passes
- [ ] Auth module exports all 8 required functions (`createAuthClient`, `signUp`, `signIn`, `signOut`, `signInWithOAuth`, `getSession`, `getAccessToken`, `onAuthStateChange`)
- [ ] All auth types are re-exported from `packages/data-access/src/index.ts`
- [ ] No Supabase Auth imports exist outside `packages/data-access/src/auth/`
- [ ] TypeScript compilation succeeds with strict mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)