### PR TITLE
feat: flash storage abstraction for nRF52840 internal flash

### DIFF
--- a/firmware/device/src/flash_storage.cpp
+++ b/firmware/device/src/flash_storage.cpp
@@ -1,0 +1,241 @@
+// PomoFocus — Flash storage implementation for nRF52840 internal flash.
+// Uses the nRF52 NVMC (Non-Volatile Memory Controller) peripheral for
+// read/write/erase of the dedicated session storage region.
+// See flash_storage.h for API documentation.
+
+#include "flash_storage.h"
+#include <Arduino.h>
+#include <cstring>
+
+// nRF52840 NVMC (Non-Volatile Memory Controller) registers.
+// These are memory-mapped hardware registers for flash operations.
+// Reference: nRF52840 Product Specification, Section 4.3 (NVMC).
+#ifndef NRF_NVMC_BASE
+#define NRF_NVMC_BASE 0x4001E000UL
+#endif
+
+// NVMC register offsets
+constexpr uint32_t NVMC_READY    = 0x400;  // Ready flag (1 = ready)
+constexpr uint32_t NVMC_CONFIG   = 0x504;  // Configuration register
+constexpr uint32_t NVMC_ERASEPAGE = 0x508; // Erase page register
+
+// NVMC CONFIG values
+constexpr uint32_t NVMC_CONFIG_REN  = 0; // Read-only (default)
+constexpr uint32_t NVMC_CONFIG_WEN  = 1; // Write enable
+constexpr uint32_t NVMC_CONFIG_EEN  = 2; // Erase enable
+
+namespace {
+
+// Access NVMC registers via memory-mapped IO.
+volatile uint32_t& nvmcReg(uint32_t offset) {
+    return *reinterpret_cast<volatile uint32_t*>(NRF_NVMC_BASE + offset);
+}
+
+// Wait for the NVMC to become ready (previous operation complete).
+void waitReady() {
+    while (nvmcReg(NVMC_READY) == 0) {
+        // Spin — typically takes ~85us for a word write, ~85ms for a page erase.
+    }
+}
+
+// Enable write mode on NVMC.
+void enableWrite() {
+    nvmcReg(NVMC_CONFIG) = NVMC_CONFIG_WEN;
+    __DSB(); // Data synchronization barrier
+}
+
+// Enable erase mode on NVMC.
+void enableErase() {
+    nvmcReg(NVMC_CONFIG) = NVMC_CONFIG_EEN;
+    __DSB();
+}
+
+// Return NVMC to read-only mode.
+void disableWrite() {
+    nvmcReg(NVMC_CONFIG) = NVMC_CONFIG_REN;
+    __DSB();
+}
+
+// Write a single 32-bit word to flash. Flash must be erased first.
+// addr must be 4-byte aligned.
+void writeWord(uint32_t addr, uint32_t value) {
+    enableWrite();
+    *reinterpret_cast<volatile uint32_t*>(addr) = value;
+    waitReady();
+    disableWrite();
+}
+
+// Current write offset within the region (bytes from REGION_START).
+// Initialized by init() scanning for the first erased location.
+uint32_t g_writeOffset = 0;
+
+} // anonymous namespace
+
+namespace FlashStorage {
+
+bool isByteErased(uint32_t absoluteAddr) {
+    return *reinterpret_cast<const volatile uint8_t*>(absoluteAddr) == ERASED_BYTE;
+}
+
+void init() {
+    // Scan the storage region to find the write offset.
+    // Walk forward from REGION_START, looking for the first 4-byte-aligned
+    // position where the record header reads as erased (0xFFFFFFFF).
+    g_writeOffset = 0;
+
+    while (g_writeOffset + RECORD_HEADER_SIZE <= REGION_SIZE) {
+        uint32_t addr = REGION_START + g_writeOffset;
+        uint32_t headerVal = *reinterpret_cast<const volatile uint32_t*>(addr);
+
+        if (headerVal == 0xFFFFFFFF) {
+            // Found erased space — this is the next write position.
+            break;
+        }
+
+        // Valid record header: skip past header + payload.
+        // Round up to 4-byte alignment for the next record.
+        uint32_t payloadLen = headerVal;
+
+        // Sanity check: if payloadLen is unreasonably large, the region
+        // is corrupt. Stop scanning here.
+        if (payloadLen > REGION_SIZE) {
+            break;
+        }
+
+        uint32_t totalSize = RECORD_HEADER_SIZE + payloadLen;
+        // Align up to 4 bytes
+        totalSize = (totalSize + 3) & ~3U;
+        g_writeOffset += totalSize;
+    }
+
+    Serial.print("[flash] init: write offset = ");
+    Serial.println(g_writeOffset);
+}
+
+FlashResult writeRecord(uint32_t offset, const uint8_t* data, uint32_t len) {
+    uint32_t totalSize = RECORD_HEADER_SIZE + len;
+    // Align total size to 4 bytes for next record alignment
+    uint32_t alignedSize = (totalSize + 3) & ~3U;
+
+    // Bounds check: record must fit within the region
+    if (offset + alignedSize > REGION_SIZE) {
+        return FlashResult::ERR_OUT_OF_BOUNDS;
+    }
+
+    uint32_t absAddr = REGION_START + offset;
+
+    // Page boundary check: record must not cross a page boundary.
+    // This simplifies erase — a page can be erased without splitting records.
+    uint32_t pageStart = absAddr & ~(PAGE_SIZE - 1);
+    uint32_t pageEnd = pageStart + PAGE_SIZE;
+    if (absAddr + alignedSize > pageEnd) {
+        return FlashResult::ERR_PAGE_BOUNDARY;
+    }
+
+    // Verify destination is erased
+    for (uint32_t i = 0; i < alignedSize; i++) {
+        if (!isByteErased(absAddr + i)) {
+            return FlashResult::ERR_NOT_ERASED;
+        }
+    }
+
+    // Write the header (4-byte length prefix)
+    writeWord(absAddr, len);
+
+    // Write the payload in 4-byte words.
+    // If len is not a multiple of 4, the last word is padded with 0xFF
+    // (erased bits stay high, so writing 0xFF to already-erased bits is safe).
+    uint32_t wordCount = (len + 3) / 4;
+    for (uint32_t i = 0; i < wordCount; i++) {
+        uint32_t word = 0xFFFFFFFF; // Default: all bits high (erased)
+        uint32_t bytesLeft = len - (i * 4);
+        uint32_t bytesToCopy = bytesLeft < 4 ? bytesLeft : 4;
+        memcpy(&word, data + (i * 4), bytesToCopy);
+        writeWord(absAddr + RECORD_HEADER_SIZE + (i * 4), word);
+    }
+
+    // Verify the write by reading back
+    uint32_t readHeader = *reinterpret_cast<const volatile uint32_t*>(absAddr);
+    if (readHeader != len) {
+        return FlashResult::ERR_WRITE_FAILED;
+    }
+
+    // Advance the write offset past this record
+    if (offset + alignedSize > g_writeOffset) {
+        g_writeOffset = offset + alignedSize;
+    }
+
+    return FlashResult::OK;
+}
+
+FlashResult readRecord(uint32_t offset, uint8_t* buf, uint32_t bufSize,
+                       uint32_t& outLen) {
+    // Bounds check: at least the header must be within the region
+    if (offset + RECORD_HEADER_SIZE > REGION_SIZE) {
+        return FlashResult::ERR_OUT_OF_BOUNDS;
+    }
+
+    uint32_t absAddr = REGION_START + offset;
+
+    // Read the header
+    uint32_t headerVal = *reinterpret_cast<const volatile uint32_t*>(absAddr);
+
+    // Check if this location is erased (no record)
+    if (headerVal == 0xFFFFFFFF) {
+        return FlashResult::ERR_INVALID_RECORD;
+    }
+
+    uint32_t payloadLen = headerVal;
+
+    // Sanity check payload length
+    if (offset + RECORD_HEADER_SIZE + payloadLen > REGION_SIZE) {
+        return FlashResult::ERR_INVALID_RECORD;
+    }
+
+    // Check caller buffer size
+    if (payloadLen > bufSize) {
+        outLen = payloadLen; // Report actual size so caller knows
+        return FlashResult::ERR_BUFFER_TOO_SMALL;
+    }
+
+    // Read the payload.
+    // Cast away volatile — flash reads are stable after NVMC is idle.
+    const void* src = reinterpret_cast<const void*>(absAddr + RECORD_HEADER_SIZE);
+    memcpy(buf, src, payloadLen);
+    outLen = payloadLen;
+
+    return FlashResult::OK;
+}
+
+FlashResult erasePage(uint32_t pageIndex) {
+    if (pageIndex >= PAGE_COUNT) {
+        return FlashResult::ERR_OUT_OF_BOUNDS;
+    }
+
+    uint32_t pageAddr = REGION_START + (pageIndex * PAGE_SIZE);
+
+    enableErase();
+    nvmcReg(NVMC_ERASEPAGE) = pageAddr;
+    waitReady();
+    disableWrite();
+
+    // Verify erase: check first and last words
+    uint32_t firstWord = *reinterpret_cast<const volatile uint32_t*>(pageAddr);
+    uint32_t lastWord = *reinterpret_cast<const volatile uint32_t*>(
+        pageAddr + PAGE_SIZE - 4);
+    if (firstWord != 0xFFFFFFFF || lastWord != 0xFFFFFFFF) {
+        return FlashResult::ERR_ERASE_FAILED;
+    }
+
+    return FlashResult::OK;
+}
+
+uint32_t getWriteOffset() {
+    return g_writeOffset;
+}
+
+uint32_t getUsedBytes() {
+    return g_writeOffset;
+}
+
+} // namespace FlashStorage

--- a/firmware/device/src/flash_storage.h
+++ b/firmware/device/src/flash_storage.h
@@ -1,0 +1,106 @@
+// PomoFocus — Flash storage abstraction for nRF52840 internal flash.
+// Provides read/write/erase for session data stored in a dedicated
+// flash region (~256KB). Sequential writes with page-level erase for
+// basic wear leveling. No dynamic allocation (NAT-F01).
+// See ADR-010 for capacity (~2500 sessions) and ADR-015 for toolchain.
+
+#ifndef POMOFOCUS_FLASH_STORAGE_H
+#define POMOFOCUS_FLASH_STORAGE_H
+
+#include <cstdint>
+#include <cstddef>
+
+namespace FlashStorage {
+
+// ── Flash region layout ──
+// nRF52840 has 1MB flash total. The session storage region occupies the
+// last 256KB, above application code. Flash page size is 4KB.
+//
+// Memory map:
+//   0x00000000 - 0x00026000  SoftDevice (BLE stack, ~152KB)
+//   0x00026000 - 0x000C0000  Application code + libraries
+//   0x000C0000 - 0x00100000  Session storage (this module)
+
+constexpr uint32_t PAGE_SIZE       = 4096;         // nRF52840 flash page: 4KB
+constexpr uint32_t REGION_START    = 0x000C0000;   // Start of session storage
+constexpr uint32_t REGION_SIZE     = 256 * 1024;   // 256KB
+constexpr uint32_t REGION_END      = REGION_START + REGION_SIZE;
+constexpr uint32_t PAGE_COUNT      = REGION_SIZE / PAGE_SIZE; // 64 pages
+
+// ── Record header ──
+// Each record written to flash is prefixed with a 4-byte header containing
+// the payload length. This enables readRecord to know how many bytes to
+// return without the caller tracking sizes externally.
+
+constexpr uint32_t RECORD_HEADER_SIZE = 4; // uint32_t length prefix
+
+// Erased flash reads as 0xFF on nRF52840.
+constexpr uint8_t ERASED_BYTE = 0xFF;
+
+// ── Return codes ──
+
+enum class FlashResult : uint8_t {
+    OK,
+    ERR_OUT_OF_BOUNDS,   // Address or offset outside the storage region
+    ERR_PAGE_BOUNDARY,   // Record would cross a page boundary
+    ERR_NOT_ERASED,      // Flash not erased at write destination
+    ERR_WRITE_FAILED,    // Hardware write failed
+    ERR_ERASE_FAILED,    // Hardware erase failed
+    ERR_INVALID_RECORD,  // No valid record at read offset (erased or corrupt)
+    ERR_BUFFER_TOO_SMALL // Caller buffer too small for the record
+};
+
+// ── Public API ──
+
+// Initialize the flash storage module. Scans the region to find the
+// current write offset (first erased location after valid records).
+// Call once from setup().
+void init();
+
+// Write a record at the given byte offset within the storage region.
+// The record is stored as: [4-byte length][payload bytes].
+// offset is relative to REGION_START (0 = start of storage region).
+//
+// Returns OK on success, or an error if:
+//   - offset + header + len exceeds the region
+//   - the write would cross a page boundary
+//   - the destination is not erased
+//   - the hardware write fails
+FlashResult writeRecord(uint32_t offset, const uint8_t* data, uint32_t len);
+
+// Read a record from the given byte offset within the storage region.
+// offset is relative to REGION_START.
+// buf: caller-provided buffer to receive the payload.
+// bufSize: size of buf in bytes.
+// outLen: set to the actual payload length on success.
+//
+// Returns OK on success, or an error if:
+//   - offset is outside the region
+//   - no valid record header at offset (erased bytes)
+//   - buf is too small for the payload
+FlashResult readRecord(uint32_t offset, uint8_t* buf, uint32_t bufSize,
+                       uint32_t& outLen);
+
+// Erase a single flash page by page index (0-based within the region).
+// pageIndex 0 = first page at REGION_START, etc.
+//
+// Returns OK on success, or an error if:
+//   - pageIndex >= PAGE_COUNT
+//   - the hardware erase fails
+FlashResult erasePage(uint32_t pageIndex);
+
+// Return the current write offset (bytes from REGION_START).
+// This is the next location where writeRecord would place data.
+// Advances after each successful writeRecord call.
+uint32_t getWriteOffset();
+
+// Return the total number of bytes used in the storage region
+// (same as getWriteOffset() — sequential layout).
+uint32_t getUsedBytes();
+
+// Return true if the byte at the given absolute flash address is erased (0xFF).
+bool isByteErased(uint32_t absoluteAddr);
+
+} // namespace FlashStorage
+
+#endif // POMOFOCUS_FLASH_STORAGE_H


### PR DESCRIPTION
## Summary

Closes #246

- Adds a flash storage abstraction (`FlashStorage` namespace) for the nRF52840's internal flash, providing read/write/erase operations over a dedicated ~256KB region (0x000C0000 - 0x00100000)
- Records use a 4-byte length-prefixed format with sequential writes and page-level erase for basic wear leveling
- Zero dynamic allocation — all operations use stack buffers and memory-mapped NVMC register access (per ADR-015)

## Details

**Header** (`flash_storage.h`):
- Flash region constants (start address, 256KB size, 4KB page size, 64 pages)
- `FlashResult` enum with 8 error codes for bounds, page boundary, erase state, and buffer size checks
- Public API: `init()`, `writeRecord()`, `readRecord()`, `erasePage()`, `getWriteOffset()`, `getUsedBytes()`, `isByteErased()`

**Implementation** (`flash_storage.cpp`):
- Direct NVMC register manipulation for write/erase operations with DSB barriers
- `init()` scans the region to locate the write offset (first erased position after valid records)
- `writeRecord()` enforces bounds, page boundary, and erased-state checks before writing; verifies readback
- `readRecord()` validates header, checks for erased/corrupt records, and reports actual size on buffer overflow
- `erasePage()` erases by page index with first/last word verification
- Payload writes padded to 4-byte alignment (0xFF padding preserves erased bits)

## Test plan

- [x] `pio run` compiles successfully
- [ ] Manual: write test data, read back, verify correctness
- [ ] Manual: power cycle, verify data persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)