### PR TITLE
feat: implement email signup and login flows

### DIFF
--- a/packages/data-access/src/auth/email.test.ts
+++ b/packages/data-access/src/auth/email.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { signUpWithEmail, signInWithEmail } from './email';
+import type { SupabaseClient, AuthError, Session, User } from '@supabase/supabase-js';
+import type { Mock } from 'vitest';
+
+function createMockSession(userId: string): Session {
+  return {
+    access_token: 'mock-access-token',
+    refresh_token: 'mock-refresh-token',
+    expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    token_type: 'bearer',
+    user: createMockUser(userId),
+  };
+}
+
+function createMockUser(userId: string): User {
+  return {
+    id: userId,
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: 'test@example.com',
+    email_confirmed_at: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    app_metadata: {},
+    user_metadata: {},
+  };
+}
+
+function createAuthError(message: string, status: number): AuthError {
+  const error = new Error(message) as AuthError;
+  error.name = 'AuthApiError';
+  error.status = status;
+  error.code = undefined;
+  return error;
+}
+
+type MockSupabase = {
+  readonly client: SupabaseClient;
+  readonly signUpMock: Mock;
+  readonly signInWithPasswordMock: Mock;
+};
+
+function createMockSupabase(overrides: {
+  signUp?: ReturnType<SupabaseClient['auth']['signUp']>;
+  signInWithPassword?: ReturnType<SupabaseClient['auth']['signInWithPassword']>;
+}): MockSupabase {
+  const signUpMock = vi.fn().mockReturnValue(
+    overrides.signUp ?? Promise.resolve({ data: { user: null, session: null }, error: null }),
+  );
+  const signInWithPasswordMock = vi.fn().mockReturnValue(
+    overrides.signInWithPassword ?? Promise.resolve({ data: { user: null, session: null }, error: null }),
+  );
+
+  const client = {
+    auth: {
+      signUp: signUpMock,
+      signInWithPassword: signInWithPasswordMock,
+    },
+  } as unknown as SupabaseClient;
+
+  return { client, signUpMock, signInWithPasswordMock };
+}
+
+describe('signUpWithEmail', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns session and userId on successful signup', async () => {
+    const userId = '550e8400-e29b-41d4-a716-446655440000';
+    const session = createMockSession(userId);
+    const user = createMockUser(userId);
+
+    const { client } = createMockSupabase({
+      signUp: Promise.resolve({
+        data: { user, session },
+        error: null,
+      }),
+    });
+
+    const result = await signUpWithEmail(client, 'test@example.com', 'password123', 'Test User');
+
+    expect(result.session).toBe(session);
+    expect(result.userId).toBe(userId);
+    expect(result.error).toBeNull();
+  });
+
+  it('passes displayName as user_metadata', async () => {
+    const { client, signUpMock } = createMockSupabase({
+      signUp: Promise.resolve({
+        data: { user: null, session: null },
+        error: null,
+      }),
+    });
+
+    await signUpWithEmail(client, 'test@example.com', 'password123', 'My Name');
+
+    expect(signUpMock).toHaveBeenCalledWith({
+      email: 'test@example.com',
+      password: 'password123',
+      options: {
+        data: {
+          display_name: 'My Name',
+        },
+      },
+    });
+  });
+
+  it('returns AuthError for duplicate email', async () => {
+    const authError = createAuthError('User already registered', 422);
+
+    const { client } = createMockSupabase({
+      signUp: Promise.resolve({
+        data: { user: null, session: null },
+        error: authError,
+      }),
+    });
+
+    const result = await signUpWithEmail(client, 'existing@example.com', 'password123', 'Test User');
+
+    expect(result.session).toBeNull();
+    expect(result.userId).toBeNull();
+    expect(result.error).toBe(authError);
+    expect(result.error?.message).toBe('User already registered');
+  });
+
+  it('returns AuthError for weak password', async () => {
+    const authError = createAuthError('Password should be at least 8 characters', 422);
+
+    const { client } = createMockSupabase({
+      signUp: Promise.resolve({
+        data: { user: null, session: null },
+        error: authError,
+      }),
+    });
+
+    const result = await signUpWithEmail(client, 'test@example.com', 'short', 'Test User');
+
+    expect(result.session).toBeNull();
+    expect(result.userId).toBeNull();
+    expect(result.error).toBe(authError);
+    expect(result.error?.message).toBe('Password should be at least 8 characters');
+  });
+
+  it('returns null userId when user is null in response', async () => {
+    const session = createMockSession('some-id');
+
+    const { client } = createMockSupabase({
+      signUp: Promise.resolve({
+        data: { user: null, session },
+        error: null,
+      }),
+    });
+
+    const result = await signUpWithEmail(client, 'test@example.com', 'password123', 'Test User');
+
+    expect(result.session).toBe(session);
+    expect(result.userId).toBeNull();
+    expect(result.error).toBeNull();
+  });
+});
+
+describe('signInWithEmail', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns session and userId on successful signin', async () => {
+    const userId = '550e8400-e29b-41d4-a716-446655440001';
+    const session = createMockSession(userId);
+    const user = createMockUser(userId);
+
+    const { client } = createMockSupabase({
+      signInWithPassword: Promise.resolve({
+        data: { user, session },
+        error: null,
+      }),
+    });
+
+    const result = await signInWithEmail(client, 'test@example.com', 'password123');
+
+    expect(result.session).toBe(session);
+    expect(result.userId).toBe(userId);
+    expect(result.error).toBeNull();
+  });
+
+  it('returns AuthError for wrong password', async () => {
+    const authError = createAuthError('Invalid login credentials', 400);
+
+    const { client } = createMockSupabase({
+      signInWithPassword: Promise.resolve({
+        data: { user: null, session: null },
+        error: authError,
+      }),
+    });
+
+    const result = await signInWithEmail(client, 'test@example.com', 'wrongpassword');
+
+    expect(result.session).toBeNull();
+    expect(result.userId).toBeNull();
+    expect(result.error).toBe(authError);
+    expect(result.error?.message).toBe('Invalid login credentials');
+    expect(result.error?.status).toBe(400);
+  });
+
+  it('returns AuthError for non-existent user', async () => {
+    const authError = createAuthError('Invalid login credentials', 400);
+
+    const { client } = createMockSupabase({
+      signInWithPassword: Promise.resolve({
+        data: { user: null, session: null },
+        error: authError,
+      }),
+    });
+
+    const result = await signInWithEmail(client, 'nonexistent@example.com', 'password123');
+
+    expect(result.session).toBeNull();
+    expect(result.userId).toBeNull();
+    expect(result.error).toBe(authError);
+  });
+
+  it('calls signInWithPassword with correct arguments', async () => {
+    const { client, signInWithPasswordMock } = createMockSupabase({
+      signInWithPassword: Promise.resolve({
+        data: { user: createMockUser('id'), session: createMockSession('id') },
+        error: null,
+      }),
+    });
+
+    await signInWithEmail(client, 'user@test.com', 'mypassword');
+
+    expect(signInWithPasswordMock).toHaveBeenCalledWith({
+      email: 'user@test.com',
+      password: 'mypassword',
+    });
+  });
+});

--- a/packages/data-access/src/auth/email.ts
+++ b/packages/data-access/src/auth/email.ts
@@ -1,0 +1,64 @@
+import type { SupabaseClient, AuthError, Session } from '@supabase/supabase-js';
+
+type SignUpResult = {
+  readonly session: Session | null;
+  readonly userId: string | null;
+  readonly error: AuthError | null;
+};
+
+type SignInResult = {
+  readonly session: Session | null;
+  readonly userId: string | null;
+  readonly error: AuthError | null;
+};
+
+async function signUpWithEmail(
+  supabase: SupabaseClient,
+  email: string,
+  password: string,
+  displayName: string,
+): Promise<SignUpResult> {
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      data: {
+        display_name: displayName,
+      },
+    },
+  });
+
+  if (error !== null) {
+    return { session: null, userId: null, error };
+  }
+
+  return {
+    session: data.session,
+    userId: data.user?.id ?? null,
+    error: null,
+  };
+}
+
+async function signInWithEmail(
+  supabase: SupabaseClient,
+  email: string,
+  password: string,
+): Promise<SignInResult> {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error !== null) {
+    return { session: null, userId: null, error };
+  }
+
+  return {
+    session: data.session,
+    userId: data.user.id,
+    error: null,
+  };
+}
+
+export { signUpWithEmail, signInWithEmail };
+export type { SignUpResult, SignInResult };

--- a/packages/data-access/src/index.ts
+++ b/packages/data-access/src/index.ts
@@ -47,3 +47,5 @@ export type {
   SignInWithGoogleResult,
   ExchangeCodeResult,
 } from './auth/oauth';
+export { signUpWithEmail, signInWithEmail } from './auth/email';
+export type { SignUpResult, SignInResult } from './auth/email';

--- a/supabase/migrations/20260322000007_create_profile_on_signup.sql
+++ b/supabase/migrations/20260322000007_create_profile_on_signup.sql
@@ -1,0 +1,43 @@
+-- Migration: Create profile row automatically on user signup
+-- Issue: #276
+-- Reference: ADR-002, ADR-005
+--
+-- When a user signs up via Supabase Auth, a trigger creates
+-- a corresponding profiles row. The display_name is read from
+-- user_metadata (set during signUp). A username is generated
+-- from the email prefix with a random suffix to ensure uniqueness.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  _display_name text;
+  _username     text;
+  _base         text;
+  _suffix       text;
+BEGIN
+  -- Extract display_name from user_metadata, fall back to email prefix
+  _display_name := COALESCE(
+    NEW.raw_user_meta_data ->> 'display_name',
+    split_part(NEW.email, '@', 1)
+  );
+
+  -- Generate a username from the email prefix + random suffix
+  _base := lower(regexp_replace(split_part(NEW.email, '@', 1), '[^a-zA-Z0-9]', '', 'g'));
+  _suffix := lpad(floor(random() * 10000)::text, 4, '0');
+  _username := _base || _suffix;
+
+  INSERT INTO public.profiles (auth_user_id, display_name, username)
+  VALUES (NEW.id, _display_name, _username);
+
+  RETURN NEW;
+END;
+$$;
+
+-- Trigger fires after a new row is inserted into auth.users
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_new_user();


### PR DESCRIPTION
## Summary

- Implement `signUpWithEmail()` and `signInWithEmail()` functions in `packages/data-access/src/auth/email.ts` wrapping Supabase Auth SDK
- Add database trigger migration (`create_profile_on_signup`) that automatically creates a `profiles` row when a new user signs up via `auth.users`
- Add comprehensive test suite covering signup, signin, error handling (wrong password, duplicate email), and typed `AuthError` returns
- Export auth functions from `packages/data-access/src/index.ts`

Closes #276

## Test plan

- [ ] `pnpm nx test @pomofocus/data-access` passes
- [ ] Signup with valid email/password returns session with user ID
- [ ] Signin with correct credentials returns session
- [ ] Signin with wrong password returns AuthError (not thrown exception)
- [ ] Duplicate signup returns appropriate error
- [ ] Profile row created automatically via database trigger after signup

🤖 Generated with [Claude Code](https://claude.com/claude-code)