### PR TITLE
feat: implement timer rehydration pure logic (#188)

### DIFF
--- a/packages/core/src/timer/index.ts
+++ b/packages/core/src/timer/index.ts
@@ -10,3 +10,5 @@ export type {
 export { createInitialState, isRunning, getTimeRemaining } from './utils.js';
 export { isLongBreak, isReflectionEnabled } from './guards.js';
 export { transition } from './transition.js';
+export { rehydrate } from './rehydrate.js';
+export type { RehydrationResult } from './rehydrate.js';

--- a/packages/core/src/timer/rehydrate.test.ts
+++ b/packages/core/src/timer/rehydrate.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect } from 'vitest';
+import { rehydrate } from './rehydrate.js';
+import { TIMER_STATUS, TIMER_EVENT_TYPE } from './types.js';
+import type { TimerConfig, TimerState } from './types.js';
+
+const defaultConfig: TimerConfig = {
+  focusDuration: 1500,
+  shortBreakDuration: 300,
+  longBreakDuration: 900,
+  sessionsBeforeLongBreak: 4,
+  reflectionEnabled: true,
+};
+
+describe('rehydrate', () => {
+  describe('running state (focusing) with elapsed < remaining', () => {
+    it('adjusts timeRemaining by elapsed time', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.FOCUSING,
+        timeRemaining: 1500,
+        startedAt: 1000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const result = rehydrate(state, 1600);
+
+      expect(result.state).toEqual({
+        status: TIMER_STATUS.FOCUSING,
+        timeRemaining: 900,
+        startedAt: 1000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      });
+      expect(result.missedTransitions).toEqual([]);
+    });
+  });
+
+  describe('running state (focusing) with elapsed >= remaining', () => {
+    it('applies TIMER_DONE transition when time has expired', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.FOCUSING,
+        timeRemaining: 1500,
+        startedAt: 1000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const now = 2600;
+      const result = rehydrate(state, now);
+
+      expect(result.state.status).toBe(TIMER_STATUS.SHORT_BREAK);
+      expect(result.missedTransitions).toEqual([
+        { type: TIMER_EVENT_TYPE.TIMER_DONE },
+      ]);
+    });
+
+    it('transitions to long break when session number matches', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.FOCUSING,
+        timeRemaining: 1500,
+        startedAt: 1000,
+        sessionNumber: 4,
+        config: defaultConfig,
+      };
+
+      const now = 2600;
+      const result = rehydrate(state, now);
+
+      expect(result.state.status).toBe(TIMER_STATUS.LONG_BREAK);
+      expect(result.missedTransitions).toEqual([
+        { type: TIMER_EVENT_TYPE.TIMER_DONE },
+      ]);
+    });
+
+    it('applies TIMER_DONE when timeRemaining is exactly zero', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.FOCUSING,
+        timeRemaining: 500,
+        startedAt: 1000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const now = 1500;
+      const result = rehydrate(state, now);
+
+      expect(result.state.status).toBe(TIMER_STATUS.SHORT_BREAK);
+      expect(result.missedTransitions).toEqual([
+        { type: TIMER_EVENT_TYPE.TIMER_DONE },
+      ]);
+    });
+  });
+
+  describe('running state (short_break) rehydration', () => {
+    it('adjusts timeRemaining when elapsed < remaining', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.SHORT_BREAK,
+        timeRemaining: 300,
+        startedAt: 2000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const result = rehydrate(state, 2100);
+
+      expect(result.state).toEqual({
+        status: TIMER_STATUS.SHORT_BREAK,
+        timeRemaining: 200,
+        startedAt: 2000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      });
+      expect(result.missedTransitions).toEqual([]);
+    });
+
+    it('applies TIMER_DONE when break time has expired', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.SHORT_BREAK,
+        timeRemaining: 300,
+        startedAt: 2000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const now = 2400;
+      const result = rehydrate(state, now);
+
+      expect(result.state.status).toBe(TIMER_STATUS.REFLECTION);
+      expect(result.missedTransitions).toEqual([
+        { type: TIMER_EVENT_TYPE.TIMER_DONE },
+      ]);
+    });
+
+    it('skips reflection if disabled', () => {
+      const noReflectionConfig: TimerConfig = {
+        ...defaultConfig,
+        reflectionEnabled: false,
+      };
+      const state: TimerState = {
+        status: TIMER_STATUS.SHORT_BREAK,
+        timeRemaining: 300,
+        startedAt: 2000,
+        sessionNumber: 1,
+        config: noReflectionConfig,
+      };
+
+      const now = 2400;
+      const result = rehydrate(state, now);
+
+      expect(result.state.status).toBe(TIMER_STATUS.FOCUSING);
+      expect(result.missedTransitions).toEqual([
+        { type: TIMER_EVENT_TYPE.TIMER_DONE },
+      ]);
+    });
+  });
+
+  describe('running state (long_break) rehydration', () => {
+    it('adjusts timeRemaining when elapsed < remaining', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.LONG_BREAK,
+        timeRemaining: 900,
+        startedAt: 3000,
+        sessionNumber: 4,
+        config: defaultConfig,
+      };
+
+      const result = rehydrate(state, 3300);
+
+      expect(result.state).toEqual({
+        status: TIMER_STATUS.LONG_BREAK,
+        timeRemaining: 600,
+        startedAt: 3000,
+        sessionNumber: 4,
+        config: defaultConfig,
+      });
+      expect(result.missedTransitions).toEqual([]);
+    });
+
+    it('applies TIMER_DONE when long break has expired', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.LONG_BREAK,
+        timeRemaining: 900,
+        startedAt: 3000,
+        sessionNumber: 4,
+        config: defaultConfig,
+      };
+
+      const now = 4000;
+      const result = rehydrate(state, now);
+
+      expect(result.state.status).toBe(TIMER_STATUS.REFLECTION);
+      expect(result.missedTransitions).toEqual([
+        { type: TIMER_EVENT_TYPE.TIMER_DONE },
+      ]);
+    });
+  });
+
+  describe('paused state rehydration', () => {
+    it('returns paused state unchanged', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.PAUSED,
+        timeRemaining: 900,
+        pausedAt: 1600,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const result = rehydrate(state, 99999);
+
+      expect(result.state).toEqual(state);
+      expect(result.missedTransitions).toEqual([]);
+    });
+  });
+
+  describe('break_paused state rehydration', () => {
+    it('returns break_paused state unchanged', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.BREAK_PAUSED,
+        timeRemaining: 200,
+        pausedAt: 2700,
+        breakType: 'short',
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const result = rehydrate(state, 99999);
+
+      expect(result.state).toEqual(state);
+      expect(result.missedTransitions).toEqual([]);
+    });
+  });
+
+  describe('non-timed state rehydration', () => {
+    it('returns idle state unchanged', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.IDLE,
+        config: defaultConfig,
+      };
+
+      const result = rehydrate(state, 99999);
+
+      expect(result.state).toEqual(state);
+      expect(result.missedTransitions).toEqual([]);
+    });
+
+    it('returns reflection state unchanged', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.REFLECTION,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const result = rehydrate(state, 99999);
+
+      expect(result.state).toEqual(state);
+      expect(result.missedTransitions).toEqual([]);
+    });
+
+    it('returns completed state unchanged', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.COMPLETED,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const result = rehydrate(state, 99999);
+
+      expect(result.state).toEqual(state);
+      expect(result.missedTransitions).toEqual([]);
+    });
+
+    it('returns abandoned state unchanged', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.ABANDONED,
+        sessionNumber: 1,
+        abandonedAt: 5000,
+        config: defaultConfig,
+      };
+
+      const result = rehydrate(state, 99999);
+
+      expect(result.state).toEqual(state);
+      expect(result.missedTransitions).toEqual([]);
+    });
+  });
+
+  describe('auto-abandon for sessions running way past max duration', () => {
+    it('auto-abandons focusing state when elapsed >= 2x focus duration', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.FOCUSING,
+        timeRemaining: 1500,
+        startedAt: 1000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const now = 1000 + 1500 * 2;
+      const result = rehydrate(state, now);
+
+      expect(result.state).toEqual({
+        status: TIMER_STATUS.ABANDONED,
+        sessionNumber: 1,
+        abandonedAt: now,
+        config: defaultConfig,
+      });
+      expect(result.missedTransitions).toEqual([
+        { type: TIMER_EVENT_TYPE.ABANDON },
+      ]);
+    });
+
+    it('auto-abandons short_break when elapsed >= 2x short break duration', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.SHORT_BREAK,
+        timeRemaining: 300,
+        startedAt: 2000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const now = 2000 + 300 * 2;
+      const result = rehydrate(state, now);
+
+      expect(result.state).toEqual({
+        status: TIMER_STATUS.ABANDONED,
+        sessionNumber: 1,
+        abandonedAt: now,
+        config: defaultConfig,
+      });
+      expect(result.missedTransitions).toEqual([
+        { type: TIMER_EVENT_TYPE.ABANDON },
+      ]);
+    });
+
+    it('auto-abandons long_break when elapsed >= 2x long break duration', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.LONG_BREAK,
+        timeRemaining: 900,
+        startedAt: 3000,
+        sessionNumber: 4,
+        config: defaultConfig,
+      };
+
+      const now = 3000 + 900 * 2;
+      const result = rehydrate(state, now);
+
+      expect(result.state).toEqual({
+        status: TIMER_STATUS.ABANDONED,
+        sessionNumber: 4,
+        abandonedAt: now,
+        config: defaultConfig,
+      });
+      expect(result.missedTransitions).toEqual([
+        { type: TIMER_EVENT_TYPE.ABANDON },
+      ]);
+    });
+
+    it('does not auto-abandon when elapsed is just under 2x threshold', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.FOCUSING,
+        timeRemaining: 1500,
+        startedAt: 1000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const now = 1000 + 1500 * 2 - 1;
+      const result = rehydrate(state, now);
+
+      expect(result.state.status).toBe(TIMER_STATUS.SHORT_BREAK);
+      expect(result.missedTransitions).toEqual([
+        { type: TIMER_EVENT_TYPE.TIMER_DONE },
+      ]);
+    });
+
+    it('auto-abandon takes priority over TIMER_DONE for very long elapsed', () => {
+      const state: TimerState = {
+        status: TIMER_STATUS.FOCUSING,
+        timeRemaining: 1500,
+        startedAt: 1000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+
+      const now = 1000 + 10000;
+      const result = rehydrate(state, now);
+
+      expect(result.state.status).toBe(TIMER_STATUS.ABANDONED);
+      expect(result.missedTransitions).toEqual([
+        { type: TIMER_EVENT_TYPE.ABANDON },
+      ]);
+    });
+  });
+});

--- a/packages/core/src/timer/rehydrate.ts
+++ b/packages/core/src/timer/rehydrate.ts
@@ -1,0 +1,87 @@
+import { TIMER_STATUS, TIMER_EVENT_TYPE } from './types.js';
+import type { TimerState, TimerEvent } from './types.js';
+import { transition } from './transition.js';
+
+export type RehydrationResult = {
+  state: TimerState;
+  missedTransitions: TimerEvent[];
+};
+
+function getMaxDuration(state: TimerState): number {
+  switch (state.status) {
+    case TIMER_STATUS.FOCUSING:
+      return state.config.focusDuration;
+    case TIMER_STATUS.SHORT_BREAK:
+      return state.config.shortBreakDuration;
+    case TIMER_STATUS.LONG_BREAK:
+      return state.config.longBreakDuration;
+    case TIMER_STATUS.IDLE:
+    case TIMER_STATUS.PAUSED:
+    case TIMER_STATUS.BREAK_PAUSED:
+    case TIMER_STATUS.REFLECTION:
+    case TIMER_STATUS.COMPLETED:
+    case TIMER_STATUS.ABANDONED:
+      return 0;
+    default: {
+      const _exhaustive: never = state;
+      return _exhaustive;
+    }
+  }
+}
+
+export function rehydrate(persistedState: TimerState, now: number): RehydrationResult {
+  switch (persistedState.status) {
+    case TIMER_STATUS.FOCUSING:
+    case TIMER_STATUS.SHORT_BREAK:
+    case TIMER_STATUS.LONG_BREAK: {
+      const elapsed = now - persistedState.startedAt;
+      const maxDuration = getMaxDuration(persistedState);
+      const autoAbandonThreshold = maxDuration * 2;
+
+      if (elapsed >= autoAbandonThreshold) {
+        return {
+          state: {
+            status: TIMER_STATUS.ABANDONED,
+            sessionNumber: persistedState.sessionNumber,
+            abandonedAt: now,
+            config: persistedState.config,
+          },
+          missedTransitions: [{ type: TIMER_EVENT_TYPE.ABANDON }],
+        };
+      }
+
+      const adjustedRemaining = persistedState.timeRemaining - elapsed;
+
+      if (adjustedRemaining <= 0) {
+        const timerDoneEvent: TimerEvent = { type: TIMER_EVENT_TYPE.TIMER_DONE };
+        const newState = transition(persistedState, timerDoneEvent, now);
+        return {
+          state: newState,
+          missedTransitions: [timerDoneEvent],
+        };
+      }
+
+      return {
+        state: {
+          ...persistedState,
+          timeRemaining: adjustedRemaining,
+        },
+        missedTransitions: [],
+      };
+    }
+    case TIMER_STATUS.IDLE:
+    case TIMER_STATUS.PAUSED:
+    case TIMER_STATUS.BREAK_PAUSED:
+    case TIMER_STATUS.REFLECTION:
+    case TIMER_STATUS.COMPLETED:
+    case TIMER_STATUS.ABANDONED:
+      return {
+        state: persistedState,
+        missedTransitions: [],
+      };
+    default: {
+      const _exhaustive: never = persistedState;
+      return _exhaustive;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implement pure `rehydrate(persistedState, nowTimestamp)` function in `packages/core/src/timer/rehydrate.ts` for restoring timer state on app relaunch
- Running states (focusing, short_break, long_break): compute elapsed time from `startedAt`, adjust `timeRemaining`, apply `TIMER_DONE` if expired, or auto-abandon if elapsed >= 2x configured duration
- Paused and non-timed states (idle, paused, break_paused, reflection, completed, abandoned): returned unchanged
- Returns `RehydrationResult` with the rehydrated state and any missed transitions
- Comprehensive test suite (393 lines) covering all states, edge cases, boundary conditions, and auto-abandon logic

Closes #188

## Test plan
- [x] `pnpm nx test @pomofocus/core` — all rehydration tests pass
- [x] Running state with elapsed < remaining adjusts timeRemaining correctly
- [x] Running state with elapsed >= remaining applies TIMER_DONE transition
- [x] Paused states restored as-is (no time adjustment)
- [x] Auto-abandon when session running >= 2x configured duration
- [x] Exhaustive switch on all timer statuses (no missing cases)
- [x] No Date, no IO — pure function (PKG-C04, PKG-C01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)