### PR TITLE
feat: implement Tier 3 aggregate and cold-start thresholds (#197)

### DIFF
--- a/packages/analytics/src/cold-start.test.ts
+++ b/packages/analytics/src/cold-start.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import type { Session } from '@pomofocus/types';
+import { hasSufficientData } from './cold-start.js';
+
+/** Helper to create a minimal session with overrides. */
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-1',
+    user_id: 'user-1',
+    process_goal_id: 'goal-1',
+    intention_text: null,
+    started_at: '2026-03-10T09:00:00Z',
+    ended_at: '2026-03-10T09:25:00Z',
+    completed: true,
+    abandonment_reason: null,
+    focus_quality: 'locked_in',
+    distraction_type: null,
+    device_id: null,
+    created_at: '2026-03-10T09:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('hasSufficientData', () => {
+  describe('tier1', () => {
+    it('always returns true even with no sessions', () => {
+      expect(hasSufficientData([], 'tier1')).toBe(true);
+    });
+
+    it('returns true with sessions', () => {
+      expect(hasSufficientData([makeSession()], 'tier1')).toBe(true);
+    });
+  });
+
+  describe('tier2', () => {
+    it('returns false with no sessions', () => {
+      expect(hasSufficientData([], 'tier2')).toBe(false);
+    });
+
+    it('returns false when all sessions are incomplete', () => {
+      const sessions = [
+        makeSession({ completed: false }),
+        makeSession({ completed: false }),
+      ];
+      expect(hasSufficientData(sessions, 'tier2')).toBe(false);
+    });
+
+    it('returns true with at least one completed session', () => {
+      const sessions = [makeSession({ completed: true })];
+      expect(hasSufficientData(sessions, 'tier2')).toBe(true);
+    });
+
+    it('returns true when mix of completed and incomplete', () => {
+      const sessions = [
+        makeSession({ completed: false }),
+        makeSession({ completed: true }),
+      ];
+      expect(hasSufficientData(sessions, 'tier2')).toBe(true);
+    });
+  });
+
+  describe('tier3', () => {
+    it('returns false with no sessions', () => {
+      expect(hasSufficientData([], 'tier3')).toBe(false);
+    });
+
+    it('returns false with only one month of data', () => {
+      const sessions = [
+        makeSession({
+          completed: true,
+          started_at: '2026-03-01T09:00:00Z',
+        }),
+        makeSession({
+          completed: true,
+          started_at: '2026-03-15T09:00:00Z',
+        }),
+      ];
+      expect(hasSufficientData(sessions, 'tier3')).toBe(false);
+    });
+
+    it('returns true with two consecutive months of completed sessions', () => {
+      const sessions = [
+        makeSession({
+          completed: true,
+          started_at: '2026-02-10T09:00:00Z',
+        }),
+        makeSession({
+          completed: true,
+          started_at: '2026-03-10T09:00:00Z',
+        }),
+      ];
+      expect(hasSufficientData(sessions, 'tier3')).toBe(true);
+    });
+
+    it('returns true with two non-consecutive months (Jan + Mar)', () => {
+      const sessions = [
+        makeSession({
+          completed: true,
+          started_at: '2026-01-10T09:00:00Z',
+        }),
+        makeSession({
+          completed: true,
+          started_at: '2026-03-10T09:00:00Z',
+        }),
+      ];
+      expect(hasSufficientData(sessions, 'tier3')).toBe(true);
+    });
+
+    it('ignores non-completed sessions', () => {
+      const sessions = [
+        makeSession({
+          completed: false,
+          started_at: '2026-01-10T09:00:00Z',
+        }),
+        makeSession({
+          completed: true,
+          started_at: '2026-03-10T09:00:00Z',
+        }),
+      ];
+      // Only 1 month with completed sessions
+      expect(hasSufficientData(sessions, 'tier3')).toBe(false);
+    });
+
+    it('counts distinct months correctly with multiple sessions per month', () => {
+      const sessions = [
+        makeSession({
+          completed: true,
+          started_at: '2026-01-01T09:00:00Z',
+        }),
+        makeSession({
+          completed: true,
+          started_at: '2026-01-15T09:00:00Z',
+        }),
+        makeSession({
+          completed: true,
+          started_at: '2026-01-28T09:00:00Z',
+        }),
+        makeSession({
+          completed: true,
+          started_at: '2026-03-10T09:00:00Z',
+        }),
+      ];
+      // 2 distinct months: Jan and Mar
+      expect(hasSufficientData(sessions, 'tier3')).toBe(true);
+    });
+
+    it('returns true with more than 2 months of data', () => {
+      const sessions = [
+        makeSession({
+          completed: true,
+          started_at: '2026-01-10T09:00:00Z',
+        }),
+        makeSession({
+          completed: true,
+          started_at: '2026-02-10T09:00:00Z',
+        }),
+        makeSession({
+          completed: true,
+          started_at: '2026-03-10T09:00:00Z',
+        }),
+      ];
+      expect(hasSufficientData(sessions, 'tier3')).toBe(true);
+    });
+
+    it('handles sessions across different years', () => {
+      const sessions = [
+        makeSession({
+          completed: true,
+          started_at: '2025-12-10T09:00:00Z',
+        }),
+        makeSession({
+          completed: true,
+          started_at: '2026-01-10T09:00:00Z',
+        }),
+      ];
+      // 2 distinct months: 2025-12 and 2026-01
+      expect(hasSufficientData(sessions, 'tier3')).toBe(true);
+    });
+  });
+});

--- a/packages/analytics/src/cold-start.ts
+++ b/packages/analytics/src/cold-start.ts
@@ -1,0 +1,53 @@
+import type { Session } from '@pomofocus/types';
+
+/**
+ * Analytics tier identifiers for cold-start threshold checks.
+ *
+ * Using `as const` object + derived union per U-010.
+ */
+export const ANALYTICS_TIER = {
+  TIER_1: 'tier1',
+  TIER_2: 'tier2',
+  TIER_3: 'tier3',
+} as const;
+
+export type AnalyticsTier =
+  (typeof ANALYTICS_TIER)[keyof typeof ANALYTICS_TIER];
+
+/**
+ * Check whether the user has sufficient data for a given analytics tier.
+ *
+ * Thresholds (from ADR-014 + domain gap closures):
+ * - Tier 1: always valid — glanceable metrics work from day zero.
+ * - Tier 2: >= 1 completed session all-time.
+ * - Tier 3: >= 2 distinct calendar months (UTC), each with >= 1 completed
+ *   session. Months need not be consecutive (Jan + Mar is valid).
+ */
+export function hasSufficientData(
+  sessions: readonly Session[],
+  tier: AnalyticsTier,
+): boolean {
+  switch (tier) {
+    case 'tier1':
+      return true;
+
+    case 'tier2':
+      return sessions.some((s) => s.completed);
+
+    case 'tier3': {
+      const monthsWithData = new Set<string>();
+      for (const s of sessions) {
+        if (s.completed && s.started_at) {
+          // Extract YYYY-MM from the ISO timestamp
+          monthsWithData.add(s.started_at.slice(0, 7));
+        }
+      }
+      return monthsWithData.size >= 2;
+    }
+
+    default: {
+      const _exhaustive: never = tier;
+      return _exhaustive;
+    }
+  }
+}

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -11,7 +11,7 @@ export { perGoalBreakdown } from './tier2/index.js';
 export type { GoalBreakdownEntry } from './tier2/index.js';
 
 // ── Tier 3: Monthly trends ──
-export type { TrendResult, DistractionPattern, GoalBreakdown } from './tier3/index.js';
+export type { TrendResult, DistractionPattern, GoalBreakdown, MonthlyResponse } from './tier3/index.js';
 export {
   consistencyTrend,
   completionTrend,
@@ -20,4 +20,9 @@ export {
   monthlyTrends,
   distractionPatterns,
   perGoalBreakdown as perGoalMonthlyBreakdown,
+  tierThreeMetrics,
 } from './tier3/index.js';
+
+// ── Cold-start thresholds ──
+export { hasSufficientData, ANALYTICS_TIER } from './cold-start.js';
+export type { AnalyticsTier } from './cold-start.js';

--- a/packages/analytics/src/tier3/index.test.ts
+++ b/packages/analytics/src/tier3/index.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect } from 'vitest';
+import type { Session } from '@pomofocus/types';
+import { tierThreeMetrics } from './index.js';
+
+/** Helper to create a minimal session with overrides. */
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-1',
+    user_id: 'user-1',
+    process_goal_id: 'goal-1',
+    intention_text: null,
+    started_at: '2026-03-10T09:00:00Z',
+    ended_at: '2026-03-10T09:25:00Z',
+    completed: true,
+    abandonment_reason: null,
+    focus_quality: 'locked_in',
+    distraction_type: null,
+    device_id: null,
+    created_at: '2026-03-10T09:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('tierThreeMetrics', () => {
+  it('returns null when cold-start threshold is not met (< 2 months)', () => {
+    const marSession = makeSession({
+      completed: true,
+      started_at: '2026-03-10T09:00:00Z',
+    });
+    const allSessions = [marSession];
+
+    const result = tierThreeMetrics(allSessions, [marSession], [], 31, 28);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when cold-start passes but current month has no completed sessions', () => {
+    // Cold-start passes: 2 months with data (Feb + Mar)
+    const febSession = makeSession({
+      completed: true,
+      started_at: '2026-02-10T09:00:00Z',
+    });
+    const marSession = makeSession({
+      completed: true,
+      started_at: '2026-03-10T09:00:00Z',
+    });
+    const allSessions = [febSession, marSession];
+    // But we pass empty current month
+    const result = tierThreeMetrics(allSessions, [], [febSession], 31, 28);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when cold-start passes but previous month has no completed sessions', () => {
+    const febSession = makeSession({
+      completed: true,
+      started_at: '2026-02-10T09:00:00Z',
+    });
+    const marSession = makeSession({
+      completed: true,
+      started_at: '2026-03-10T09:00:00Z',
+    });
+    const allSessions = [febSession, marSession];
+    const result = tierThreeMetrics(allSessions, [marSession], [], 31, 28);
+    expect(result).toBeNull();
+  });
+
+  it('returns full MonthlyResponse when sufficient data exists', () => {
+    const febSession = makeSession({
+      id: 'feb-1',
+      completed: true,
+      started_at: '2026-02-10T09:00:00Z',
+      ended_at: '2026-02-10T09:25:00Z',
+      focus_quality: 'decent',
+    });
+    const marSession = makeSession({
+      id: 'mar-1',
+      completed: true,
+      started_at: '2026-03-10T09:00:00Z',
+      ended_at: '2026-03-10T09:25:00Z',
+      focus_quality: 'locked_in',
+    });
+
+    const allSessions = [febSession, marSession];
+    const result = tierThreeMetrics(
+      allSessions,
+      [marSession],
+      [febSession],
+      31,
+      28,
+    );
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+
+    // Verify shape has all required fields
+    expect(result.trends).toHaveProperty('consistency');
+    expect(result.trends).toHaveProperty('completionRate');
+    expect(result.trends).toHaveProperty('focusQuality');
+    expect(result.trends).toHaveProperty('totalHours');
+    expect(result).toHaveProperty('topDistraction');
+    expect(result).toHaveProperty('perGoal');
+  });
+
+  it('computes correct trend values', () => {
+    const febSessions = [
+      makeSession({
+        id: 'feb-1',
+        completed: true,
+        started_at: '2026-02-05T09:00:00Z',
+        ended_at: '2026-02-05T09:30:00Z',
+        focus_quality: 'locked_in',
+      }),
+    ];
+    const marSessions = [
+      makeSession({
+        id: 'mar-1',
+        completed: true,
+        started_at: '2026-03-01T09:00:00Z',
+        ended_at: '2026-03-01T09:30:00Z',
+        focus_quality: 'locked_in',
+      }),
+      makeSession({
+        id: 'mar-2',
+        completed: true,
+        started_at: '2026-03-02T09:00:00Z',
+        ended_at: '2026-03-02T09:30:00Z',
+        focus_quality: 'decent',
+      }),
+    ];
+
+    const allSessions = [...febSessions, ...marSessions];
+    const result = tierThreeMetrics(
+      allSessions,
+      marSessions,
+      febSessions,
+      31,
+      28,
+    );
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+
+    // Consistency: Mar 2 days / 31, Feb 1 day / 28
+    expect(result.trends.consistency.current).toBeCloseTo(2 / 31);
+    expect(result.trends.consistency.previous).toBeCloseTo(1 / 28);
+
+    // Completion: 2/2 = 1.0, 1/1 = 1.0
+    expect(result.trends.completionRate.current).toBeCloseTo(1.0);
+    expect(result.trends.completionRate.previous).toBeCloseTo(1.0);
+
+    // Focus quality: Mar 1 locked_in / 2 = 0.5, Feb 1/1 = 1.0
+    expect(result.trends.focusQuality.current).toBeCloseTo(0.5);
+    expect(result.trends.focusQuality.previous).toBeCloseTo(1.0);
+
+    // Total hours: Mar 30min + 30min = 1h, Feb 30min = 0.5h
+    expect(result.trends.totalHours.current).toBeCloseTo(1.0);
+    expect(result.trends.totalHours.previous).toBeCloseTo(0.5);
+  });
+
+  it('includes top distraction from current month', () => {
+    const febSessions = [
+      makeSession({
+        id: 'feb-1',
+        completed: true,
+        started_at: '2026-02-10T09:00:00Z',
+        ended_at: '2026-02-10T09:25:00Z',
+      }),
+    ];
+    const marSessions = [
+      makeSession({
+        id: 'mar-1',
+        completed: true,
+        started_at: '2026-03-10T09:00:00Z',
+        ended_at: '2026-03-10T09:25:00Z',
+        focus_quality: 'struggled',
+        distraction_type: 'phone',
+      }),
+      makeSession({
+        id: 'mar-2',
+        completed: true,
+        started_at: '2026-03-11T09:00:00Z',
+        ended_at: '2026-03-11T09:25:00Z',
+        focus_quality: 'struggled',
+        distraction_type: 'phone',
+      }),
+      makeSession({
+        id: 'mar-3',
+        completed: true,
+        started_at: '2026-03-12T09:00:00Z',
+        ended_at: '2026-03-12T09:25:00Z',
+        focus_quality: 'struggled',
+        distraction_type: 'thoughts_wandering',
+      }),
+    ];
+
+    const allSessions = [...febSessions, ...marSessions];
+    const result = tierThreeMetrics(
+      allSessions,
+      marSessions,
+      febSessions,
+      31,
+      28,
+    );
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+
+    expect(result.topDistraction).toEqual({ type: 'phone', count: 2 });
+  });
+
+  it('returns null topDistraction when no struggled sessions', () => {
+    const febSessions = [
+      makeSession({
+        id: 'feb-1',
+        completed: true,
+        started_at: '2026-02-10T09:00:00Z',
+        ended_at: '2026-02-10T09:25:00Z',
+        focus_quality: 'locked_in',
+      }),
+    ];
+    const marSessions = [
+      makeSession({
+        id: 'mar-1',
+        completed: true,
+        started_at: '2026-03-10T09:00:00Z',
+        ended_at: '2026-03-10T09:25:00Z',
+        focus_quality: 'locked_in',
+      }),
+    ];
+
+    const allSessions = [...febSessions, ...marSessions];
+    const result = tierThreeMetrics(
+      allSessions,
+      marSessions,
+      febSessions,
+      31,
+      28,
+    );
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+
+    expect(result.topDistraction).toBeNull();
+  });
+
+  it('includes per-goal breakdown from current month', () => {
+    const febSessions = [
+      makeSession({
+        id: 'feb-1',
+        completed: true,
+        started_at: '2026-02-10T09:00:00Z',
+        ended_at: '2026-02-10T09:25:00Z',
+      }),
+    ];
+    const marSessions = [
+      makeSession({
+        id: 'mar-1',
+        process_goal_id: 'goal-a',
+        completed: true,
+        started_at: '2026-03-10T09:00:00Z',
+        ended_at: '2026-03-10T09:25:00Z',
+      }),
+      makeSession({
+        id: 'mar-2',
+        process_goal_id: 'goal-a',
+        completed: true,
+        started_at: '2026-03-11T09:00:00Z',
+        ended_at: '2026-03-11T09:30:00Z',
+      }),
+      makeSession({
+        id: 'mar-3',
+        process_goal_id: 'goal-b',
+        completed: true,
+        started_at: '2026-03-12T09:00:00Z',
+        ended_at: '2026-03-12T09:25:00Z',
+      }),
+    ];
+
+    const allSessions = [...febSessions, ...marSessions];
+    const result = tierThreeMetrics(
+      allSessions,
+      marSessions,
+      febSessions,
+      31,
+      28,
+    );
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+
+    expect(result.perGoal).toHaveLength(2);
+
+    const goalA = result.perGoal.find((g) => g.goalId === 'goal-a');
+    expect(goalA).toEqual(
+      expect.objectContaining({ sessions: 2 }),
+    );
+    expect(goalA?.focusMinutes).toBeCloseTo(55); // 25 + 30
+
+    const goalB = result.perGoal.find((g) => g.goalId === 'goal-b');
+    expect(goalB).toEqual(
+      expect.objectContaining({ sessions: 1 }),
+    );
+    expect(goalB?.focusMinutes).toBeCloseTo(25);
+  });
+
+  it('works with non-consecutive months (Jan + Mar)', () => {
+    const janSessions = [
+      makeSession({
+        id: 'jan-1',
+        completed: true,
+        started_at: '2026-01-15T09:00:00Z',
+        ended_at: '2026-01-15T09:25:00Z',
+      }),
+    ];
+    const marSessions = [
+      makeSession({
+        id: 'mar-1',
+        completed: true,
+        started_at: '2026-03-10T09:00:00Z',
+        ended_at: '2026-03-10T09:25:00Z',
+      }),
+    ];
+
+    // allSessions includes Jan + Mar — non-consecutive, still passes cold-start
+    const allSessions = [...janSessions, ...marSessions];
+
+    // Comparing Mar (current) vs Jan (previous) — both have data
+    const result = tierThreeMetrics(
+      allSessions,
+      marSessions,
+      janSessions,
+      31,
+      31,
+    );
+
+    expect(result).not.toBeNull();
+  });
+});

--- a/packages/analytics/src/tier3/index.ts
+++ b/packages/analytics/src/tier3/index.ts
@@ -1,4 +1,15 @@
-export type { TrendResult, DistractionPattern, GoalBreakdown } from './types.js';
+import type { Session } from '@pomofocus/types';
+import type { MonthlyResponse } from './types.js';
+import { hasSufficientData } from '../cold-start.js';
+import { monthlyTrends } from './trends.js';
+import { distractionPatterns, perGoalBreakdown } from './distractions.js';
+
+export type {
+  TrendResult,
+  DistractionPattern,
+  GoalBreakdown,
+  MonthlyResponse,
+} from './types.js';
 export {
   consistencyTrend,
   completionTrend,
@@ -7,3 +18,46 @@ export {
   monthlyTrends,
 } from './trends.js';
 export { distractionPatterns, perGoalBreakdown } from './distractions.js';
+
+/**
+ * Compose all Tier 3 analytics into the MonthlyResponse shape.
+ *
+ * Returns null when cold-start conditions are not met:
+ * requires >= 2 calendar months each with >= 1 completed session
+ * (months need not be consecutive).
+ *
+ * The `allSessions` parameter is the user's full session history,
+ * used for cold-start checking. `currentMonthSessions` and
+ * `prevMonthSessions` are the filtered subsets for the two months
+ * being compared.
+ */
+export function tierThreeMetrics(
+  allSessions: readonly Session[],
+  currentMonthSessions: readonly Session[],
+  prevMonthSessions: readonly Session[],
+  currentMonthDays: number,
+  prevMonthDays: number,
+): MonthlyResponse | null {
+  if (!hasSufficientData(allSessions, 'tier3')) {
+    return null;
+  }
+
+  const trends = monthlyTrends(
+    currentMonthSessions,
+    prevMonthSessions,
+    currentMonthDays,
+    prevMonthDays,
+  );
+
+  // monthlyTrends returns null when either month lacks completed sessions.
+  // This is a stricter per-month check on top of the cold-start gate.
+  if (trends === null) {
+    return null;
+  }
+
+  return {
+    trends,
+    topDistraction: distractionPatterns(currentMonthSessions),
+    perGoal: perGoalBreakdown(currentMonthSessions),
+  };
+}

--- a/packages/analytics/src/tier3/types.ts
+++ b/packages/analytics/src/tier3/types.ts
@@ -18,3 +18,15 @@ export type GoalBreakdown = {
   readonly sessions: number;
   readonly focusMinutes: number;
 };
+
+/** Full Tier 3 monthly response shape. */
+export type MonthlyResponse = {
+  readonly trends: {
+    readonly consistency: TrendResult;
+    readonly completionRate: TrendResult;
+    readonly focusQuality: TrendResult;
+    readonly totalHours: TrendResult;
+  };
+  readonly topDistraction: DistractionPattern;
+  readonly perGoal: readonly GoalBreakdown[];
+};


### PR DESCRIPTION
## Summary

- Implements `tierThreeMetrics()` in `packages/analytics/src/tier3/index.ts` — composes all Tier 3 functions into the `MonthlyResponse` shape with trends (consistency, completionRate, focusQuality, totalHours), topDistraction, and perGoal breakdown
- Adds shared `hasSufficientData(sessions, tier)` cold-start utility in `packages/analytics/src/cold-start.ts` — enforces thresholds per tier (Tier 1: always valid, Tier 2: >= 1 completed session, Tier 3: >= 2 calendar months with completed sessions, non-consecutive allowed)
- Adds `MonthlyResponse` type in `packages/analytics/src/tier3/types.ts`
- Re-exports new symbols from `packages/analytics/src/index.ts`
- Comprehensive test suites for both `tierThreeMetrics` (337 lines) and `hasSufficientData` (180 lines)

Closes #197

## Test plan

- [x] `pnpm nx test @pomofocus/analytics` — all tests pass
- [ ] Verify cold-start returns null for < 2 months of data
- [ ] Verify non-consecutive months (Jan + Mar) pass cold-start
- [ ] Verify MonthlyResponse shape matches ADR-014 Tier 3 spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)