### PR TITLE
feat: add BLE SoftDevice init and advertising for nRF52840

### DIFF
--- a/firmware/device/src/ble_manager.cpp
+++ b/firmware/device/src/ble_manager.cpp
@@ -1,0 +1,105 @@
+// PomoFocus Device Firmware — BLE SoftDevice Manager
+// See ble_manager.h for interface documentation.
+// See ADR-010 (hardware) and ADR-013 (GATT protocol) for design decisions.
+//
+// Uses Adafruit Bluefruit library (bundled with framework-arduinoadafruitnrf52)
+// which wraps the Nordic SoftDevice S140. The Bluefruit API handles SoftDevice
+// initialization, advertising packet construction, and connection management.
+//
+// This file initializes BLE and starts advertising only. GATT services and
+// pairing are separate issues — not implemented here.
+//
+// NOTE: This file is named ble_manager.cpp (not ble.cpp) because the Nordic
+// SoftDevice SDK ships its own ble.h. If our header were named ble.h, the
+// Bluefruit library's #include "ble.h" would resolve to ours instead of the
+// SoftDevice's, causing compilation failures.
+
+#include "ble_manager.h"
+
+#include <bluefruit.h>
+
+// Timer Service UUID object for advertising.
+// Constructed from the 128-bit UUID byte array defined in ble_manager.h.
+static BLEUuid s_timerServiceUuid(TIMER_SERVICE_UUID);
+
+// ── Connection callbacks ──
+
+static void onConnect(uint16_t connHandle) {
+    BLEConnection* conn = Bluefruit.Connection(connHandle);
+    char peerName[32 + 1] = {};
+    conn->getPeerName(peerName, sizeof(peerName));
+
+    Serial.print("[ble] connected: handle=");
+    Serial.print(connHandle);
+    Serial.print(" peer=");
+    Serial.println(peerName);
+}
+
+static void onDisconnect(uint16_t connHandle, uint8_t reason) {
+    Serial.print("[ble] disconnected: handle=");
+    Serial.print(connHandle);
+    Serial.print(" reason=0x");
+    Serial.println(reason, HEX);
+
+    // Restart advertising after disconnect so the device remains discoverable.
+    // Bluefruit can auto-restart, but explicit restart ensures consistent
+    // behavior across SoftDevice versions.
+    Bluefruit.Advertising.start(ADV_TIMEOUT_SEC);
+}
+
+// ── Advertising configuration ──
+
+static void startAdvertising() {
+    // Clear any previous advertising data.
+    Bluefruit.Advertising.clearData();
+
+    // Add flags: general discoverable + BLE only (no BR/EDR).
+    Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
+
+    // Include TX power level in advertising packet.
+    Bluefruit.Advertising.addTxPower();
+
+    // Include the Timer Service UUID so scanners (nRF Connect) can filter by it.
+    // Uses addUuid() to advertise the UUID without registering a full GATT service
+    // (GATT services are separate issues — out of scope here).
+    Bluefruit.Advertising.addUuid(s_timerServiceUuid);
+
+    // Include the device name in the scan response packet.
+    // The name may not fit in the 31-byte advertising packet alongside the
+    // 128-bit UUID, so Bluefruit places it in the scan response automatically.
+    Bluefruit.ScanResponse.addName();
+
+    // Set advertising interval and timeout.
+    Bluefruit.Advertising.setInterval(ADV_INTERVAL_FAST, ADV_INTERVAL_FAST);
+    Bluefruit.Advertising.setFastTimeout(ADV_TIMEOUT_SEC);
+
+    // Start advertising indefinitely.
+    Bluefruit.Advertising.start(ADV_TIMEOUT_SEC);
+
+    Serial.println("[ble] advertising started");
+}
+
+// ── Public API ──
+
+void ble_init() {
+    Serial.println("[ble] initializing SoftDevice");
+
+    // Initialize Bluefruit with max connections: 1 peripheral, 0 central.
+    // PomoFocus device is a peripheral only — the phone is the central.
+    Bluefruit.begin(1, 0);
+
+    // Set device name (appears in nRF Connect scan results).
+    Bluefruit.setName(BLE_DEVICE_NAME);
+
+    // Set TX power level.
+    Bluefruit.setTxPower(ADV_TX_POWER);
+
+    // Register connection callbacks.
+    Bluefruit.Periph.setConnectCallback(onConnect);
+    Bluefruit.Periph.setDisconnectCallback(onDisconnect);
+
+    Serial.println("[ble] SoftDevice initialized");
+
+    // Configure and start advertising.
+    startAdvertising();
+}

--- a/firmware/device/src/ble_manager.h
+++ b/firmware/device/src/ble_manager.h
@@ -1,0 +1,46 @@
+// PomoFocus Device Firmware — BLE SoftDevice Manager
+// Initializes nRF52840 BLE SoftDevice (S140) via Adafruit Bluefruit,
+// configures advertising with device name and Timer Service UUID.
+// See ADR-010 (hardware) and ADR-013 (GATT protocol) for design decisions.
+
+#ifndef POMOFOCUS_BLE_MANAGER_H
+#define POMOFOCUS_BLE_MANAGER_H
+
+#include <cstdint>
+
+// ── Device identity ──
+
+// BLE advertised device name. Matches ADR-013 advertising spec.
+constexpr const char* BLE_DEVICE_NAME = "PomoFocus";
+
+// ── Timer Service UUID ──
+// Primary service UUID included in advertising packets for discovery.
+// Full 128-bit UUID: 504D4643-0001-CAFE-FACE-DEAD00000000
+// See ADR-013 UUID scheme: PMFC{XXXX}-CAFE-FACE-DEAD-P0M0F0CUS00
+// Byte array in little-endian order for Bluefruit API.
+constexpr uint8_t TIMER_SERVICE_UUID[16] = {
+    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
+    0xFE, 0xCA, 0x01, 0x00, 0x43, 0x46, 0x4D, 0x50
+};
+
+// ── Advertising parameters ──
+
+// Fast advertising interval in units of 0.625ms.
+// 160 * 0.625ms = 100ms (ADR-013: ~100ms for discoverability).
+constexpr uint16_t ADV_INTERVAL_FAST = 160;
+
+// Advertising timeout: 0 = advertise indefinitely until connected.
+constexpr uint16_t ADV_TIMEOUT_SEC = 0;
+
+// TX power level in dBm. 0 dBm is a good default for indoor range
+// without excessive battery drain.
+constexpr int8_t ADV_TX_POWER = 0;
+
+// ── Public API ──
+
+// Initialize BLE SoftDevice, configure advertising, and start advertising.
+// Call once from setup() after Serial.begin().
+// Logs initialization progress and any errors to Serial.
+void ble_init();
+
+#endif // POMOFOCUS_BLE_MANAGER_H

--- a/firmware/device/src/main.cpp
+++ b/firmware/device/src/main.cpp
@@ -3,6 +3,7 @@
 // Input-to-timer event mapping wired in loop() (issue #221).
 
 #include <Arduino.h>
+#include "ble_manager.h"
 #include "display.h"
 #include "input.h"
 #include "timer.h"
@@ -204,6 +205,9 @@ void setup() {
   digitalWrite(LED_BUILTIN, LOW);
   delay(LED_BLINK_MS);
   digitalWrite(LED_BUILTIN, HIGH);
+
+  // Initialize BLE SoftDevice and start advertising.
+  ble_init();
 
   // Initialize e-ink display and show idle screen.
   Display::init();


### PR DESCRIPTION
## Summary
- Initialize nRF52840 BLE SoftDevice (S140) via Adafruit Bluefruit library with device name "PomoFocus" and Timer Service UUID advertising
- Set advertising interval to ~100ms for fast discoverability by nRF Connect
- Add connection/disconnection callbacks with serial logging
- Files named `ble_manager.h/cpp` (not `ble.h/cpp`) to avoid shadowing the Nordic SoftDevice's own `ble.h` header

Closes #229

## Test plan
- [ ] `pio run` compiles without errors
- [ ] Scan with nRF Connect app — verify "PomoFocus" device appears
- [ ] Verify Timer Service UUID `504D4643-0001-CAFE-FACE-DEAD00000000` in advertising data
- [ ] Connect from nRF Connect — verify serial log shows connection callback
- [ ] Disconnect — verify serial log shows disconnection callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)