### PR TITLE
feat: implement goal progress calculation (#178)

### DIFF
--- a/packages/core/src/goals/index.ts
+++ b/packages/core/src/goals/index.ts
@@ -19,3 +19,4 @@ export type {
 } from './validation.js';
 export { currentStreak } from './streak.js';
 export type { StreakSession } from './streak.js';
+export { goalProgress } from './progress.js';

--- a/packages/core/src/goals/progress.test.ts
+++ b/packages/core/src/goals/progress.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import { goalProgress } from './progress.js';
+import { GOAL_STATUS, RECURRENCE_TYPE } from './types.js';
+import type { ProcessGoal } from './types.js';
+import type { SessionData } from '../session/types.js';
+
+// ── Helpers ──
+
+function makeGoal(overrides: Partial<ProcessGoal> = {}): ProcessGoal {
+  return {
+    id: 'goal-1',
+    longTermGoalId: 'lt-1',
+    userId: 'user-1',
+    title: 'Study calculus',
+    targetSessionsPerDay: 3,
+    recurrence: RECURRENCE_TYPE.DAILY,
+    status: GOAL_STATUS.ACTIVE,
+    sortOrder: 0,
+    createdAt: '2026-03-20T00:00:00Z',
+    updatedAt: '2026-03-20T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<SessionData> = {}): SessionData {
+  return {
+    id: 'session-1',
+    userId: 'user-1',
+    processGoalId: 'goal-1',
+    intentionText: null,
+    startedAt: '2026-03-23T10:00:00Z',
+    endedAt: '2026-03-23T10:25:00Z',
+    completed: true,
+    abandonmentReason: null,
+    deviceId: null,
+    ...overrides,
+  };
+}
+
+// Today boundary: 2026-03-23 midnight UTC
+const TODAY_START = '2026-03-23T00:00:00Z';
+const TODAY_END = '2026-03-24T00:00:00Z';
+
+describe('goalProgress', () => {
+  it('returns progress for a single active goal with completed sessions today', () => {
+    const goals = [makeGoal()];
+    const sessions = [
+      makeSession({ id: 's1', startedAt: '2026-03-23T10:00:00Z' }),
+      makeSession({ id: 's2', startedAt: '2026-03-23T14:00:00Z' }),
+    ];
+
+    const result = goalProgress(goals, sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([
+      { goalId: 'goal-1', goalTitle: 'Study calculus', completedToday: 2, targetToday: 3 },
+    ]);
+  });
+
+  it('returns 0 completedToday when no sessions exist for the goal', () => {
+    const goals = [makeGoal()];
+    const sessions: SessionData[] = [];
+
+    const result = goalProgress(goals, sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([
+      { goalId: 'goal-1', goalTitle: 'Study calculus', completedToday: 0, targetToday: 3 },
+    ]);
+  });
+
+  it('excludes non-completed sessions', () => {
+    const goals = [makeGoal()];
+    const sessions = [
+      makeSession({ id: 's1', completed: true }),
+      makeSession({ id: 's2', completed: false, abandonmentReason: 'gave_up' }),
+    ];
+
+    const result = goalProgress(goals, sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([
+      { goalId: 'goal-1', goalTitle: 'Study calculus', completedToday: 1, targetToday: 3 },
+    ]);
+  });
+
+  it('excludes sessions outside today boundaries (before today)', () => {
+    const goals = [makeGoal()];
+    const sessions = [
+      makeSession({ id: 's1', startedAt: '2026-03-22T23:59:59Z' }), // yesterday
+      makeSession({ id: 's2', startedAt: '2026-03-23T00:00:00Z' }), // today (inclusive)
+    ];
+
+    const result = goalProgress(goals, sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([
+      { goalId: 'goal-1', goalTitle: 'Study calculus', completedToday: 1, targetToday: 3 },
+    ]);
+  });
+
+  it('excludes sessions outside today boundaries (at or after end)', () => {
+    const goals = [makeGoal()];
+    const sessions = [
+      makeSession({ id: 's1', startedAt: '2026-03-23T23:59:59Z' }), // today
+      makeSession({ id: 's2', startedAt: '2026-03-24T00:00:00Z' }), // tomorrow (exclusive)
+    ];
+
+    const result = goalProgress(goals, sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([
+      { goalId: 'goal-1', goalTitle: 'Study calculus', completedToday: 1, targetToday: 3 },
+    ]);
+  });
+
+  it('includes session at exactly today start boundary (inclusive)', () => {
+    const goals = [makeGoal()];
+    const sessions = [
+      makeSession({ id: 's1', startedAt: '2026-03-23T00:00:00Z' }),
+    ];
+
+    const result = goalProgress(goals, sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([
+      { goalId: 'goal-1', goalTitle: 'Study calculus', completedToday: 1, targetToday: 3 },
+    ]);
+  });
+
+  it('only includes active goals', () => {
+    const goals = [
+      makeGoal({ id: 'g1', status: GOAL_STATUS.ACTIVE }),
+      makeGoal({ id: 'g2', status: GOAL_STATUS.COMPLETED, title: 'Completed goal' }),
+      makeGoal({ id: 'g3', status: GOAL_STATUS.RETIRED, title: 'Retired goal' }),
+    ];
+    const sessions: SessionData[] = [];
+
+    const result = goalProgress(goals, sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([
+      { goalId: 'g1', goalTitle: 'Study calculus', completedToday: 0, targetToday: 3 },
+    ]);
+  });
+
+  it('handles multiple goals with sessions assigned to different goals', () => {
+    const goals = [
+      makeGoal({ id: 'g1', title: 'Study calculus', targetSessionsPerDay: 3 }),
+      makeGoal({ id: 'g2', title: 'Read philosophy', targetSessionsPerDay: 2 }),
+    ];
+    const sessions = [
+      makeSession({ id: 's1', processGoalId: 'g1', startedAt: '2026-03-23T10:00:00Z' }),
+      makeSession({ id: 's2', processGoalId: 'g2', startedAt: '2026-03-23T11:00:00Z' }),
+      makeSession({ id: 's3', processGoalId: 'g2', startedAt: '2026-03-23T15:00:00Z' }),
+      makeSession({ id: 's4', processGoalId: 'g1', startedAt: '2026-03-23T16:00:00Z' }),
+    ];
+
+    const result = goalProgress(goals, sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([
+      { goalId: 'g1', goalTitle: 'Study calculus', completedToday: 2, targetToday: 3 },
+      { goalId: 'g2', goalTitle: 'Read philosophy', completedToday: 2, targetToday: 2 },
+    ]);
+  });
+
+  it('ignores sessions for goals not in the provided goals list', () => {
+    const goals = [makeGoal({ id: 'g1' })];
+    const sessions = [
+      makeSession({ id: 's1', processGoalId: 'g1', startedAt: '2026-03-23T10:00:00Z' }),
+      makeSession({ id: 's2', processGoalId: 'g-unknown', startedAt: '2026-03-23T11:00:00Z' }),
+    ];
+
+    const result = goalProgress(goals, sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([
+      { goalId: 'g1', goalTitle: 'Study calculus', completedToday: 1, targetToday: 3 },
+    ]);
+  });
+
+  it('returns empty array when no goals are provided', () => {
+    const sessions = [makeSession()];
+
+    const result = goalProgress([], sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when no active goals exist', () => {
+    const goals = [
+      makeGoal({ id: 'g1', status: GOAL_STATUS.COMPLETED }),
+      makeGoal({ id: 'g2', status: GOAL_STATUS.RETIRED }),
+    ];
+    const sessions = [makeSession({ processGoalId: 'g1' })];
+
+    const result = goalProgress(goals, sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([]);
+  });
+
+  it('works with timezone-shifted day boundaries (e.g., US Eastern = UTC-4)', () => {
+    // Eastern time: today is 2026-03-23 00:00 ET = 2026-03-23 04:00 UTC
+    //               tomorrow is 2026-03-24 00:00 ET = 2026-03-24 04:00 UTC
+    const easternStart = '2026-03-23T04:00:00Z';
+    const easternEnd = '2026-03-24T04:00:00Z';
+
+    const goals = [makeGoal()];
+    const sessions = [
+      // 2026-03-23 03:30 UTC = still "yesterday" in Eastern time
+      makeSession({ id: 's1', startedAt: '2026-03-23T03:30:00Z' }),
+      // 2026-03-23 05:00 UTC = "today" in Eastern time
+      makeSession({ id: 's2', startedAt: '2026-03-23T05:00:00Z' }),
+    ];
+
+    const result = goalProgress(goals, sessions, easternStart, easternEnd);
+
+    expect(result).toEqual([
+      { goalId: 'goal-1', goalTitle: 'Study calculus', completedToday: 1, targetToday: 3 },
+    ]);
+  });
+
+  it('preserves goal order from input', () => {
+    const goals = [
+      makeGoal({ id: 'g-b', title: 'Goal B', sortOrder: 1 }),
+      makeGoal({ id: 'g-a', title: 'Goal A', sortOrder: 0 }),
+    ];
+    const sessions: SessionData[] = [];
+
+    const result = goalProgress(goals, sessions, TODAY_START, TODAY_END);
+
+    expect(result).toEqual([
+      { goalId: 'g-b', goalTitle: 'Goal B', completedToday: 0, targetToday: 3 },
+      { goalId: 'g-a', goalTitle: 'Goal A', completedToday: 0, targetToday: 3 },
+    ]);
+  });
+});

--- a/packages/core/src/goals/progress.ts
+++ b/packages/core/src/goals/progress.ts
@@ -1,0 +1,56 @@
+import type { SessionData } from '../session/types.js';
+import { GOAL_STATUS } from './types.js';
+import type { GoalProgress, ProcessGoal } from './types.js';
+
+/**
+ * Computes goal progress for active process goals.
+ *
+ * Pure function — no IO, no Date (PKG-C04). Day boundaries are provided
+ * by the caller as ISO-8601 timestamps already adjusted to the user's timezone.
+ *
+ * @param goals - All process goals (active and inactive; inactive are filtered out).
+ * @param sessions - All sessions (completed and incomplete; incomplete are filtered out).
+ * @param todayStart - Inclusive lower bound (ISO-8601, start of day in user timezone).
+ * @param todayEnd - Exclusive upper bound (ISO-8601, start of next day in user timezone).
+ * @returns GoalProgress[] for each active goal, preserving input order.
+ */
+export function goalProgress(
+  goals: readonly ProcessGoal[],
+  sessions: readonly SessionData[],
+  todayStart: string,
+  todayEnd: string,
+): readonly GoalProgress[] {
+  const activeGoals = goals.filter((g) => g.status === GOAL_STATUS.ACTIVE);
+
+  if (activeGoals.length === 0) {
+    return [];
+  }
+
+  // Build a set of active goal IDs for fast lookup
+  const activeGoalIds = new Set(activeGoals.map((g) => g.id));
+
+  // Count completed sessions per goal within today's boundaries
+  const counts = new Map<string, number>();
+
+  for (const session of sessions) {
+    if (!session.completed) {
+      continue;
+    }
+    if (!activeGoalIds.has(session.processGoalId)) {
+      continue;
+    }
+    if (session.startedAt < todayStart || session.startedAt >= todayEnd) {
+      continue;
+    }
+
+    const current = counts.get(session.processGoalId) ?? 0;
+    counts.set(session.processGoalId, current + 1);
+  }
+
+  return activeGoals.map((goal) => ({
+    goalId: goal.id,
+    goalTitle: goal.title,
+    completedToday: counts.get(goal.id) ?? 0,
+    targetToday: goal.targetSessionsPerDay,
+  }));
+}

--- a/packages/core/src/goals/types.ts
+++ b/packages/core/src/goals/types.ts
@@ -59,6 +59,7 @@ export type StreakResult = {
 
 export type GoalProgress = {
   readonly goalId: string;
+  readonly goalTitle: string;
   readonly completedToday: number;
-  readonly target: number;
+  readonly targetToday: number;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,7 +12,7 @@ export type {
   ProcessGoalInput,
   LongTermGoalInput,
 } from './goals/index.js';
-export { validateIntention, validateProcessGoal, validateLongTermGoal, currentStreak } from './goals/index.js';
+export { validateIntention, validateProcessGoal, validateLongTermGoal, currentStreak, goalProgress } from './goals/index.js';
 export type { StreakSession } from './goals/index.js';
 export { TIMER_STATUS, TIMER_EVENT_TYPE, createInitialState, isRunning, getTimeRemaining, transition } from './timer/index.js';
 export type {


### PR DESCRIPTION
## Summary
- Implements pure `goalProgress()` function in `packages/core/src/goals/progress.ts` that computes daily progress for active process goals (ADR-014 Tier 1 metric)
- Returns `{goalId, goalTitle, completedToday, targetToday}[]` for active process goals, counting only completed sessions within caller-provided day boundaries (timezone-safe, no `Date` usage per PKG-C04)
- Adds `goalTitle` field and renames `target` to `targetToday` in `GoalProgress` type for clarity
- Includes 13 test cases covering boundary conditions, timezone offsets, multiple goals, filtering, and edge cases

Closes #178

## Test plan
- [x] `pnpm nx test @pomofocus/core` — all 13 new tests pass
- [x] Pure function with no IO — no mocks needed (TST-004)
- [x] Tests co-located at `packages/core/src/goals/progress.test.ts` (TST-006)

🤖 Generated with [Claude Code](https://claude.com/claude-code)