### PR TITLE
feat: implement streak calculation with 1-day grace period

### DIFF
--- a/packages/core/src/goals/index.ts
+++ b/packages/core/src/goals/index.ts
@@ -17,3 +17,5 @@ export type {
   ProcessGoalInput,
   LongTermGoalInput,
 } from './validation.js';
+export { currentStreak } from './streak.js';
+export type { StreakSession } from './streak.js';

--- a/packages/core/src/goals/streak.test.ts
+++ b/packages/core/src/goals/streak.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest';
+import { currentStreak } from './streak.js';
+import type { StreakSession } from './streak.js';
+
+// ── Test helpers ──
+
+// All timestamps are epoch ms. We use simple arithmetic from a known anchor.
+// 2026-03-23T12:00:00Z = 1774267200000 (verified externally)
+const MAR_23_NOON_UTC = 1774267200000;
+const MS_PER_DAY = 86_400_000;
+const MS_PER_HOUR = 3_600_000;
+
+// Helper: epoch ms for noon UTC on a given day relative to 2026-03-23
+function dayMs(daysBeforeMar23: number, hoursOffset = 0): number {
+  return MAR_23_NOON_UTC - daysBeforeMar23 * MS_PER_DAY + hoursOffset * MS_PER_HOUR;
+}
+
+// Helper: create a session with a given epoch ms, completed by default
+function session(startedAtMs: number, completed = true): StreakSession {
+  return { startedAtMs, completed };
+}
+
+// UTC offset = 0 minutes for most tests
+const UTC = 0;
+
+describe('currentStreak', () => {
+  it('returns 0 for empty sessions array', () => {
+    const result = currentStreak([], UTC, dayMs(0));
+    expect(result).toEqual({ currentStreak: 0, longestStreak: 0, gracePeriodActive: false });
+  });
+
+  it('returns 0 when no sessions are completed', () => {
+    const sessions = [
+      session(dayMs(0), false),
+      session(dayMs(1), false),
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result).toEqual({ currentStreak: 0, longestStreak: 0, gracePeriodActive: false });
+  });
+
+  it('returns 1 for a single completed session today', () => {
+    const sessions = [session(dayMs(0))];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result).toEqual({ currentStreak: 1, longestStreak: 1, gracePeriodActive: false });
+  });
+
+  it('counts consecutive days', () => {
+    const sessions = [
+      session(dayMs(0)), // Mar 23
+      session(dayMs(1)), // Mar 22
+      session(dayMs(2)), // Mar 21
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result).toEqual({ currentStreak: 3, longestStreak: 3, gracePeriodActive: false });
+  });
+
+  it('tolerates exactly 1 missed day (grace period)', () => {
+    // Sessions on day 23, 21 (skipped 22), 20
+    const sessions = [
+      session(dayMs(0)), // Mar 23
+      session(dayMs(2)), // Mar 21
+      session(dayMs(3)), // Mar 20
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    // Gap day 22 is tolerated, but does NOT count toward streak length
+    expect(result.currentStreak).toBe(3);
+    expect(result.gracePeriodActive).toBe(true);
+  });
+
+  it('resets streak after 2 consecutive missed days', () => {
+    // Sessions on day 23, 20 (skipped 22 AND 21)
+    const sessions = [
+      session(dayMs(0)), // Mar 23
+      session(dayMs(3)), // Mar 20
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result.currentStreak).toBe(1);
+  });
+
+  it('gap days do NOT count toward streak length', () => {
+    // Sessions on 23, 21, 19 — two gaps (22 and 20) each of 1 day
+    const sessions = [
+      session(dayMs(0)), // Mar 23
+      session(dayMs(2)), // Mar 21
+      session(dayMs(4)), // Mar 19
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    // 3 active days, 2 gap days tolerated (each gap is exactly 1 day)
+    expect(result.currentStreak).toBe(3);
+    expect(result.gracePeriodActive).toBe(true);
+  });
+
+  it('only completed sessions count', () => {
+    const sessions = [
+      session(dayMs(0), false), // Mar 23 — abandoned
+      session(dayMs(1), true),  // Mar 22
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    // Today has no completed session, yesterday has one
+    // Today is a gap day from yesterday — grace period
+    expect(result.currentStreak).toBe(1);
+    expect(result.gracePeriodActive).toBe(true);
+  });
+
+  it('handles multiple sessions on the same day (only needs one completed)', () => {
+    const sessions = [
+      session(dayMs(0, -4), false), // Mar 23 8am
+      session(dayMs(0, -2), true),  // Mar 23 10am
+      session(dayMs(0, 2), false),  // Mar 23 2pm
+      session(dayMs(1), true),      // Mar 22
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result.currentStreak).toBe(2);
+  });
+
+  it('streak accounts for internal grace period and double gap', () => {
+    // 23, 22, (skip 21), 20, (skip 19 AND 18 — two gaps = reset), 17
+    const sessions = [
+      session(dayMs(0)), // Mar 23
+      session(dayMs(1)), // Mar 22
+      session(dayMs(3)), // Mar 20
+      session(dayMs(6)), // Mar 17
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    // 23, 22, (skip 21), 20 — then 19 and 18 are two consecutive misses
+    expect(result.currentStreak).toBe(3);
+  });
+
+  it('streak can start from yesterday with grace period active for today', () => {
+    // No session today (23), but session yesterday (22) and before
+    const sessions = [
+      session(dayMs(1)), // Mar 22
+      session(dayMs(2)), // Mar 21
+      session(dayMs(3)), // Mar 20
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    // Today is missed, yesterday starts the streak backward
+    expect(result.currentStreak).toBe(3);
+    expect(result.gracePeriodActive).toBe(true);
+  });
+
+  it('returns 0 when the most recent session is 2+ days ago', () => {
+    // No session on 23 or 22, only on 21
+    const sessions = [
+      session(dayMs(2)), // Mar 21
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    // Two consecutive missed days (22 and 23) — streak reset
+    expect(result.currentStreak).toBe(0);
+  });
+
+  it('calculates longestStreak across all sessions', () => {
+    const sessions = [
+      // Current streak: 2 days (23, 22)
+      session(dayMs(0)), // Mar 23
+      session(dayMs(1)), // Mar 22
+      // Gap of 2 days (21, 20) — reset
+      // Older streak: 4 days (19, 18, 17, 16)
+      session(dayMs(4)), // Mar 19
+      session(dayMs(5)), // Mar 18
+      session(dayMs(6)), // Mar 17
+      session(dayMs(7)), // Mar 16
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result.currentStreak).toBe(2);
+    expect(result.longestStreak).toBe(4);
+  });
+
+  it('longestStreak equals currentStreak when current is the longest', () => {
+    const sessions = [
+      session(dayMs(0)), // Mar 23
+      session(dayMs(1)), // Mar 22
+      session(dayMs(2)), // Mar 21
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result.currentStreak).toBe(3);
+    expect(result.longestStreak).toBe(3);
+  });
+
+  it('respects timezone offset for day boundaries', () => {
+    // Session at 01:00 UTC on Mar 23
+    // In UTC-5 (e.g., EST), that's still 8pm Mar 22
+    const sessionAt1amUtc = MAR_23_NOON_UTC - 11 * MS_PER_HOUR; // 01:00 UTC Mar 23
+    const sessions = [session(sessionAt1amUtc)];
+
+    // utcOffsetMinutes = -300 (UTC-5, i.e., EST)
+    const EST = -300;
+    // "now" is 05:00 UTC Mar 23 = 00:00 EST Mar 23 (midnight just started)
+    const nowAt5amUtc = MAR_23_NOON_UTC - 7 * MS_PER_HOUR;
+    const result = currentStreak(sessions, EST, nowAt5amUtc);
+    // In EST: session is on March 22, "now" is March 23 — session is yesterday, grace period
+    expect(result.currentStreak).toBe(1);
+    expect(result.gracePeriodActive).toBe(true);
+  });
+
+  it('handles timezone where session crosses midnight boundary', () => {
+    // Two sessions:
+    // 03:00 UTC = 10pm EST (Mar 22 in EST)
+    // 06:00 UTC = 1am EST (Mar 23 in EST)
+    const EST = -300;
+    const sessionLateEvening = MAR_23_NOON_UTC - 9 * MS_PER_HOUR;  // 03:00 UTC Mar 23
+    const sessionEarlyMorning = MAR_23_NOON_UTC - 6 * MS_PER_HOUR; // 06:00 UTC Mar 23
+    const sessions = [
+      session(sessionLateEvening),   // Mar 22 in EST
+      session(sessionEarlyMorning),  // Mar 23 in EST
+    ];
+    // "now" is 15:00 UTC Mar 23 = 10am EST Mar 23
+    const now = MAR_23_NOON_UTC + 3 * MS_PER_HOUR;
+    const result = currentStreak(sessions, EST, now);
+    // In EST: sessions on March 22 and March 23 — 2-day streak
+    expect(result.currentStreak).toBe(2);
+    expect(result.gracePeriodActive).toBe(false);
+  });
+
+  it('handles nowTimestamp as epoch milliseconds', () => {
+    const sessions = [session(MAR_23_NOON_UTC)];
+    const result = currentStreak(sessions, UTC, MAR_23_NOON_UTC);
+    expect(result.currentStreak).toBe(1);
+  });
+
+  it('grace period not active when all days are consecutive', () => {
+    const sessions = [
+      session(dayMs(0)),
+      session(dayMs(1)),
+      session(dayMs(2)),
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result.gracePeriodActive).toBe(false);
+  });
+
+  it('grace period active when today has no session but yesterday does', () => {
+    const sessions = [session(dayMs(1))]; // yesterday only
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result.gracePeriodActive).toBe(true);
+  });
+
+  it('grace period active when a gap day exists within the streak', () => {
+    const sessions = [
+      session(dayMs(0)), // Mar 23
+      // gap on 22
+      session(dayMs(2)), // Mar 21
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result.gracePeriodActive).toBe(true);
+    expect(result.currentStreak).toBe(2);
+  });
+
+  it('longest streak accounts for grace periods in historical streaks', () => {
+    const sessions = [
+      // Current streak: 1 (only today)
+      session(dayMs(0)),  // Mar 23
+      // 2 consecutive missed days (22, 21) — reset
+      // Historical streak: 20, 19, (skip 18), 17, 16 = 4 active days with grace
+      session(dayMs(3)),  // Mar 20
+      session(dayMs(4)),  // Mar 19
+      session(dayMs(6)),  // Mar 17
+      session(dayMs(7)),  // Mar 16
+    ];
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(4);
+  });
+
+  it('handles very long streak (30 consecutive days)', () => {
+    const sessions: StreakSession[] = [];
+    for (let i = 0; i < 30; i++) {
+      sessions.push(session(dayMs(i)));
+    }
+    const result = currentStreak(sessions, UTC, dayMs(0));
+    expect(result.currentStreak).toBe(30);
+    expect(result.longestStreak).toBe(30);
+  });
+
+  it('positive UTC offset shifts day boundary earlier', () => {
+    // UTC+5:30 (India) = 330 minutes
+    const IST = 330;
+    // Session at 18:00 UTC Mar 22 = 23:30 IST Mar 22
+    const sessionEvening = MAR_23_NOON_UTC - 18 * MS_PER_HOUR;
+    // Session at 19:00 UTC Mar 22 = 00:30 IST Mar 23
+    const sessionAfterMidnight = MAR_23_NOON_UTC - 17 * MS_PER_HOUR;
+    const sessions = [
+      session(sessionEvening),        // Mar 22 in IST
+      session(sessionAfterMidnight),  // Mar 23 in IST
+    ];
+    // "now" is 06:00 UTC Mar 23 = 11:30 IST Mar 23
+    const now = MAR_23_NOON_UTC - 6 * MS_PER_HOUR;
+    const result = currentStreak(sessions, IST, now);
+    expect(result.currentStreak).toBe(2);
+  });
+});

--- a/packages/core/src/goals/streak.ts
+++ b/packages/core/src/goals/streak.ts
@@ -1,0 +1,140 @@
+import type { StreakResult } from './types.js';
+
+// ── Minimal session shape required for streak calculation ──
+
+export type StreakSession = {
+  readonly startedAtMs: number;
+  readonly completed: boolean;
+};
+
+// ── Pure arithmetic day computation (no Date, no Intl — PKG-C04) ──
+
+const MS_PER_DAY = 86_400_000;
+
+function epochMsToDayNumber(epochMs: number, utcOffsetMinutes: number): number {
+  // Shift epoch ms by the UTC offset to get "local" epoch ms,
+  // then divide by ms-per-day and floor to get a day number.
+  // Day 0 = 1970-01-01 in the given offset.
+  const localMs = epochMs + utcOffsetMinutes * 60_000;
+  return Math.floor(localMs / MS_PER_DAY);
+}
+
+// ── Streak computation (pure function) ──
+
+function computeStreakFromDays(sortedDaysDesc: readonly number[], startDay: number): {
+  readonly length: number;
+  readonly usedGrace: boolean;
+} {
+  // sortedDaysDesc: unique day numbers with completed sessions, sorted descending (newest first)
+  // startDay: the day number to start counting from
+
+  if (sortedDaysDesc.length === 0) {
+    return { length: 0, usedGrace: false };
+  }
+
+  let streakLength = 0;
+  let usedGrace = false;
+  let expectedDay = startDay;
+  let dayIndex = 0;
+
+  while (dayIndex < sortedDaysDesc.length) {
+    const day = sortedDaysDesc[dayIndex];
+    if (day === undefined) break;
+
+    const gap = expectedDay - day;
+
+    if (gap === 0) {
+      // This day matches the expected day
+      streakLength++;
+      expectedDay = day - 1;
+      dayIndex++;
+    } else if (gap === 1) {
+      // 1 day gap — use grace period
+      usedGrace = true;
+      // Skip the gap day and move expected to the day before
+      expectedDay = expectedDay - 1;
+      // Don't increment dayIndex — re-check this day against the new expected day
+    } else {
+      // Gap of 2+ days — streak broken
+      break;
+    }
+  }
+
+  return { length: streakLength, usedGrace };
+}
+
+function computeLongestStreak(sortedDaysDesc: readonly number[]): number {
+  if (sortedDaysDesc.length === 0) return 0;
+
+  let longest = 0;
+  let i = 0;
+
+  while (i < sortedDaysDesc.length) {
+    const startDay = sortedDaysDesc[i];
+    if (startDay === undefined) break;
+    const result = computeStreakFromDays(sortedDaysDesc.slice(i), startDay);
+    longest = Math.max(longest, result.length);
+    // Skip past the days we just counted (at least 1 to avoid infinite loop)
+    i += Math.max(result.length, 1);
+  }
+
+  return longest;
+}
+
+export function currentStreak(
+  sessions: readonly StreakSession[],
+  utcOffsetMinutes: number,
+  nowTimestamp: number,
+): StreakResult {
+  // Filter to completed sessions only
+  const completedSessions = sessions.filter((s) => s.completed);
+
+  if (completedSessions.length === 0) {
+    return { currentStreak: 0, longestStreak: 0, gracePeriodActive: false };
+  }
+
+  // Convert each session's startedAtMs to a day number in the user's timezone
+  const sessionDayNumbers = completedSessions.map((s) =>
+    epochMsToDayNumber(s.startedAtMs, utcOffsetMinutes),
+  );
+
+  // Get unique days, sorted descending (newest first)
+  const uniqueDays = [...new Set(sessionDayNumbers)].sort((a, b) => b - a);
+
+  // Get today's day number
+  const todayDay = epochMsToDayNumber(nowTimestamp, utcOffsetMinutes);
+
+  // Determine the start day for current streak calculation
+  const mostRecentDay = uniqueDays[0];
+  if (mostRecentDay === undefined) {
+    return { currentStreak: 0, longestStreak: 0, gracePeriodActive: false };
+  }
+
+  let startDay: number;
+  let currentGraceUsed = false;
+
+  if (mostRecentDay === todayDay) {
+    startDay = todayDay;
+  } else if (todayDay - mostRecentDay === 1) {
+    // Most recent session was yesterday — grace period for today
+    startDay = mostRecentDay;
+    currentGraceUsed = true;
+  } else {
+    // Most recent session is 2+ days ago — no current streak
+    const longestResult = computeLongestStreak(uniqueDays);
+    return { currentStreak: 0, longestStreak: longestResult, gracePeriodActive: false };
+  }
+
+  // Compute current streak
+  const current = computeStreakFromDays(uniqueDays, startDay);
+  const currentGracePeriodActive = currentGraceUsed || current.usedGrace;
+
+  // Compute longest streak across all historical data
+  const longest = computeLongestStreak(uniqueDays);
+
+  return {
+    currentStreak: current.length,
+    longestStreak: Math.max(current.length, longest),
+    gracePeriodActive: currentGracePeriodActive,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,7 +12,8 @@ export type {
   ProcessGoalInput,
   LongTermGoalInput,
 } from './goals/index.js';
-export { validateIntention, validateProcessGoal, validateLongTermGoal } from './goals/index.js';
+export { validateIntention, validateProcessGoal, validateLongTermGoal, currentStreak } from './goals/index.js';
+export type { StreakSession } from './goals/index.js';
 export { TIMER_STATUS, TIMER_EVENT_TYPE, createInitialState, isRunning, getTimeRemaining, transition } from './timer/index.js';
 export type {
   TimerStatus,


### PR DESCRIPTION
## Summary

- Implements `currentStreak()` pure function in `packages/core/src/goals/streak.ts` that counts consecutive calendar days with completed sessions, tolerating exactly 1 missed day (grace period)
- Returns `StreakResult` with `currentStreak`, `longestStreak`, and `gracePeriodActive` fields
- Pure arithmetic day computation using epoch milliseconds and UTC offset — no `Date` object (PKG-C04 compliant)
- Comprehensive test suite (290 lines) covering grace period logic, timezone offsets, edge cases, and 30-day long streaks

Closes #177

## Test plan

- [x] `pnpm nx test @pomofocus/core` passes
- [ ] Verify streak returns 0 for empty/no-completed sessions
- [ ] Verify 1-day grace period tolerates exactly 1 missed day
- [ ] Verify 2 consecutive missed days resets streak
- [ ] Verify gap days do not count toward streak length
- [ ] Verify timezone offset shifts day boundaries correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)