### PR TITLE
feat: add Nanopb .options file for static buffer sizing

### DIFF
--- a/packages/ble-protocol/proto/pomofocus.options
+++ b/packages/ble-protocol/proto/pomofocus.options
@@ -1,0 +1,31 @@
+# Nanopb options for pomofocus.proto
+# Ensures static-only allocation — no malloc on MCU.
+# String max_size includes null terminator.
+# All bytes fields are 128-bit UUIDs (16 bytes).
+
+# --- Timer Service ---
+
+pomofocus.ble.TimerState.goal_id             max_size:16
+
+pomofocus.ble.TimerCommand.goal_id           max_size:16
+
+# --- Goal Service ---
+
+pomofocus.ble.Goal.id                        max_size:16
+pomofocus.ble.Goal.title                     max_size:101
+
+pomofocus.ble.GoalList.goals                 max_count:10
+
+pomofocus.ble.SelectedGoal.goal_id           max_size:16
+
+# --- Session Sync Service ---
+
+pomofocus.ble.SessionRecord.id               max_size:16
+pomofocus.ble.SessionRecord.goal_id          max_size:16
+pomofocus.ble.SessionRecord.intention        max_size:201
+pomofocus.ble.SessionRecord.reflection       max_size:501
+pomofocus.ble.SessionRecord.distraction_note max_size:201
+
+pomofocus.ble.SyncStatus.last_synced_id      max_size:16
+
+pomofocus.ble.SyncControl.last_synced_id     max_size:16


### PR DESCRIPTION
## Summary
- Add `pomofocus.options` file defining max field sizes for all Protobuf messages, enabling Nanopb static-only allocation on the MCU (no dynamic memory)
- Covers all string, bytes, and repeated fields: Goal.title (101), SessionRecord.intention (201), reflection (501), distraction_note (201), UUID fields (16), GoalList.goals (max_count 10)

Closes #224

## Test plan
- [ ] Manual review: all string/bytes/repeated fields in the `.proto` have corresponding `.options` constraints
- [ ] No `FT_DEFAULT` or dynamic allocation flags present
- [ ] Sizes match acceptance criteria: title 101, intention 201, reflection 501, distraction_note 201, UUIDs 16, goals max_count 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)