### PR TITLE
feat: implement auth state hook and provider in packages/state

### DIFF
--- a/packages/state/src/auth/hooks.ts
+++ b/packages/state/src/auth/hooks.ts
@@ -1,0 +1,51 @@
+import { useContext } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import type { AuthUser, AuthError } from '@pomofocus/data-access';
+import { AuthStoreContext } from './provider.js';
+import type { AuthStoreInstance } from './store.js';
+
+type UseAuthReturn = {
+  readonly user: AuthUser | null;
+  readonly isLoading: boolean;
+  readonly isAuthenticated: boolean;
+  readonly error: AuthError | null;
+  readonly signIn: (email: string, password: string) => Promise<void>;
+  readonly signUp: (email: string, password: string) => Promise<void>;
+  readonly signOut: () => Promise<void>;
+};
+
+function useAuthStoreFromContext(): AuthStoreInstance {
+  const store = useContext(AuthStoreContext);
+  if (store === null) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return store;
+}
+
+function useAuth(): UseAuthReturn {
+  const store = useAuthStoreFromContext();
+  return store(
+    useShallow((state) => ({
+      user: state.user,
+      isLoading: state.isLoading,
+      isAuthenticated: state.isAuthenticated,
+      error: state.error,
+      signIn: state.signIn,
+      signUp: state.signUp,
+      signOut: state.signOut,
+    })),
+  );
+}
+
+function useUser(): AuthUser | null {
+  const store = useAuthStoreFromContext();
+  return store((state) => state.user);
+}
+
+function useIsAuthenticated(): boolean {
+  const store = useAuthStoreFromContext();
+  return store((state) => state.isAuthenticated);
+}
+
+export { useAuth, useUser, useIsAuthenticated };
+export type { UseAuthReturn };

--- a/packages/state/src/auth/index.ts
+++ b/packages/state/src/auth/index.ts
@@ -1,0 +1,6 @@
+export { createAuthStore } from './store.js';
+export type { AuthStore, AuthStoreInstance, AuthState, AuthActions, AuthOperations } from './store.js';
+export { useAuth, useUser, useIsAuthenticated } from './hooks.js';
+export type { UseAuthReturn } from './hooks.js';
+export { AuthProvider, AuthStoreContext } from './provider.js';
+export type { AuthProviderProps } from './provider.js';

--- a/packages/state/src/auth/provider.tsx
+++ b/packages/state/src/auth/provider.tsx
@@ -1,0 +1,35 @@
+import { createContext, useEffect, useRef } from 'react';
+import type { ReactNode } from 'react';
+import { createAuthStore } from './store.js';
+import type { AuthStoreInstance, AuthOperations } from './store.js';
+
+const AuthStoreContext = createContext<AuthStoreInstance | null>(null);
+
+type AuthProviderProps = {
+  readonly ops: AuthOperations;
+  readonly children: ReactNode;
+};
+
+function AuthProvider({ ops, children }: AuthProviderProps): ReactNode {
+  const storeRef = useRef<AuthStoreInstance | null>(null);
+  storeRef.current ??= createAuthStore(ops);
+
+  const store = storeRef.current;
+
+  useEffect(() => {
+    const subscription = store.getState().initialize();
+
+    return (): void => {
+      subscription.unsubscribe();
+    };
+  }, [store]);
+
+  return (
+    <AuthStoreContext.Provider value={store}>
+      {children}
+    </AuthStoreContext.Provider>
+  );
+}
+
+export { AuthProvider, AuthStoreContext };
+export type { AuthProviderProps };

--- a/packages/state/src/auth/store.test.ts
+++ b/packages/state/src/auth/store.test.ts
@@ -1,0 +1,462 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+import type { AuthSession, AuthUser, AuthResult, AuthStateChangeCallback } from '@pomofocus/data-access';
+import { createAuthStore } from './store.js';
+import type { AuthOperations, AuthStoreInstance } from './store.js';
+import { AuthProvider } from './provider.js';
+import { useAuth, useUser, useIsAuthenticated } from './hooks.js';
+
+// -- Test Fixtures --
+
+const mockUser: AuthUser = {
+  id: 'user-123',
+  email: 'test@example.com',
+  displayName: 'Test User',
+  provider: undefined,
+};
+
+const mockSession: AuthSession = {
+  accessToken: 'access-token-123',
+  refreshToken: 'refresh-token-123',
+  expiresAt: 9999999999,
+  user: mockUser,
+};
+
+function createMockOps(overrides?: Partial<AuthOperations>): AuthOperations {
+  return {
+    signIn: vi.fn<(email: string, password: string) => Promise<AuthResult<AuthSession>>>()
+      .mockResolvedValue({ data: undefined, error: undefined }),
+    signUp: vi.fn<(email: string, password: string) => Promise<AuthResult<AuthSession>>>()
+      .mockResolvedValue({ data: undefined, error: undefined }),
+    signOut: vi.fn<() => Promise<AuthResult<undefined>>>()
+      .mockResolvedValue({ data: undefined, error: undefined }),
+    getSession: vi.fn<() => Promise<AuthResult<AuthSession>>>()
+      .mockResolvedValue({ data: undefined, error: undefined }),
+    onAuthStateChange: vi.fn<
+      (callback: (event: string, session: AuthSession | undefined) => void) => { unsubscribe: () => void }
+    >()
+      .mockReturnValue({ unsubscribe: vi.fn() }),
+    ...overrides,
+  };
+}
+
+function createStore(ops: AuthOperations): AuthStoreInstance {
+  return createAuthStore(ops);
+}
+
+describe('auth store', () => {
+  it('initializes with isLoading: true', () => {
+    const ops = createMockOps();
+    const store = createStore(ops);
+    const state = store.getState();
+
+    expect(state.isLoading).toBe(true);
+    expect(state.user).toBeNull();
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  describe('signIn', () => {
+    it('updates user and isAuthenticated on successful login', async () => {
+      const ops = createMockOps({
+        signIn: vi.fn<(email: string, password: string) => Promise<AuthResult<AuthSession>>>()
+          .mockResolvedValue({ data: mockSession, error: undefined }),
+      });
+      const store = createStore(ops);
+
+      await store.getState().signIn('test@example.com', 'password');
+
+      const state = store.getState();
+      expect(state.user).toEqual(mockUser);
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+      expect(ops.signIn).toHaveBeenCalledWith('test@example.com', 'password');
+    });
+
+    it('sets error state on failed login', async () => {
+      const authError = { message: 'Invalid credentials', status: 401 };
+      const ops = createMockOps({
+        signIn: vi.fn<(email: string, password: string) => Promise<AuthResult<AuthSession>>>()
+          .mockResolvedValue({ data: undefined, error: authError }),
+      });
+      const store = createStore(ops);
+
+      await store.getState().signIn('test@example.com', 'wrong');
+
+      const state = store.getState();
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toEqual(authError);
+    });
+
+    it('sets isLoading: true during login', async () => {
+      let resolveSignIn!: (value: AuthResult<AuthSession>) => void;
+      const ops = createMockOps({
+        signIn: vi.fn<(email: string, password: string) => Promise<AuthResult<AuthSession>>>()
+          .mockReturnValue(
+            new Promise((resolve) => {
+              resolveSignIn = resolve;
+            }),
+          ),
+      });
+      const store = createStore(ops);
+
+      const signInPromise = store.getState().signIn('test@example.com', 'password');
+
+      // While in-flight, isLoading should be true
+      expect(store.getState().isLoading).toBe(true);
+
+      resolveSignIn({ data: mockSession, error: undefined });
+      await signInPromise;
+
+      expect(store.getState().isLoading).toBe(false);
+    });
+  });
+
+  describe('signUp', () => {
+    it('updates user and isAuthenticated on successful signup with session', async () => {
+      const ops = createMockOps({
+        signUp: vi.fn<(email: string, password: string) => Promise<AuthResult<AuthSession>>>()
+          .mockResolvedValue({ data: mockSession, error: undefined }),
+      });
+      const store = createStore(ops);
+
+      await store.getState().signUp('new@example.com', 'password');
+
+      const state = store.getState();
+      expect(state.user).toEqual(mockUser);
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it('handles signup pending email confirmation (no session returned)', async () => {
+      const ops = createMockOps();
+      const store = createStore(ops);
+
+      await store.getState().signUp('new@example.com', 'password');
+
+      const state = store.getState();
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it('sets error state on failed signup', async () => {
+      const authError = { message: 'Email already registered', status: 422 };
+      const ops = createMockOps({
+        signUp: vi.fn<(email: string, password: string) => Promise<AuthResult<AuthSession>>>()
+          .mockResolvedValue({ data: undefined, error: authError }),
+      });
+      const store = createStore(ops);
+
+      await store.getState().signUp('existing@example.com', 'password');
+
+      const state = store.getState();
+      expect(state.error).toEqual(authError);
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('signOut', () => {
+    it('clears user and sets isAuthenticated to false', async () => {
+      // First sign in
+      const ops = createMockOps({
+        signIn: vi.fn<(email: string, password: string) => Promise<AuthResult<AuthSession>>>()
+          .mockResolvedValue({ data: mockSession, error: undefined }),
+        signOut: vi.fn<() => Promise<AuthResult<undefined>>>()
+          .mockResolvedValue({ data: undefined, error: undefined }),
+      });
+      const store = createStore(ops);
+
+      await store.getState().signIn('test@example.com', 'password');
+      expect(store.getState().isAuthenticated).toBe(true);
+
+      // Then sign out
+      await store.getState().signOut();
+
+      const state = store.getState();
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it('sets error state on failed signout', async () => {
+      const authError = { message: 'Network error', status: undefined };
+      const ops = createMockOps({
+        signOut: vi.fn<() => Promise<AuthResult<undefined>>>()
+          .mockResolvedValue({ data: undefined, error: authError }),
+      });
+      const store = createStore(ops);
+
+      await store.getState().signOut();
+
+      expect(store.getState().error).toEqual(authError);
+      expect(store.getState().isLoading).toBe(false);
+    });
+  });
+
+  describe('initialize', () => {
+    it('restores session from existing auth on initialize', async () => {
+      const ops = createMockOps({
+        getSession: vi.fn<() => Promise<AuthResult<AuthSession>>>()
+          .mockResolvedValue({ data: mockSession, error: undefined }),
+      });
+      const store = createStore(ops);
+
+      store.getState().initialize();
+
+      await waitFor(() => {
+        expect(store.getState().isLoading).toBe(false);
+      });
+
+      const state = store.getState();
+      expect(state.user).toEqual(mockUser);
+      expect(state.isAuthenticated).toBe(true);
+    });
+
+    it('sets isLoading false when no existing session', async () => {
+      const ops = createMockOps();
+      const store = createStore(ops);
+
+      store.getState().initialize();
+
+      await waitFor(() => {
+        expect(store.getState().isLoading).toBe(false);
+      });
+
+      const state = store.getState();
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+    });
+
+    it('subscribes to onAuthStateChange', () => {
+      const ops = createMockOps();
+      const store = createStore(ops);
+
+      store.getState().initialize();
+
+      expect(ops.onAuthStateChange).toHaveBeenCalledWith(
+        expect.any(Function),
+      );
+    });
+
+    it('returns unsubscribe function', () => {
+      const mockUnsubscribe = vi.fn();
+      const ops = createMockOps({
+        onAuthStateChange: vi.fn().mockReturnValue({ unsubscribe: mockUnsubscribe }),
+      });
+      const store = createStore(ops);
+
+      const subscription = store.getState().initialize();
+
+      subscription.unsubscribe();
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('auth state change subscription', () => {
+    it('updates store when user signs in via auth state change', async () => {
+      let capturedCallback: AuthStateChangeCallback | undefined;
+      const ops = createMockOps({
+        onAuthStateChange: vi.fn().mockImplementation(
+          (callback: AuthStateChangeCallback) => {
+            capturedCallback = callback;
+            return { unsubscribe: vi.fn() };
+          },
+        ),
+      });
+      const store = createStore(ops);
+
+      store.getState().initialize();
+
+      // Wait for initial session check to complete
+      await waitFor(() => {
+        expect(store.getState().isLoading).toBe(false);
+      });
+
+      expect(capturedCallback).toBeDefined();
+
+      // Simulate auth state change to signed in
+      act(() => {
+        if (capturedCallback !== undefined) {
+          capturedCallback('SIGNED_IN', mockSession);
+        }
+      });
+
+      const state = store.getState();
+      expect(state.user).toEqual(mockUser);
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('clears user when auth state change indicates sign out', async () => {
+      // Start with a user signed in
+      let capturedCallback: AuthStateChangeCallback | undefined;
+      const ops = createMockOps({
+        getSession: vi.fn<() => Promise<AuthResult<AuthSession>>>()
+          .mockResolvedValue({ data: mockSession, error: undefined }),
+        onAuthStateChange: vi.fn().mockImplementation(
+          (callback: AuthStateChangeCallback) => {
+            capturedCallback = callback;
+            return { unsubscribe: vi.fn() };
+          },
+        ),
+      });
+      const store = createStore(ops);
+
+      store.getState().initialize();
+
+      await waitFor(() => {
+        expect(store.getState().isAuthenticated).toBe(true);
+      });
+
+      // Simulate sign out via auth state change
+      act(() => {
+        if (capturedCallback !== undefined) {
+          capturedCallback('SIGNED_OUT', undefined);
+        }
+      });
+
+      const state = store.getState();
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+    });
+  });
+
+  describe('clearError', () => {
+    it('clears the error state', async () => {
+      const authError = { message: 'Some error', status: 500 };
+      const ops = createMockOps({
+        signIn: vi.fn<(email: string, password: string) => Promise<AuthResult<AuthSession>>>()
+          .mockResolvedValue({ data: undefined, error: authError }),
+      });
+      const store = createStore(ops);
+
+      await store.getState().signIn('test@example.com', 'wrong');
+      expect(store.getState().error).toEqual(authError);
+
+      store.getState().clearError();
+      expect(store.getState().error).toBeNull();
+    });
+  });
+});
+
+describe('AuthProvider', () => {
+  let mockOps: AuthOperations;
+  let mockUnsubscribe: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockUnsubscribe = vi.fn();
+    mockOps = createMockOps({
+      onAuthStateChange: vi.fn().mockReturnValue({ unsubscribe: mockUnsubscribe }),
+    });
+  });
+
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => null, {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(AuthProvider, { ops: mockOps, children }),
+    });
+
+    // onAuthStateChange should have been called (subscribed)
+    expect(mockOps.onAuthStateChange).toHaveBeenCalledTimes(1);
+
+    // Unmount triggers cleanup
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('auth hooks', () => {
+  function createWrapper(ops: AuthOperations): (props: { children: ReactNode }) => ReactNode {
+    return function Wrapper({ children }: { children: ReactNode }): ReactNode {
+      return createElement(AuthProvider, { ops, children });
+    };
+  }
+
+  describe('useAuth', () => {
+    it('returns auth state with actions', async () => {
+      const ops = createMockOps({
+        getSession: vi.fn<() => Promise<AuthResult<AuthSession>>>()
+          .mockResolvedValue({ data: mockSession, error: undefined }),
+      });
+
+      const { result } = renderHook(() => useAuth(), {
+        wrapper: createWrapper(ops),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.user).toEqual(mockUser);
+      expect(result.current.isAuthenticated).toBe(true);
+      expect(result.current.error).toBeNull();
+      expect(typeof result.current.signIn).toBe('function');
+      expect(typeof result.current.signUp).toBe('function');
+      expect(typeof result.current.signOut).toBe('function');
+    });
+  });
+
+  describe('useUser', () => {
+    it('returns current user', async () => {
+      const ops = createMockOps({
+        getSession: vi.fn<() => Promise<AuthResult<AuthSession>>>()
+          .mockResolvedValue({ data: mockSession, error: undefined }),
+      });
+
+      const { result } = renderHook(() => useUser(), {
+        wrapper: createWrapper(ops),
+      });
+
+      await waitFor(() => {
+        expect(result.current).toEqual(mockUser);
+      });
+    });
+
+    it('returns null when no user', () => {
+      const ops = createMockOps();
+
+      const { result } = renderHook(() => useUser(), {
+        wrapper: createWrapper(ops),
+      });
+
+      expect(result.current).toBeNull();
+    });
+  });
+
+  describe('useIsAuthenticated', () => {
+    it('returns true when authenticated', async () => {
+      const ops = createMockOps({
+        getSession: vi.fn<() => Promise<AuthResult<AuthSession>>>()
+          .mockResolvedValue({ data: mockSession, error: undefined }),
+      });
+
+      const { result } = renderHook(() => useIsAuthenticated(), {
+        wrapper: createWrapper(ops),
+      });
+
+      await waitFor(() => {
+        expect(result.current).toBe(true);
+      });
+    });
+
+    it('returns false when not authenticated', () => {
+      const ops = createMockOps();
+
+      const { result } = renderHook(() => useIsAuthenticated(), {
+        wrapper: createWrapper(ops),
+      });
+
+      // Initial value is false (default state)
+      expect(result.current).toBe(false);
+    });
+  });
+});

--- a/packages/state/src/auth/store.ts
+++ b/packages/state/src/auth/store.ts
@@ -1,0 +1,210 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import type { StoreApi, UseBoundStore } from 'zustand';
+import type { AuthUser, AuthError, AuthSession, AuthResult, Unsubscribe } from '@pomofocus/data-access';
+
+// -- Auth Operations Interface --
+// Pre-bound functions that the app shell creates by binding the SupabaseClient.
+// This keeps @supabase/supabase-js out of packages/state/.
+
+type AuthOperations = {
+  readonly signIn: (email: string, password: string) => Promise<AuthResult<AuthSession>>;
+  readonly signUp: (email: string, password: string) => Promise<AuthResult<AuthSession>>;
+  readonly signOut: () => Promise<AuthResult<undefined>>;
+  readonly getSession: () => Promise<AuthResult<AuthSession>>;
+  readonly onAuthStateChange: (
+    callback: (event: string, session: AuthSession | undefined) => void,
+  ) => Unsubscribe;
+};
+
+// -- Store Shape --
+
+type AuthState = {
+  readonly user: AuthUser | null;
+  readonly isLoading: boolean;
+  readonly isAuthenticated: boolean;
+  readonly error: AuthError | null;
+};
+
+type AuthActions = {
+  readonly signIn: (email: string, password: string) => Promise<void>;
+  readonly signUp: (email: string, password: string) => Promise<void>;
+  readonly signOut: () => Promise<void>;
+  readonly initialize: () => Unsubscribe;
+  readonly clearError: () => void;
+};
+
+type AuthStore = AuthState & AuthActions;
+
+// -- Initial State --
+
+const INITIAL_STATE: AuthState = {
+  user: null,
+  isLoading: true,
+  isAuthenticated: false,
+  error: null,
+};
+
+type AuthStoreInstance = UseBoundStore<StoreApi<AuthStore>>;
+
+// -- Store Factory --
+
+function createAuthStore(ops: AuthOperations): AuthStoreInstance {
+  return create<AuthStore>()(
+    devtools(
+      (set) => ({
+        ...INITIAL_STATE,
+
+        signIn: async (email: string, password: string): Promise<void> => {
+          set({ isLoading: true, error: null }, false, 'auth/signIn:start');
+
+          const result = await ops.signIn(email, password);
+
+          if (result.error !== undefined) {
+            set(
+              { isLoading: false, error: result.error },
+              false,
+              'auth/signIn:error',
+            );
+            return;
+          }
+
+          if (result.data !== undefined) {
+            set(
+              {
+                user: result.data.user,
+                isAuthenticated: true,
+                isLoading: false,
+                error: null,
+              },
+              false,
+              'auth/signIn:success',
+            );
+          }
+        },
+
+        signUp: async (email: string, password: string): Promise<void> => {
+          set({ isLoading: true, error: null }, false, 'auth/signUp:start');
+
+          const result = await ops.signUp(email, password);
+
+          if (result.error !== undefined) {
+            set(
+              { isLoading: false, error: result.error },
+              false,
+              'auth/signUp:error',
+            );
+            return;
+          }
+
+          if (result.data !== undefined) {
+            set(
+              {
+                user: result.data.user,
+                isAuthenticated: true,
+                isLoading: false,
+                error: null,
+              },
+              false,
+              'auth/signUp:success',
+            );
+          } else {
+            // signUp returned no session (e.g. email confirmation required)
+            set(
+              { isLoading: false },
+              false,
+              'auth/signUp:pending',
+            );
+          }
+        },
+
+        signOut: async (): Promise<void> => {
+          set({ isLoading: true, error: null }, false, 'auth/signOut:start');
+
+          const result = await ops.signOut();
+
+          if (result.error !== undefined) {
+            set(
+              { isLoading: false, error: result.error },
+              false,
+              'auth/signOut:error',
+            );
+            return;
+          }
+
+          set(
+            {
+              user: null,
+              isAuthenticated: false,
+              isLoading: false,
+              error: null,
+            },
+            false,
+            'auth/signOut:success',
+          );
+        },
+
+        initialize: (): Unsubscribe => {
+          // Check existing session
+          void ops.getSession().then((result) => {
+            if (result.data !== undefined) {
+              set(
+                {
+                  user: result.data.user,
+                  isAuthenticated: true,
+                  isLoading: false,
+                  error: null,
+                },
+                false,
+                'auth/initialize:session',
+              );
+            } else {
+              set(
+                { isLoading: false },
+                false,
+                'auth/initialize:noSession',
+              );
+            }
+          });
+
+          // Subscribe to auth state changes
+          const subscription = ops.onAuthStateChange((_event, session) => {
+            if (session !== undefined) {
+              set(
+                {
+                  user: session.user,
+                  isAuthenticated: true,
+                  isLoading: false,
+                  error: null,
+                },
+                false,
+                'auth/stateChange:signedIn',
+              );
+            } else {
+              set(
+                {
+                  user: null,
+                  isAuthenticated: false,
+                  isLoading: false,
+                  error: null,
+                },
+                false,
+                'auth/stateChange:signedOut',
+              );
+            }
+          });
+
+          return subscription;
+        },
+
+        clearError: (): void => {
+          set({ error: null }, false, 'auth/clearError');
+        },
+      }),
+      { name: 'AuthStore' },
+    ),
+  );
+}
+
+export { createAuthStore };
+export type { AuthStore, AuthStoreInstance, AuthState, AuthActions, AuthOperations };

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -6,3 +6,5 @@ export type { TimerStore, TimerStoreInstance } from './timer/index.js';
 export { useSessions, sessionsQueryOptions, useCreateSession } from './hooks/index.js';
 export { createQueryClient } from './query-client.js';
 export { QueryProvider } from './providers.js';
+export { createAuthStore, useAuth, useUser, useIsAuthenticated, AuthProvider, AuthStoreContext } from './auth/index.js';
+export type { AuthStore, AuthStoreInstance, AuthState, AuthActions, AuthOperations, UseAuthReturn, AuthProviderProps } from './auth/index.js';


### PR DESCRIPTION
## Summary

- Implements the auth Zustand store in `packages/state/` that wraps `packages/data-access/auth/` and exposes reactive auth state to all React apps
- Adds `useAuth()`, `useUser()`, and `useIsAuthenticated()` hooks plus an `AuthProvider` component that subscribes to auth state changes
- Includes comprehensive test suite (462 lines) covering store initialization, login/logout flows, error handling, and auth state change subscriptions

Closes #281

## Test plan

- [ ] `pnpm nx test @pomofocus/state` passes
- [ ] Store initializes with `isLoading: true`
- [ ] Successful login updates user and isAuthenticated
- [ ] Logout clears user and sets isAuthenticated to false
- [ ] Auth state change subscription works correctly
- [ ] Error state is set on failed auth operations
- [ ] No Supabase imports in `packages/state/` (only imports from `data-access`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)