### PR TITLE
feat: implement input-to-timer event mapping (#221)

### DIFF
--- a/firmware/device/src/input.cpp
+++ b/firmware/device/src/input.cpp
@@ -214,3 +214,71 @@ void input_poll() {
 int32_t input_step_count() {
   return s_step_count;
 }
+
+// ==================== Input-to-Timer Event Mapping (issue #221) ====================
+
+MappedEvent input_map_press(TimerPhase phase, PressEvent press) {
+  switch (phase) {
+    case TimerPhase::idle:
+      if (press == PressEvent::SHORT_PRESS) {
+        return {true, TimerEvent::START};
+      }
+      return {false, {}};
+
+    case TimerPhase::focusing:
+      if (press == PressEvent::SHORT_PRESS) {
+        return {true, TimerEvent::PAUSE};
+      }
+      if (press == PressEvent::LONG_PRESS) {
+        return {true, TimerEvent::ABANDON};
+      }
+      return {false, {}};
+
+    case TimerPhase::paused:
+      if (press == PressEvent::SHORT_PRESS) {
+        return {true, TimerEvent::RESUME};
+      }
+      if (press == PressEvent::LONG_PRESS) {
+        return {true, TimerEvent::ABANDON};
+      }
+      return {false, {}};
+
+    case TimerPhase::short_break:
+    case TimerPhase::long_break:
+    case TimerPhase::break_paused:
+      if (press == PressEvent::SHORT_PRESS) {
+        return {true, TimerEvent::SKIP_BREAK};
+      }
+      if (press == PressEvent::LONG_PRESS) {
+        return {true, TimerEvent::ABANDON};
+      }
+      return {false, {}};
+
+    case TimerPhase::reflection:
+      if (press == PressEvent::SHORT_PRESS) {
+        return {true, TimerEvent::SKIP};
+      }
+      return {false, {}};
+
+    case TimerPhase::completed:
+    case TimerPhase::abandoned:
+      if (press == PressEvent::SHORT_PRESS) {
+        return {true, TimerEvent::RESET};
+      }
+      return {false, {}};
+  }
+
+  return {false, {}};
+}
+
+int8_t input_map_rotation_to_goal_delta(RotationDir dir) {
+  switch (dir) {
+    case RotationDir::Clockwise:
+      return 1;
+    case RotationDir::CounterClockwise:
+      return -1;
+    case RotationDir::None:
+      return 0;
+  }
+  return 0;
+}

--- a/firmware/device/src/input.h
+++ b/firmware/device/src/input.h
@@ -75,4 +75,43 @@ void input_poll();
 // Return the cumulative signed step count (CW increments, CCW decrements).
 int32_t input_step_count();
 
+// --- Input-to-Timer Event Mapping (issue #221) ---
+
+#include "timer.h"
+
+// Screen mode determines how encoder events are interpreted.
+// TIMER: press/long-press maps to timer FSM events per current phase.
+// GOAL_SELECT: rotation scrolls goals, press selects a goal.
+enum class ScreenMode : uint8_t {
+  TIMER,
+  GOAL_SELECT,
+};
+
+// Result of mapping an encoder press to a timer event.
+// valid=false means the press has no timer event mapping in the current state
+// (e.g., rotation during focusing, or press in a terminal state).
+struct MappedEvent {
+  bool valid;
+  TimerEvent event;
+};
+
+// Map a press event to a timer FSM event based on the current timer phase.
+// Only meaningful in TIMER screen mode.
+//
+// Mapping table (from issue #221 acceptance criteria):
+//   idle:         SHORT_PRESS -> START
+//   focusing:     SHORT_PRESS -> PAUSE,   LONG_PRESS -> ABANDON
+//   paused:       SHORT_PRESS -> RESUME,  LONG_PRESS -> ABANDON
+//   short_break:  SHORT_PRESS -> SKIP_BREAK, LONG_PRESS -> ABANDON
+//   long_break:   SHORT_PRESS -> SKIP_BREAK, LONG_PRESS -> ABANDON
+//   break_paused: SHORT_PRESS -> SKIP_BREAK, LONG_PRESS -> ABANDON
+//   reflection:   SHORT_PRESS -> SKIP (skip reflection on device)
+//   completed:    SHORT_PRESS -> RESET
+//   abandoned:    SHORT_PRESS -> RESET
+MappedEvent input_map_press(TimerPhase phase, PressEvent press);
+
+// Map a rotation event in GOAL_SELECT mode to a delta for the goal selection index.
+// Returns +1 for CW (next goal), -1 for CCW (previous goal), 0 for no rotation.
+int8_t input_map_rotation_to_goal_delta(RotationDir dir);
+
 #endif // POMOFOCUS_INPUT_H

--- a/firmware/device/src/main.cpp
+++ b/firmware/device/src/main.cpp
@@ -1,16 +1,194 @@
 // PomoFocus Device Firmware — EN04 (nRF52840 Plus)
 // Arduino setup/loop skeleton. See ADR-010 and ADR-015.
+// Input-to-timer event mapping wired in loop() (issue #221).
 
 #include <Arduino.h>
 #include "display.h"
 #include "input.h"
 #include "timer.h"
+#include "feedback.h"
 
 // Serial baud rate for debug output (matches monitor_speed in platformio.ini)
 constexpr uint32_t SERIAL_BAUD = 115200;
 
 // LED blink duration in milliseconds
 constexpr uint32_t LED_BLINK_MS = 500;
+
+// Timer tick interval: 1 second (matches timer FSM expectation of 1 TICK per second)
+constexpr uint32_t TICK_INTERVAL_MS = 1000;
+
+// ---------- Application state ----------
+// All static, zero dynamic allocation (NAT-F01).
+
+static TimerState g_timerState = createIdleState(DEFAULT_TIMER_CONFIG);
+static ScreenMode g_screenMode = ScreenMode::TIMER;
+static uint8_t g_selectedGoal = 0;
+static uint8_t g_sessionsToday = 0;
+static unsigned long g_lastTickMs = 0;
+static bool g_displayDirty = true;  // Force initial display update
+
+// Goal data — synced from phone via BLE (stub for now).
+static Display::GoalInfo g_goals[Display::MAX_GOALS] = {};
+static uint8_t g_goalCount = 0;
+
+// Feedback driver
+static Feedback g_feedback;
+
+// ---------- Display helpers ----------
+
+// Map TimerPhase to feedback TimerStatus (separate enums due to different modules).
+static TimerStatus phaseToStatus(TimerPhase phase) {
+  switch (phase) {
+    case TimerPhase::idle:         return TimerStatus::IDLE;
+    case TimerPhase::focusing:     return TimerStatus::FOCUSING;
+    case TimerPhase::paused:       return TimerStatus::PAUSED;
+    case TimerPhase::short_break:  return TimerStatus::SHORT_BREAK;
+    case TimerPhase::long_break:   return TimerStatus::LONG_BREAK;
+    case TimerPhase::break_paused: return TimerStatus::BREAK_PAUSED;
+    case TimerPhase::reflection:   return TimerStatus::REFLECTION;
+    case TimerPhase::completed:    return TimerStatus::COMPLETED;
+    case TimerPhase::abandoned:    return TimerStatus::ABANDONED;
+  }
+  return TimerStatus::IDLE;
+}
+
+// Get the title of the currently selected goal, or nullptr if none.
+static const char* currentGoalTitle() {
+  if (g_goalCount == 0 || g_selectedGoal >= g_goalCount) {
+    return nullptr;
+  }
+  return g_goals[g_selectedGoal].title;
+}
+
+// Refresh the display based on current screen mode and timer state.
+static void refreshDisplay() {
+  if (g_screenMode == ScreenMode::GOAL_SELECT) {
+    Display::showGoalScreen(g_goals, g_goalCount, g_selectedGoal);
+    return;
+  }
+
+  // TIMER mode: choose screen based on phase
+  switch (g_timerState.phase) {
+    case TimerPhase::idle:
+      Display::showIdleScreen(g_sessionsToday, currentGoalTitle());
+      break;
+
+    case TimerPhase::focusing:
+    case TimerPhase::paused:
+    case TimerPhase::short_break:
+    case TimerPhase::long_break:
+    case TimerPhase::break_paused: {
+      uint32_t mins = g_timerState.timeRemaining / 60;
+      uint32_t secs = g_timerState.timeRemaining % 60;
+      Display::showTimerScreen(mins, secs, g_timerState.phase,
+                               g_timerState.sessionNumber, currentGoalTitle());
+      break;
+    }
+
+    case TimerPhase::reflection:
+      Display::showTimerScreen(0, 0, TimerPhase::reflection,
+                               g_timerState.sessionNumber, currentGoalTitle());
+      break;
+
+    case TimerPhase::completed: {
+      Display::SessionSummary summary = {};
+      summary.focusDurationSec = g_timerState.config.focusDuration;
+      summary.sessionNumber = static_cast<uint8_t>(g_timerState.sessionNumber);
+      const char* goal = currentGoalTitle();
+      if (goal != nullptr) {
+        strncpy(summary.goalTitle, goal, Display::MAX_GOAL_TITLE_LEN);
+        summary.goalTitle[Display::MAX_GOAL_TITLE_LEN] = '\0';
+      } else {
+        summary.goalTitle[0] = '\0';
+      }
+      Display::showSessionComplete(summary);
+      break;
+    }
+
+    case TimerPhase::abandoned:
+      Display::showIdleScreen(g_sessionsToday, currentGoalTitle());
+      break;
+  }
+}
+
+// Apply a timer event: run the FSM transition and mark display dirty if state changed.
+static void applyTimerEvent(TimerEvent event) {
+  TimerPhase prevPhase = g_timerState.phase;
+  uint32_t prevTime = g_timerState.timeRemaining;
+
+  g_timerState = transition(g_timerState, event, millis());
+
+  if (g_timerState.phase != prevPhase || g_timerState.timeRemaining != prevTime) {
+    g_displayDirty = true;
+  }
+
+  // Track completed sessions
+  if (prevPhase != TimerPhase::completed && g_timerState.phase == TimerPhase::completed) {
+    g_sessionsToday++;
+  }
+}
+
+// ---------- Input callbacks ----------
+
+static void onRotation(RotationDir direction, int32_t /* step_count */) {
+  if (g_screenMode == ScreenMode::GOAL_SELECT) {
+    int8_t delta = input_map_rotation_to_goal_delta(direction);
+    if (delta == 0) {
+      return;
+    }
+    int16_t newIdx = static_cast<int16_t>(g_selectedGoal) + delta;
+    if (newIdx < 0) {
+      newIdx = 0;
+    }
+    if (newIdx >= g_goalCount) {
+      newIdx = g_goalCount > 0 ? g_goalCount - 1 : 0;
+    }
+    if (static_cast<uint8_t>(newIdx) != g_selectedGoal) {
+      g_selectedGoal = static_cast<uint8_t>(newIdx);
+      g_displayDirty = true;
+      Serial.print("[main] goal select idx=");
+      Serial.println(g_selectedGoal);
+    }
+    return;
+  }
+
+  // In idle/timer mode, rotation while idle enters goal selection
+  if (g_timerState.phase == TimerPhase::idle && g_goalCount > 0) {
+    g_screenMode = ScreenMode::GOAL_SELECT;
+    g_displayDirty = true;
+    Serial.println("[main] entering goal select");
+  }
+}
+
+static void onPress(PressEvent press) {
+  // Goal select mode: press = select goal and return to timer
+  if (g_screenMode == ScreenMode::GOAL_SELECT) {
+    if (press == PressEvent::SHORT_PRESS) {
+      g_screenMode = ScreenMode::TIMER;
+      g_displayDirty = true;
+      Serial.print("[main] goal selected idx=");
+      Serial.println(g_selectedGoal);
+    }
+    return;
+  }
+
+  // Timer mode: map press to timer FSM event
+  MappedEvent mapped = input_map_press(g_timerState.phase, press);
+  if (mapped.valid) {
+    Serial.print("[main] timer event from press: ");
+    Serial.println(static_cast<uint8_t>(mapped.event));
+    applyTimerEvent(mapped.event);
+
+    // Haptic feedback on user-initiated actions
+    if (press == PressEvent::LONG_PRESS) {
+      g_feedback.vibratePattern(VibrationPattern::LONG_BUZZ);
+    } else {
+      g_feedback.vibratePattern(VibrationPattern::SHORT_BUZZ);
+    }
+  }
+}
+
+// ---------- Arduino entry points ----------
 
 void setup() {
   Serial.begin(SERIAL_BAUD);
@@ -27,17 +205,57 @@ void setup() {
   delay(LED_BLINK_MS);
   digitalWrite(LED_BUILTIN, HIGH);
 
-  // Initialize e-ink display and show test pattern.
+  // Initialize e-ink display and show idle screen.
   Display::init();
-  Display::showTestPattern();
 
   // Initialize rotary encoder input (rotation + press).
   input_init();
+  input_on_rotation(onRotation);
+  input_set_press_callback(onPress);
+
+  // Initialize feedback drivers.
+  initLed();
+  g_feedback.begin();
+
+  // Initialize timer tick baseline.
+  g_lastTickMs = millis();
 
   Serial.println("Setup complete");
 }
 
 void loop() {
+  unsigned long now = millis();
+
   // Poll rotary encoder for rotation and press events.
   input_poll();
+
+  // Timer tick: send TICK event every second while timer is running.
+  if (now - g_lastTickMs >= TICK_INTERVAL_MS) {
+    g_lastTickMs = now;
+
+    TimerPhase phase = g_timerState.phase;
+    if (phase == TimerPhase::focusing ||
+        phase == TimerPhase::short_break ||
+        phase == TimerPhase::long_break) {
+      applyTimerEvent(TimerEvent::TICK);
+
+      // Check if time ran out — fire TIMER_DONE
+      if (g_timerState.timeRemaining == 0) {
+        g_feedback.vibratePattern(VibrationPattern::TIMER_END);
+        applyTimerEvent(TimerEvent::TIMER_DONE);
+      }
+    }
+  }
+
+  // Update LED based on current timer state.
+  updateLed(phaseToStatus(g_timerState.phase));
+
+  // Update vibration motor (non-blocking pattern playback).
+  g_feedback.update();
+
+  // Refresh display only when state changes (e-ink is slow).
+  if (g_displayDirty) {
+    g_displayDirty = false;
+    refreshDisplay();
+  }
 }


### PR DESCRIPTION
## Summary

- Implements encoder press/rotation-to-timer FSM event mapping based on current timer phase (`input_map_press`, `input_map_rotation_to_goal_delta`)
- Wires input polling into the main loop with timer tick dispatching, display refresh, haptic feedback, and goal selection screen mode
- Adds `ScreenMode` enum and `MappedEvent` struct to support context-aware input handling

Closes #221

## Mapping Table

| Timer Phase | Short Press | Long Press |
|---|---|---|
| idle | START | — |
| focusing | PAUSE | ABANDON |
| paused | RESUME | ABANDON |
| short_break / long_break / break_paused | SKIP_BREAK | ABANDON |
| reflection | SKIP | — |
| completed / abandoned | RESET | — |

Goal select mode: rotate = scroll goals, short press = select goal

## Test plan

- [ ] `pio run` compiles without errors
- [ ] Manual: encoder press in idle starts timer
- [ ] Manual: encoder press in focusing pauses, long press abandons
- [ ] Manual: rotation in idle enters goal selection, press selects goal
- [ ] Manual: break states respond to SKIP_BREAK on press

🤖 Generated with [Claude Code](https://claude.com/claude-code)