### PR TITLE
feat: implement idle, goal selection, and session complete e-ink screens

### DIFF
--- a/firmware/device/src/display.cpp
+++ b/firmware/device/src/display.cpp
@@ -28,6 +28,7 @@
 #include <SPI.h>
 #include <Adafruit_GFX.h>
 #include <nrf_gpio.h>
+#include <cstring>
 
 // ---------- Pin definitions (Feather variant Arduino pin numbers) ----------
 // These are indices into g_ADigitalPinMap that resolve to the correct
@@ -129,6 +130,263 @@ void showTestPattern() {
     } while (display.nextPage());
 
     Serial.println("Test pattern displayed");
+}
+
+// ---------- Layout constants ----------
+// Adafruit GFX default font: 5x7 px per character at size 1.
+// Character width at scale S = 6*S px (5px glyph + 1px spacing).
+// Character height at scale S = 8*S px (7px glyph + 1px spacing).
+constexpr int16_t CHAR_W_BASE = 6;
+constexpr int16_t CHAR_H_BASE = 8;
+
+// Margins and padding
+constexpr int16_t MARGIN_X = 40;
+constexpr int16_t MARGIN_TOP = 40;
+
+// Goal list layout
+constexpr int16_t GOAL_ROW_HEIGHT = 52;
+constexpr int16_t GOAL_ROW_PAD_X = 12;
+constexpr int16_t GOAL_ROW_PAD_Y = 10;
+
+// Maximum characters that fit in the goal list area at text size 2.
+// Usable width = 800 - 2*40(margin) - 2*12(row padding) - 160(progress) = 536px
+// At size 2: 536 / 12 = 44 chars. Truncate at MAX_GOAL_TITLE_LEN (40) + ellipsis.
+constexpr uint8_t GOAL_DISPLAY_MAX_CHARS = 38;
+
+// ---------- Helpers ----------
+
+// Copy src into dst, truncating with "..." if longer than maxChars.
+// dst must have room for maxChars + 3 (ellipsis) + 1 (null).
+static void truncateTitle(char* dst, uint8_t dstSize,
+                          const char* src, uint8_t maxChars) {
+    uint8_t len = static_cast<uint8_t>(strlen(src));
+    if (len <= maxChars) {
+        strncpy(dst, src, dstSize - 1);
+        dst[dstSize - 1] = '\0';
+    } else {
+        // Truncate and append ellipsis
+        uint8_t copyLen = (maxChars >= 3) ? (maxChars - 3) : 0;
+        if (copyLen >= dstSize) {
+            copyLen = dstSize - 4;
+        }
+        memcpy(dst, src, copyLen);
+        dst[copyLen]     = '.';
+        dst[copyLen + 1] = '.';
+        dst[copyLen + 2] = '.';
+        dst[copyLen + 3] = '\0';
+    }
+}
+
+// Draw text centered horizontally at the given y coordinate.
+static void drawCenteredText(const char* text, uint8_t textSize, int16_t y) {
+    int16_t textLen = static_cast<int16_t>(strlen(text));
+    int16_t textW = textLen * CHAR_W_BASE * textSize;
+    int16_t x = (WIDTH - textW) / 2;
+    display.setTextSize(textSize);
+    display.setCursor(x, y);
+    display.print(text);
+}
+
+void showIdleScreen(uint8_t sessionsToday, const char* currentGoalTitle) {
+    // Layout (centered vertically on 480px):
+    //   "PomoFocus" at size 3            — branding
+    //   "Ready to focus" at size 4       — main message
+    //   "N sessions today" at size 2     — counter
+    //   "[goal title]" at size 2         — current goal
+
+    // Vertical centering: total content height ~200px, start at ~120px
+    constexpr int16_t Y_BRAND   = 120;
+    constexpr int16_t Y_HEADING = 180;
+    constexpr int16_t Y_COUNTER = 260;
+    constexpr int16_t Y_GOAL    = 310;
+
+    // Format session count string (fixed buffer, NAT-F01)
+    char counterBuf[32];
+    snprintf(counterBuf, sizeof(counterBuf), "%u session%s today",
+             sessionsToday, (sessionsToday == 1) ? "" : "s");
+
+    // Truncate goal title for display
+    char goalBuf[MAX_GOAL_TITLE_LEN + 4];
+    if (currentGoalTitle != nullptr && currentGoalTitle[0] != '\0') {
+        truncateTitle(goalBuf, sizeof(goalBuf), currentGoalTitle,
+                      GOAL_DISPLAY_MAX_CHARS);
+    } else {
+        strncpy(goalBuf, "No goal selected", sizeof(goalBuf) - 1);
+        goalBuf[sizeof(goalBuf) - 1] = '\0';
+    }
+
+    display.setTextColor(GxEPD_BLACK);
+    display.setFullWindow();
+    display.firstPage();
+    do {
+        display.fillScreen(GxEPD_WHITE);
+
+        drawCenteredText("PomoFocus", 3, Y_BRAND);
+        drawCenteredText("Ready to focus", 4, Y_HEADING);
+        drawCenteredText(counterBuf, 2, Y_COUNTER);
+        drawCenteredText(goalBuf, 2, Y_GOAL);
+    } while (display.nextPage());
+
+    Serial.println("Idle screen displayed");
+}
+
+void showGoalScreen(const GoalInfo* goals, uint8_t goalCount,
+                    uint8_t selectedIndex) {
+    // Layout:
+    //   "Select Goal" heading at size 3 — top
+    //   List of goals with progress — scrollable area
+    //   Selected goal: inverted (white text on black background)
+    //   Each row: "[title]    N/M" with progress fraction right-aligned
+
+    constexpr int16_t HEADING_Y = MARGIN_TOP;
+    constexpr int16_t LIST_START_Y = HEADING_Y + CHAR_H_BASE * 3 + 30;
+    constexpr int16_t LIST_WIDTH = WIDTH - 2 * MARGIN_X;
+
+    // Maximum visible rows that fit in the remaining screen height
+    constexpr int16_t AVAILABLE_HEIGHT = HEIGHT - LIST_START_Y - 20;
+    constexpr uint8_t MAX_VISIBLE_ROWS =
+        static_cast<uint8_t>(AVAILABLE_HEIGHT / GOAL_ROW_HEIGHT);
+
+    // Scroll offset: keep selected item visible
+    uint8_t scrollOffset = 0;
+    if (selectedIndex >= MAX_VISIBLE_ROWS) {
+        scrollOffset = selectedIndex - MAX_VISIBLE_ROWS + 1;
+    }
+
+    display.setTextColor(GxEPD_BLACK);
+    display.setFullWindow();
+    display.firstPage();
+    do {
+        display.fillScreen(GxEPD_WHITE);
+
+        // Heading
+        drawCenteredText("Select Goal", 3, HEADING_Y);
+
+        // Divider line under heading
+        int16_t divY = LIST_START_Y - 8;
+        display.drawLine(MARGIN_X, divY, WIDTH - MARGIN_X, divY, GxEPD_BLACK);
+
+        // Goal list
+        uint8_t visibleCount = goalCount - scrollOffset;
+        if (visibleCount > MAX_VISIBLE_ROWS) {
+            visibleCount = MAX_VISIBLE_ROWS;
+        }
+
+        for (uint8_t i = 0; i < visibleCount; i++) {
+            uint8_t goalIdx = scrollOffset + i;
+            int16_t rowY = LIST_START_Y + i * GOAL_ROW_HEIGHT;
+            bool isSelected = (goalIdx == selectedIndex);
+
+            // Row background: inverted for selected
+            if (isSelected) {
+                display.fillRect(MARGIN_X, rowY,
+                                 LIST_WIDTH, GOAL_ROW_HEIGHT - 4,
+                                 GxEPD_BLACK);
+                display.setTextColor(GxEPD_WHITE);
+            } else {
+                display.setTextColor(GxEPD_BLACK);
+            }
+
+            // Truncated goal title
+            char titleBuf[MAX_GOAL_TITLE_LEN + 4];
+            truncateTitle(titleBuf, sizeof(titleBuf),
+                          goals[goalIdx].title, GOAL_DISPLAY_MAX_CHARS);
+
+            display.setTextSize(2);
+            display.setCursor(MARGIN_X + GOAL_ROW_PAD_X,
+                              rowY + GOAL_ROW_PAD_Y);
+            display.print(titleBuf);
+
+            // Progress fraction right-aligned: "N/M"
+            char progressBuf[8];
+            snprintf(progressBuf, sizeof(progressBuf), "%u/%u",
+                     goals[goalIdx].completedSessions,
+                     goals[goalIdx].targetSessions);
+            int16_t progW = static_cast<int16_t>(strlen(progressBuf))
+                            * CHAR_W_BASE * 2;
+            display.setCursor(WIDTH - MARGIN_X - GOAL_ROW_PAD_X - progW,
+                              rowY + GOAL_ROW_PAD_Y);
+            display.print(progressBuf);
+
+            // Reset text color for next row
+            display.setTextColor(GxEPD_BLACK);
+        }
+
+        // Scroll indicators if list overflows
+        if (scrollOffset > 0) {
+            // Up arrow hint
+            drawCenteredText("^", 2, LIST_START_Y - 20);
+        }
+        if (scrollOffset + visibleCount < goalCount) {
+            // Down arrow hint
+            int16_t arrowY = LIST_START_Y + visibleCount * GOAL_ROW_HEIGHT + 4;
+            drawCenteredText("v", 2, arrowY);
+        }
+    } while (display.nextPage());
+
+    Serial.println("Goal screen displayed");
+}
+
+void showSessionComplete(const SessionSummary& summary) {
+    // Layout (centered):
+    //   "Session Complete" at size 4     — heading
+    //   "Session #N" at size 2           — session number
+    //   "MM:SS focus time" at size 3     — duration
+    //   "[goal title]" at size 2         — which goal
+
+    constexpr int16_t Y_HEADING  = 100;
+    constexpr int16_t Y_SESSION  = 190;
+    constexpr int16_t Y_DURATION = 250;
+    constexpr int16_t Y_GOAL     = 330;
+
+    // Format session number
+    char sessionBuf[24];
+    snprintf(sessionBuf, sizeof(sessionBuf), "Session #%u",
+             summary.sessionNumber);
+
+    // Format duration as MM:SS
+    uint32_t minutes = summary.focusDurationSec / 60;
+    uint32_t seconds = summary.focusDurationSec % 60;
+    char durationBuf[24];
+    snprintf(durationBuf, sizeof(durationBuf), "%lu:%02lu focus",
+             static_cast<unsigned long>(minutes),
+             static_cast<unsigned long>(seconds));
+
+    // Truncate goal title
+    char goalBuf[MAX_GOAL_TITLE_LEN + 4];
+    if (summary.goalTitle[0] != '\0') {
+        truncateTitle(goalBuf, sizeof(goalBuf), summary.goalTitle,
+                      GOAL_DISPLAY_MAX_CHARS);
+    } else {
+        strncpy(goalBuf, "No goal", sizeof(goalBuf) - 1);
+        goalBuf[sizeof(goalBuf) - 1] = '\0';
+    }
+
+    display.setTextColor(GxEPD_BLACK);
+    display.setFullWindow();
+    display.firstPage();
+    do {
+        display.fillScreen(GxEPD_WHITE);
+
+        // Decorative line above heading
+        constexpr int16_t LINE_Y = Y_HEADING - 20;
+        constexpr int16_t LINE_W = 200;
+        display.drawLine((WIDTH - LINE_W) / 2, LINE_Y,
+                         (WIDTH + LINE_W) / 2, LINE_Y, GxEPD_BLACK);
+
+        drawCenteredText("Session Complete", 4, Y_HEADING);
+
+        // Decorative line below heading
+        constexpr int16_t LINE2_Y = Y_HEADING + CHAR_H_BASE * 4 + 12;
+        display.drawLine((WIDTH - LINE_W) / 2, LINE2_Y,
+                         (WIDTH + LINE_W) / 2, LINE2_Y, GxEPD_BLACK);
+
+        drawCenteredText(sessionBuf, 2, Y_SESSION);
+        drawCenteredText(durationBuf, 3, Y_DURATION);
+        drawCenteredText(goalBuf, 2, Y_GOAL);
+    } while (display.nextPage());
+
+    Serial.println("Session complete screen displayed");
 }
 
 } // namespace Display

--- a/firmware/device/src/display.h
+++ b/firmware/device/src/display.h
@@ -14,6 +14,28 @@ namespace Display {
 constexpr uint16_t WIDTH = 800;
 constexpr uint16_t HEIGHT = 480;
 
+// Maximum title length for a goal (fits ~26 chars at text size 3 on 800px).
+// Titles longer than this are truncated with ellipsis by rendering functions.
+constexpr uint8_t MAX_GOAL_TITLE_LEN = 40;
+
+// Maximum number of goals the device can hold at once.
+// Synced from phone via BLE Goal Service (ADR-013).
+constexpr uint8_t MAX_GOALS = 10;
+
+// Goal data synced from phone. Fixed-size for zero dynamic allocation (NAT-F01).
+struct GoalInfo {
+    char title[MAX_GOAL_TITLE_LEN + 1];  // null-terminated
+    uint8_t targetSessions;               // daily target
+    uint8_t completedSessions;            // completed today
+};
+
+// Session summary shown on the completion screen.
+struct SessionSummary {
+    uint32_t focusDurationSec;            // actual focus time in seconds
+    uint8_t sessionNumber;                // which session this was (1-based)
+    char goalTitle[MAX_GOAL_TITLE_LEN + 1]; // goal this session was for
+};
+
 // Initialize display hardware: configures SPI pins for EN04 FPC
 // connector, resets the display controller, and powers on.
 // Call once from setup().
@@ -28,6 +50,19 @@ void hibernate();
 
 // Draw centered "PomoFocus" test pattern for hardware validation.
 void showTestPattern();
+
+// Idle screen: "Ready to focus" with today's session count and current goal.
+void showIdleScreen(uint8_t sessionsToday, const char* currentGoalTitle);
+
+// Goal selection menu: scrollable list with highlighted selection.
+// goals: array of GoalInfo structs.
+// goalCount: number of valid entries in goals (0..MAX_GOALS).
+// selectedIndex: index of the currently highlighted goal.
+void showGoalScreen(const GoalInfo* goals, uint8_t goalCount,
+                    uint8_t selectedIndex);
+
+// Session complete screen: summary of the finished session.
+void showSessionComplete(const SessionSummary& summary);
 
 } // namespace Display
 


### PR DESCRIPTION
## Summary
- Implements three e-ink display screens for the physical device: idle screen (ready to focus), goal selection menu (scrollable list with highlighted selection), and session complete screen (completion summary)
- Adds `showIdleScreen`, `showGoalScreen`, and `showSessionComplete` functions to `display.h/cpp` using GxEPD2 library for the 800x480 e-ink display
- Goal titles are truncated gracefully when too long, and the selected goal is visually highlighted with inverted text

Closes #207

## Test plan
- [ ] `pio run` compiles successfully
- [ ] Manual verification: call `showIdleScreen()` with test data, verify "Ready to focus" layout with sessions today and current goal
- [ ] Manual verification: call `showGoalScreen()` with multiple goals, verify scrollable list with highlighted selection
- [ ] Manual verification: call `showSessionComplete()`, verify completion screen with session summary
- [ ] Verify long goal titles are truncated gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)