### PR TITLE
feat: implement timer guards -- isLongBreak and session counting (#213)

### DIFF
--- a/firmware/device/src/timer.cpp
+++ b/firmware/device/src/timer.cpp
@@ -6,13 +6,13 @@
 
 // ── Guards (port of packages/core/src/timer/guards.ts) ──
 
-static bool isLongBreak(uint32_t sessionNumber, const TimerConfig& config) {
+bool isLongBreak(uint32_t sessionNumber, const TimerConfig& config) {
   if (sessionNumber < 1) return false;
   if (config.sessionsBeforeLongBreak < 1) return false;
   return sessionNumber % config.sessionsBeforeLongBreak == 0;
 }
 
-static bool isReflectionEnabled(const TimerConfig& config) {
+bool isReflectionEnabled(const TimerConfig& config) {
   return config.reflectionEnabled;
 }
 

--- a/firmware/device/src/timer.h
+++ b/firmware/device/src/timer.h
@@ -102,6 +102,17 @@ constexpr TimerState createIdleState(TimerConfig config) {
   };
 }
 
+// ── Guard Functions ──
+// Port of packages/core/src/timer/guards.ts.
+// Used by transition function for break-type selection and session flow.
+
+// Returns true when sessionNumber is a multiple of sessionsBeforeLongBreak.
+// Session 0 and invalid config (sessionsBeforeLongBreak < 1) return false.
+bool isLongBreak(uint32_t sessionNumber, const TimerConfig& config);
+
+// Returns true when reflection is enabled in the config.
+bool isReflectionEnabled(const TimerConfig& config);
+
 // ── Transition Function ──
 // Pure function: transition(state, event, now) -> newState.
 // Direct port of packages/core/src/timer/transition.ts.


### PR DESCRIPTION
## Summary

- Expose `isLongBreak` and `isReflectionEnabled` guard functions as public API in `timer.h`
- Remove `static` linkage from guard implementations in `timer.cpp` so they can be called by the transition function for break-type selection
- Guards determine short vs long break based on session count modulo `sessionsBeforeLongBreak` (default: every 4 sessions)

Closes #213

## Test plan

- [ ] `pio run` compiles successfully
- [ ] `isLongBreak` returns true when sessionNumber is a multiple of sessionsBeforeLongBreak
- [ ] `isLongBreak` returns false for non-multiples
- [ ] Session cycles are open-ended (no totalSessions limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)