### PR TITLE
feat: protect all API routes with auth middleware

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,13 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { corsMiddleware } from './middleware/cors.js';
+import { authMiddleware } from './middleware/auth.js';
 import { errorHandler } from './middleware/error-handler.js';
 import { registerHealthRoute } from './routes/health.js';
 import { registerMeRoute } from './routes/me.js';
 import { registerSessionsRoute } from './routes/sessions.js';
+import type { AppEnv } from './types.js';
 
-const app = new OpenAPIHono({
+const app = new OpenAPIHono<AppEnv>({
   defaultHook: (result, c) => {
     if (!result.success) {
       return c.json({ error: 'Validation failed', details: result.error.flatten() }, 422);
@@ -15,6 +17,10 @@ const app = new OpenAPIHono({
 
 app.use('*', corsMiddleware);
 app.onError(errorHandler);
+
+// Auth middleware applies to all /v1/* routes only.
+// /health remains publicly accessible.
+app.use('/v1/*', authMiddleware);
 
 registerHealthRoute(app);
 registerMeRoute(app);
@@ -26,6 +32,14 @@ app.doc('/openapi.json', {
     title: 'PomoFocus API',
     version: '0.1.0',
   },
+  security: [{ Bearer: [] }],
+});
+
+app.openAPIRegistry.registerComponent('securitySchemes', 'Bearer', {
+  type: 'http',
+  scheme: 'bearer',
+  bearerFormat: 'JWT',
+  description: 'Supabase JWT access token',
 });
 
 export default app;

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import type { OpenAPIHono } from '@hono/zod-openapi';
+import type { AppEnv } from '../types.js';
 
 /**
  * Zod schema for the health check response.
@@ -30,7 +31,7 @@ export const healthRoute = createRoute({
 /**
  * Registers the health route on the given OpenAPIHono app.
  */
-export function registerHealthRoute(app: OpenAPIHono): void {
+export function registerHealthRoute(app: OpenAPIHono<AppEnv>): void {
   app.openapi(healthRoute, (c) => {
     return c.json(
       {

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1,52 +1,140 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { OpenAPIHono } from '@hono/zod-openapi';
+import { authMiddleware } from '../middleware/auth.js';
+import type { AuthVariables } from '../middleware/auth.js';
+import type { SupabaseEnv } from '../lib/supabase.js';
 import { registerMeRoute, MeResponseSchema } from './me.js';
 
-function createTestApp(): OpenAPIHono {
-  const app = new OpenAPIHono();
+/**
+ * Mock the Supabase client factory so no real clients are created.
+ * Uses vi.hoisted() because vi.mock factories are hoisted above imports.
+ */
+const { mockCreateUserClient, mockGetUser } = vi.hoisted(() => ({
+  mockCreateUserClient: vi.fn(),
+  mockGetUser: vi.fn(),
+}));
+
+vi.mock('../lib/supabase.js', () => ({
+  createUserClient: mockCreateUserClient,
+}));
+
+const FAKE_ENV: SupabaseEnv = {
+  SUPABASE_URL: 'https://test-project.supabase.co',
+  SUPABASE_ANON_KEY: 'test-anon-key',
+  SUPABASE_SERVICE_ROLE_KEY: 'test-service-role-key',
+};
+
+const FAKE_JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTEyMyJ9.fake';
+
+const FAKE_USER = {
+  id: 'aaaa1111-0000-0000-0000-000000000001',
+  email: 'alice@example.com',
+  created_at: '2026-03-01T00:00:00.000Z',
+};
+
+function createTestApp(): OpenAPIHono<{ Bindings: SupabaseEnv; Variables: AuthVariables }> {
+  const app = new OpenAPIHono<{ Bindings: SupabaseEnv; Variables: AuthVariables }>();
+  app.use('/v1/*', authMiddleware);
   registerMeRoute(app);
   return app;
 }
 
 describe('GET /v1/me', () => {
-  it('returns 200 status', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCreateUserClient.mockReturnValue({
+      from: vi.fn(),
+      auth: { getUser: mockGetUser },
+    });
+  });
+
+  it('returns 401 without authorization header', async () => {
     const app = createTestApp();
-    const res = await app.request('/v1/me');
+    const res = await app.request('/v1/me', {}, FAKE_ENV);
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with invalid authorization scheme', async () => {
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/me',
+      { headers: { Authorization: `Basic ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with authenticated user profile', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/me',
+      { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
 
     expect(res.status).toBe(200);
-  });
-
-  it('returns JSON with id "anonymous"', async () => {
-    const app = createTestApp();
-    const res = await app.request('/v1/me');
     const body = MeResponseSchema.parse(await res.json());
-
-    expect(body.id).toBe('anonymous');
+    expect(body.id).toBe(FAKE_USER.id);
+    expect(body.email).toBe(FAKE_USER.email);
+    expect(body.created_at).toBe(FAKE_USER.created_at);
   });
 
-  it('returns a valid ISO 8601 created_at timestamp', async () => {
+  it('returns null email when user has no email', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { ...FAKE_USER, email: undefined } },
+      error: null,
+    });
+
     const app = createTestApp();
-    const res = await app.request('/v1/me');
+    const res = await app.request(
+      '/v1/me',
+      { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(200);
     const body = MeResponseSchema.parse(await res.json());
-
-    expect(body.created_at).toBeDefined();
-    const parsed = new Date(body.created_at);
-    expect(parsed.toISOString()).toBe(body.created_at);
-    expect(Number.isNaN(parsed.getTime())).toBe(false);
-  });
-
-  it('returns correct content-type header', async () => {
-    const app = createTestApp();
-    const res = await app.request('/v1/me');
-
-    expect(res.headers.get('content-type')).toContain('application/json');
+    expect(body.email).toBeNull();
   });
 
   it('returns exactly the expected shape', async () => {
-    const app = createTestApp();
-    const res = await app.request('/v1/me');
-    const body = MeResponseSchema.parse(await res.json());
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: FAKE_USER },
+      error: null,
+    });
 
-    expect(Object.keys(body).sort()).toEqual(['created_at', 'id']);
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/me',
+      { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
+
+    const body = MeResponseSchema.parse(await res.json());
+    expect(Object.keys(body).sort()).toEqual(['created_at', 'email', 'id']);
+  });
+
+  it('returns correct content-type header', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/me',
+      { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
+
+    expect(res.headers.get('content-type')).toContain('application/json');
   });
 });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -1,14 +1,15 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import type { OpenAPIHono } from '@hono/zod-openapi';
+import type { AppEnv } from '../types.js';
 
 /**
  * Zod schema for the GET /v1/me response.
- * Phase 1 stub — returns anonymous placeholder.
- * Phase 2 will derive user identity from auth middleware.
+ * Returns the authenticated user's profile.
  */
 export const MeResponseSchema = z.object({
   id: z.string(),
-  created_at: z.string().datetime(),
+  email: z.string().nullable(),
+  created_at: z.string(),
 });
 
 /**
@@ -17,6 +18,7 @@ export const MeResponseSchema = z.object({
 export const meRoute = createRoute({
   method: 'get',
   path: '/v1/me',
+  security: [{ Bearer: [] }],
   responses: {
     200: {
       content: {
@@ -26,21 +28,40 @@ export const meRoute = createRoute({
       },
       description: 'Current user profile',
     },
+    401: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: z.string(),
+            status: z.number(),
+          }),
+        },
+      },
+      description: 'Missing or invalid authorization token',
+    },
   },
 });
 
 /**
- * Registers the GET /v1/me stub route on the given OpenAPIHono app.
+ * Registers the GET /v1/me route on the given OpenAPIHono app.
  *
- * Phase 1 stub: returns anonymous placeholder. Phase 2 will derive
- * user identity from the Supabase JWT via auth middleware.
+ * Uses the user-scoped Supabase client from auth middleware to resolve
+ * the authenticated user's identity from the JWT.
  */
-export function registerMeRoute(app: OpenAPIHono): void {
-  app.openapi(meRoute, (c) => {
+export function registerMeRoute(app: OpenAPIHono<AppEnv>): void {
+  app.openapi(meRoute, async (c) => {
+    const supabase = c.get('supabase');
+
+    const { data, error } = await supabase.auth.getUser();
+    if (error) {
+      throw error;
+    }
+
     return c.json(
       {
-        id: 'anonymous',
-        created_at: new Date().toISOString(),
+        id: data.user.id,
+        email: data.user.email ?? null,
+        created_at: data.user.created_at,
       },
       200,
     );

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { OpenAPIHono } from '@hono/zod-openapi';
+import { authMiddleware } from '../middleware/auth.js';
+import type { AuthVariables } from '../middleware/auth.js';
+import type { SupabaseEnv } from '../lib/supabase.js';
 import { registerSessionsRoute, CreateSessionBodySchema, ListSessionsQuerySchema } from './sessions.js';
 
 /**
@@ -17,26 +20,34 @@ const mockRange = vi.fn();
 const mockOrder = vi.fn(() => ({ range: mockRange }));
 const mockQuerySelect = vi.fn(() => ({ order: mockOrder }));
 
-vi.mock('../lib/supabase.js', () => ({
-  createSupabaseClient: vi.fn(() => ({
-    from: vi.fn(() => ({
-      insert: mockInsert,
-      select: mockQuerySelect,
-    })),
-  })),
+const mockGetUser = vi.fn();
+
+const { mockCreateUserClient } = vi.hoisted(() => ({
+  mockCreateUserClient: vi.fn(),
 }));
 
-/**
- * Fake Supabase env bindings for test requests.
- * These are never sent to a real Supabase instance — the module is mocked.
- */
-const FAKE_ENV = {
+vi.mock('../lib/supabase.js', () => ({
+  createUserClient: mockCreateUserClient,
+}));
+
+const FAKE_ENV: SupabaseEnv = {
   SUPABASE_URL: 'https://fake.supabase.co',
+  SUPABASE_ANON_KEY: 'fake-anon-key',
   SUPABASE_SERVICE_ROLE_KEY: 'fake-service-role-key',
 };
 
-function createTestApp(): OpenAPIHono {
-  const app = new OpenAPIHono({
+const FAKE_JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTEyMyJ9.fake';
+
+const FAKE_USER_ID = 'aaaa1111-0000-0000-0000-000000000001';
+
+const FAKE_USER = {
+  id: FAKE_USER_ID,
+  email: 'alice@example.com',
+  created_at: '2026-03-01T00:00:00.000Z',
+};
+
+function createTestApp(): OpenAPIHono<{ Bindings: SupabaseEnv; Variables: AuthVariables }> {
+  const app = new OpenAPIHono<{ Bindings: SupabaseEnv; Variables: AuthVariables }>({
     defaultHook: (result, c) => {
       if (!result.success) {
         return c.json(
@@ -46,6 +57,7 @@ function createTestApp(): OpenAPIHono {
       }
     },
   });
+  app.use('/v1/*', authMiddleware);
   registerSessionsRoute(app);
   return app;
 }
@@ -59,7 +71,7 @@ function validSessionBody(): Record<string, unknown> {
 
 const FAKE_SESSION_ROW = {
   id: '11111111-1111-1111-1111-111111111111',
-  user_id: '00000000-0000-0000-0000-000000000000',
+  user_id: FAKE_USER_ID,
   process_goal_id: '00000000-0000-0000-0000-000000000000',
   intention_text: null,
   started_at: '2026-03-17T10:00:00.000Z',
@@ -72,13 +84,45 @@ const FAKE_SESSION_ROW = {
   created_at: '2026-03-17T10:25:01.000Z',
 };
 
+function authHeaders(): Record<string, string> {
+  return { Authorization: `Bearer ${FAKE_JWT}` };
+}
+
 describe('POST /v1/sessions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    mockGetUser.mockResolvedValue({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    mockCreateUserClient.mockReturnValue({
+      from: vi.fn(() => ({
+        insert: mockInsert,
+        select: mockQuerySelect,
+      })),
+      auth: { getUser: mockGetUser },
+    });
   });
 
-  it('returns 201 with created session for valid body', async () => {
+  it('returns 401 without authorization header', async () => {
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/sessions',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validSessionBody()),
+      },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 201 with created session for valid body and auth', async () => {
     mockSingle.mockResolvedValueOnce({ data: FAKE_SESSION_ROW, error: null });
 
     const app = createTestApp();
@@ -86,7 +130,7 @@ describe('POST /v1/sessions', () => {
       '/v1/sessions',
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(validSessionBody()),
       },
       FAKE_ENV,
@@ -115,7 +159,7 @@ describe('POST /v1/sessions', () => {
       '/v1/sessions',
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({
           ...validSessionBody(),
           focus_quality: 'locked_in',
@@ -139,7 +183,7 @@ describe('POST /v1/sessions', () => {
       '/v1/sessions',
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(bodyWithoutStartedAt),
       },
       FAKE_ENV,
@@ -158,7 +202,7 @@ describe('POST /v1/sessions', () => {
       '/v1/sessions',
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(bodyWithoutEndedAt),
       },
       FAKE_ENV,
@@ -176,7 +220,7 @@ describe('POST /v1/sessions', () => {
       '/v1/sessions',
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({
           ...validSessionBody(),
           focus_quality: 'invalid_value',
@@ -198,7 +242,7 @@ describe('POST /v1/sessions', () => {
       '/v1/sessions',
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({
           ...validSessionBody(),
           distraction_type: 'invalid_value',
@@ -219,7 +263,7 @@ describe('POST /v1/sessions', () => {
       '/v1/sessions',
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({
           ...validSessionBody(),
           started_at: 'not-a-date',
@@ -233,7 +277,7 @@ describe('POST /v1/sessions', () => {
     expect(body.error).toBe('Validation failed');
   });
 
-  it('passes correct data to Supabase insert', async () => {
+  it('passes authenticated user_id to Supabase insert', async () => {
     mockSingle.mockResolvedValueOnce({ data: FAKE_SESSION_ROW, error: null });
 
     const app = createTestApp();
@@ -241,7 +285,7 @@ describe('POST /v1/sessions', () => {
       '/v1/sessions',
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({
           ...validSessionBody(),
           focus_quality: 'decent',
@@ -252,7 +296,7 @@ describe('POST /v1/sessions', () => {
     );
 
     expect(mockInsert).toHaveBeenCalledWith({
-      user_id: 'aaaa1111-0000-0000-0000-000000000001',
+      user_id: FAKE_USER_ID,
       process_goal_id: 'eeee0001-0000-0000-0000-000000000001',
       started_at: '2026-03-17T10:00:00.000Z',
       ended_at: '2026-03-17T10:25:00.000Z',
@@ -280,7 +324,7 @@ describe('POST /v1/sessions', () => {
       '/v1/sessions',
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(validSessionBody()),
       },
       FAKE_ENV,
@@ -316,6 +360,19 @@ describe('GET /v1/sessions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    mockGetUser.mockResolvedValue({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    mockCreateUserClient.mockReturnValue({
+      from: vi.fn(() => ({
+        insert: mockInsert,
+        select: mockQuerySelect,
+      })),
+      auth: { getUser: mockGetUser },
+    });
   });
 
   const FAKE_SESSIONS_LIST = [
@@ -327,6 +384,13 @@ describe('GET /v1/sessions', () => {
     FAKE_SESSION_ROW,
   ];
 
+  it('returns 401 without authorization header', async () => {
+    const app = createTestApp();
+    const res = await app.request('/v1/sessions', { method: 'GET' }, FAKE_ENV);
+
+    expect(res.status).toBe(401);
+  });
+
   it('returns 200 with default pagination (limit=20, offset=0)', async () => {
     mockRange.mockResolvedValueOnce({
       data: FAKE_SESSIONS_LIST,
@@ -335,7 +399,11 @@ describe('GET /v1/sessions', () => {
     });
 
     const app = createTestApp();
-    const res = await app.request('/v1/sessions', { method: 'GET' }, FAKE_ENV);
+    const res = await app.request(
+      '/v1/sessions',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
 
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -358,7 +426,7 @@ describe('GET /v1/sessions', () => {
     const app = createTestApp();
     const res = await app.request(
       '/v1/sessions?limit=5&offset=10',
-      { method: 'GET' },
+      { method: 'GET', headers: authHeaders() },
       FAKE_ENV,
     );
 
@@ -400,7 +468,11 @@ describe('GET /v1/sessions', () => {
     });
 
     const app = createTestApp();
-    const res = await app.request('/v1/sessions', { method: 'GET' }, FAKE_ENV);
+    const res = await app.request(
+      '/v1/sessions',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
 
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -423,7 +495,11 @@ describe('GET /v1/sessions', () => {
       );
     });
 
-    const res = await app.request('/v1/sessions', { method: 'GET' }, FAKE_ENV);
+    const res = await app.request(
+      '/v1/sessions',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
 
     expect(res.status).toBe(500);
   });

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import type { OpenAPIHono } from '@hono/zod-openapi';
-import { createSupabaseClient } from '../lib/supabase.js';
+import type { AppEnv } from '../types.js';
 
 /**
  * Valid focus_quality enum values matching the Postgres enum.
@@ -68,6 +68,7 @@ export const ListSessionsResponseSchema = z.object({
 export const createSessionRoute = createRoute({
   method: 'post',
   path: '/v1/sessions',
+  security: [{ Bearer: [] }],
   request: {
     body: {
       content: {
@@ -86,6 +87,17 @@ export const createSessionRoute = createRoute({
         },
       },
       description: 'Session created successfully',
+    },
+    401: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: z.string(),
+            status: z.number(),
+          }),
+        },
+      },
+      description: 'Missing or invalid authorization token',
     },
     422: {
       content: {
@@ -107,6 +119,7 @@ export const createSessionRoute = createRoute({
 export const listSessionsRoute = createRoute({
   method: 'get',
   path: '/v1/sessions',
+  security: [{ Bearer: [] }],
   request: {
     query: ListSessionsQuerySchema,
   },
@@ -118,6 +131,17 @@ export const listSessionsRoute = createRoute({
         },
       },
       description: 'Paginated list of sessions',
+    },
+    401: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: z.string(),
+            status: z.number(),
+          }),
+        },
+      },
+      description: 'Missing or invalid authorization token',
     },
     422: {
       content: {
@@ -134,41 +158,37 @@ export const listSessionsRoute = createRoute({
 });
 
 /**
- * Zod schema to validate that the Cloudflare Workers env contains
- * the required Supabase bindings at runtime (U-009: Zod parsing, not type assertions).
- */
-const SupabaseEnvSchema = z.object({
-  SUPABASE_URL: z.string(),
-  SUPABASE_SERVICE_ROLE_KEY: z.string(),
-});
-
-/**
  * Registers the POST /v1/sessions and GET /v1/sessions routes on the given OpenAPIHono app.
  *
- * POST: Validates request body with Zod, inserts a session into Supabase,
- * and returns the created session. Auth is not yet implemented (Phase 2) —
- * user_id and process_goal_id use placeholder values.
+ * Both routes require authentication — the auth middleware sets a user-scoped
+ * Supabase client on the context. RLS policies scope queries to the authenticated user.
  *
- * GET: Returns a paginated list of sessions ordered by started_at descending.
+ * POST: Validates request body with Zod, derives user_id from the authenticated
+ * Supabase client, inserts a session, and returns the created row.
+ *
+ * GET: Returns a paginated list of the authenticated user's sessions
+ * ordered by started_at descending. RLS filters to the current user.
  */
-export function registerSessionsRoute(app: OpenAPIHono): void {
+export function registerSessionsRoute(app: OpenAPIHono<AppEnv>): void {
   app.openapi(createSessionRoute, async (c) => {
     const body = c.req.valid('json');
+    const supabase = c.get('supabase');
 
-    const env = SupabaseEnvSchema.parse(c.env);
-    const supabase = createSupabaseClient(env);
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError) {
+      throw userError;
+    }
 
-    // Phase 2 will derive user_id from auth middleware and require process_goal_id.
-    // For the walking skeleton, use placeholder values.
-    // Must match seed.sql rows — Alice's profile and first process goal.
-    // Phase 2 will derive user_id from auth middleware and require process_goal_id.
-    const PLACEHOLDER_USER_ID = 'aaaa1111-0000-0000-0000-000000000001';
+    const userId = userData.user.id;
+
+    // process_goal_id still uses a placeholder — goal selection is a future feature.
+    // Must match seed.sql rows — Alice's first process goal.
     const PLACEHOLDER_PROCESS_GOAL_ID = 'eeee0001-0000-0000-0000-000000000001';
 
     const { data, error } = await supabase
       .from('sessions')
       .insert({
-        user_id: PLACEHOLDER_USER_ID,
+        user_id: userId,
         process_goal_id: PLACEHOLDER_PROCESS_GOAL_ID,
         started_at: body.started_at,
         ended_at: body.ended_at,
@@ -188,9 +208,7 @@ export function registerSessionsRoute(app: OpenAPIHono): void {
 
   app.openapi(listSessionsRoute, async (c) => {
     const { limit, offset } = c.req.valid('query');
-
-    const env = SupabaseEnvSchema.parse(c.env);
-    const supabase = createSupabaseClient(env);
+    const supabase = c.get('supabase');
 
     const { data, error, count } = await supabase
       .from('sessions')

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,4 +1,6 @@
 import type { Env } from 'hono';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@pomofocus/types';
 
 /**
  * Authenticated user object extracted from a verified Supabase JWT.
@@ -11,10 +13,11 @@ export type AuthUser = {
 
 /**
  * Hono context variables set by middleware.
- * Route handlers access these via `c.get('user')`.
+ * Route handlers access these via `c.get('user')` or `c.get('supabase')`.
  */
 export type AppVariables = {
   readonly user: AuthUser;
+  readonly supabase: SupabaseClient<Database>;
 };
 
 /**
@@ -23,6 +26,7 @@ export type AppVariables = {
  */
 export type AppBindings = {
   readonly SUPABASE_URL: string;
+  readonly SUPABASE_ANON_KEY: string;
   readonly SUPABASE_SERVICE_ROLE_KEY: string;
   readonly ALLOWED_ORIGINS?: string;
 };


### PR DESCRIPTION
## Summary

- Apply JWT validation middleware to all `/v1/*` routes, keeping `/health` publicly accessible
- Update session and profile routes to use authenticated Supabase client (user-scoped via JWT forwarding)
- Add comprehensive tests for auth enforcement (401 without token, 200 with valid token)

Closes #285

## Test plan

- [ ] `pnpm nx test @pomofocus/api` passes
- [ ] `GET /health` returns 200 without auth
- [ ] `GET /v1/sessions` returns 401 without auth header
- [ ] `GET /v1/sessions` returns 200 with valid Bearer token
- [ ] `POST /v1/sessions` returns 401 without auth header
- [ ] `GET /v1/me` returns authenticated user's profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)