### PR TITLE
feat: register custom 128-bit UUIDs for GATT services

### DIFF
--- a/firmware/device/src/ble_manager.cpp
+++ b/firmware/device/src/ble_manager.cpp
@@ -13,6 +13,11 @@
 // Key (LTK) is persisted after the first pairing — subsequent connections
 // skip the passkey step.
 //
+// This file initializes BLE, registers custom GATT services with their
+// characteristics, and starts advertising. Timer and Session Sync services
+// have full Protobuf handlers in ble_services.cpp. Goal Service is
+// registered here as a placeholder — handlers are a separate issue.
+//
 // NOTE: This file is named ble_manager.cpp (not ble.cpp) because the Nordic
 // SoftDevice SDK ships its own ble.h. If our header were named ble.h, the
 // Bluefruit library's #include "ble.h" would resolve to ours instead of the
@@ -24,9 +29,20 @@
 
 #include <bluefruit.h>
 
-// Timer Service UUID object for advertising.
-// Constructed from the 128-bit UUID byte array defined in ble_manager.h.
-static BLEUuid s_timerServiceUuid(TIMER_SERVICE_UUID);
+// ── Timer Service UUID for advertising ──
+// Constructed from the 128-bit UUID byte array defined in ble_uuids.h.
+// The Timer Service BLEService object lives in ble_services.cpp.
+static BLEUuid s_timerServiceUuid(UUID_TIMER_SERVICE);
+
+// ── GATT Service and Characteristic objects ──
+// Static instances — zero dynamic allocation (NAT-F01).
+// Goal Service is registered in setupServices() as a placeholder.
+// Timer and Session Sync services are handled by ble_services.cpp.
+
+// Goal Service (0002) — phone pushes goals, device reports selection.
+static BLEService        s_goalService(UUID_GOAL_SERVICE);
+static BLECharacteristic s_goalListChar(UUID_GOAL_LIST_CHAR);
+static BLECharacteristic s_goalSelectedChar(UUID_GOAL_SELECTED_CHAR);
 
 // ── Connection state ──
 
@@ -135,6 +151,36 @@ static void onDisconnect(uint16_t connHandle, uint8_t reason) {
     Bluefruit.Advertising.start(ADV_TIMEOUT_SEC);
 }
 
+// ── GATT service registration (Goal Service) ──
+// Timer and Session Sync services are registered by ble_services_init()
+// in ble_services.cpp. This function registers the Goal Service as a
+// placeholder. Protobuf handlers for Goal Service are a separate issue.
+
+// Maximum Protobuf payload sizes from ADR-013 design doc.
+// Used to set characteristic fixed_len so the SoftDevice allocates
+// the right ATT attribute buffer. Sizes are generous upper bounds.
+constexpr uint16_t GOAL_LIST_MAX_LEN    = 512;  // GoalList chunked, max per write
+constexpr uint16_t GOAL_SELECTED_MAX_LEN = 20;  // SelectedGoal ~16 bytes + overhead
+
+static void setupServices() {
+    // ── Goal Service ──
+    s_goalService.begin();
+
+    // Goal List: Write (phone → device).
+    s_goalListChar.setProperties(CHR_PROPS_WRITE);
+    s_goalListChar.setPermission(SECMODE_NO_ACCESS, SECMODE_ENC_NO_MITM);
+    s_goalListChar.setMaxLen(GOAL_LIST_MAX_LEN);
+    s_goalListChar.begin();
+
+    // Selected Goal: Read + Notify (device → phone).
+    s_goalSelectedChar.setProperties(CHR_PROPS_READ | CHR_PROPS_NOTIFY);
+    s_goalSelectedChar.setPermission(SECMODE_ENC_NO_MITM, SECMODE_NO_ACCESS);
+    s_goalSelectedChar.setMaxLen(GOAL_SELECTED_MAX_LEN);
+    s_goalSelectedChar.begin();
+
+    Serial.println("[ble] Goal Service registered");
+}
+
 // ── Advertising configuration ──
 
 static void startAdvertising() {
@@ -148,8 +194,7 @@ static void startAdvertising() {
     Bluefruit.Advertising.addTxPower();
 
     // Include the Timer Service UUID so scanners (nRF Connect) can filter by it.
-    // Uses addUuid() to advertise the UUID without registering a full GATT service
-    // (GATT services are separate issues — out of scope here).
+    // Uses addUuid() because the BLEService object lives in ble_services.cpp.
     Bluefruit.Advertising.addUuid(s_timerServiceUuid);
 
     // Include the device name in the scan response packet.
@@ -227,6 +272,10 @@ void ble_init() {
     // Initialize all GATT services before advertising starts.
     // Services must be registered before Bluefruit.Advertising.start().
     ble_services_init();
+
+    // Register Goal Service (placeholder registration).
+    // Protobuf handlers for Goal Service are a separate issue.
+    setupServices();
 
     // Configure and start advertising.
     startAdvertising();

--- a/firmware/device/src/ble_manager.h
+++ b/firmware/device/src/ble_manager.h
@@ -1,28 +1,19 @@
 // PomoFocus Device Firmware — BLE SoftDevice Manager
 // Initializes nRF52840 BLE SoftDevice (S140) via Adafruit Bluefruit,
 // configures advertising with device name and Timer Service UUID,
-// and sets up LE Secure Connections (LESC) with Passkey Entry pairing.
+// registers custom GATT services, and sets up LE Secure Connections
+// (LESC) with Passkey Entry pairing.
 // See ADR-010 (hardware), ADR-012 (security), and ADR-013 (GATT protocol).
 
 #ifndef POMOFOCUS_BLE_MANAGER_H
 #define POMOFOCUS_BLE_MANAGER_H
 
-#include <cstdint>
+#include "ble_uuids.h"
 
 // ── Device identity ──
 
 // BLE advertised device name. Matches ADR-013 advertising spec.
 constexpr const char* BLE_DEVICE_NAME = "PomoFocus";
-
-// ── Timer Service UUID ──
-// Primary service UUID included in advertising packets for discovery.
-// Full 128-bit UUID: 504D4643-0001-CAFE-FACE-DEAD00000000
-// See ADR-013 UUID scheme: PMFC{XXXX}-CAFE-FACE-DEAD-P0M0F0CUS00
-// Byte array in little-endian order for Bluefruit API.
-constexpr uint8_t TIMER_SERVICE_UUID[16] = {
-    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
-    0xFE, 0xCA, 0x01, 0x00, 0x43, 0x46, 0x4D, 0x50
-};
 
 // ── Advertising parameters ──
 

--- a/firmware/device/src/ble_services.cpp
+++ b/firmware/device/src/ble_services.cpp
@@ -40,15 +40,15 @@ static uint8_t s_syncStatusBuf[pomofocus_ble_SyncStatus_size];
 
 // ── BLE objects — Timer Service ──
 // Static instances — Bluefruit requires persistent objects.
-static BLEService s_timerService(TIMER_SERVICE_UUID);
-static BLECharacteristic s_timerStateChr(TIMER_STATE_CHR_UUID);
-static BLECharacteristic s_timerCommandChr(TIMER_COMMAND_CHR_UUID);
+static BLEService s_timerService(UUID_TIMER_SERVICE);
+static BLECharacteristic s_timerStateChr(UUID_TIMER_STATE_CHAR);
+static BLECharacteristic s_timerCommandChr(UUID_TIMER_COMMAND_CHAR);
 
 // ── BLE objects — Session Sync Service ──
-static BLEService       s_syncService(SESSION_SYNC_SERVICE_UUID);
-static BLECharacteristic s_syncStatusChar(SYNC_STATUS_CHAR_UUID);
-static BLECharacteristic s_sessionDataChar(SESSION_DATA_CHAR_UUID);
-static BLECharacteristic s_syncControlChar(SYNC_CONTROL_CHAR_UUID);
+static BLEService       s_syncService(UUID_SESSION_SYNC_SERVICE);
+static BLECharacteristic s_syncStatusChar(UUID_SYNC_STATUS_CHAR);
+static BLECharacteristic s_sessionDataChar(UUID_SESSION_DATA_CHAR);
+static BLECharacteristic s_syncControlChar(UUID_SYNC_CONTROL_CHAR);
 
 // ── Standard service instances ──
 // Static module-level objects — zero dynamic allocation (NAT-F01).

--- a/firmware/device/src/ble_services.h
+++ b/firmware/device/src/ble_services.h
@@ -9,56 +9,13 @@
 #ifndef POMOFOCUS_BLE_SERVICES_H
 #define POMOFOCUS_BLE_SERVICES_H
 
+#include "ble_uuids.h"
+
 #include <cstdint>
 
 // Forward declaration — avoids pulling timer.h into the header.
 struct TimerState;
 enum class TimerEvent : uint8_t;
-
-// ── Timer Service Characteristic UUIDs (ADR-013 UUID scheme) ──
-// Timer State: 504D4643-0101-CAFE-FACE-DEAD00000000
-// Timer Command: 504D4643-0102-CAFE-FACE-DEAD00000000
-// Byte arrays in little-endian order for Bluefruit API.
-
-constexpr uint8_t TIMER_STATE_CHR_UUID[16] = {
-    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
-    0xFE, 0xCA, 0x01, 0x01, 0x43, 0x46, 0x4D, 0x50
-};
-
-constexpr uint8_t TIMER_COMMAND_CHR_UUID[16] = {
-    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
-    0xFE, 0xCA, 0x02, 0x01, 0x43, 0x46, 0x4D, 0x50
-};
-
-// ── Session Sync Service UUIDs ──
-// Service UUID: 504D4643-0003-CAFE-FACE-DEAD00000000
-// Byte arrays in little-endian order for Bluefruit API.
-
-constexpr uint8_t SESSION_SYNC_SERVICE_UUID[16] = {
-    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
-    0xFE, 0xCA, 0x03, 0x00, 0x43, 0x46, 0x4D, 0x50
-};
-
-// Sync Status characteristic (0301): Read + Notify
-// Returns SyncStatus Protobuf (pending_sessions, total_stored, last_synced_id, state).
-constexpr uint8_t SYNC_STATUS_CHAR_UUID[16] = {
-    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
-    0xFE, 0xCA, 0x01, 0x03, 0x43, 0x46, 0x4D, 0x50
-};
-
-// Session Data characteristic (0302): Notify
-// Device-to-phone bulk session transfer. Chunked protocol in 7A.7.
-constexpr uint8_t SESSION_DATA_CHAR_UUID[16] = {
-    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
-    0xFE, 0xCA, 0x02, 0x03, 0x43, 0x46, 0x4D, 0x50
-};
-
-// Sync Control characteristic (0303): Write
-// Accepts SyncControl Protobuf from phone (START, ACK, NACK, ABORT, CURSOR_UPDATE).
-constexpr uint8_t SYNC_CONTROL_CHAR_UUID[16] = {
-    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
-    0xFE, 0xCA, 0x03, 0x03, 0x43, 0x46, 0x4D, 0x50
-};
 
 // ── Callback type ──
 // Called when a valid Timer Command is received over BLE.

--- a/firmware/device/src/ble_uuids.h
+++ b/firmware/device/src/ble_uuids.h
@@ -1,0 +1,110 @@
+// PomoFocus Device Firmware — BLE GATT UUID Definitions
+// Custom 128-bit UUIDs for all PomoFocus GATT services and characteristics.
+// See ADR-013 (GATT protocol) for the UUID scheme and service design.
+//
+// UUID scheme: 504D4643-XXXX-CAFE-FACE-DEAD00000000
+//   504D4643 = "PMFC" (PomoFocus prefix)
+//   XXXX     = service/characteristic identifier
+//   Services: 0001 (Timer), 0002 (Goal), 0003 (Session Sync)
+//   Characteristics: first two hex digits match service (01xx, 02xx, 03xx)
+//
+// All byte arrays are in little-endian order for the Adafruit Bluefruit API.
+
+#ifndef POMOFOCUS_BLE_UUIDS_H
+#define POMOFOCUS_BLE_UUIDS_H
+
+#include <cstdint>
+
+// ── Helper: UUID byte-array layout ──
+// 128-bit UUID: 504D4643-XXXX-CAFE-FACE-DEAD00000000
+// Written as bytes (big-endian): 50 4D 46 43 XX XX CA FE FA CE DE AD 00 00 00 00
+// Bluefruit expects little-endian order (last byte first):
+//   bytes[0..3]   = last 4 bytes   = 00 00 00 00 → DEAD
+//   bytes[4..5]   = DEAD            → FACE
+//   bytes[6..7]   = FACE            → CAFE
+//   bytes[8..9]   = CAFE            → XXXX
+//   bytes[10..11] = XXXX            → 504D4643
+//   bytes[12..15] = 504D4643
+//
+// Little-endian: 00 00 00 00  AD DE  CE FA  FE CA  XX XX  43 46 4D 50
+
+// ══════════════════════════════════════════════════════════════════════
+// Timer Service (0001)
+// ══════════════════════════════════════════════════════════════════════
+
+// Timer Service UUID: 504D4643-0001-CAFE-FACE-DEAD00000000
+constexpr uint8_t UUID_TIMER_SERVICE[16] = {
+    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
+    0xFE, 0xCA, 0x01, 0x00, 0x43, 0x46, 0x4D, 0x50
+};
+
+// Timer State Characteristic UUID: 504D4643-0101-CAFE-FACE-DEAD00000000
+// Properties: Read, Notify
+constexpr uint8_t UUID_TIMER_STATE_CHAR[16] = {
+    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
+    0xFE, 0xCA, 0x01, 0x01, 0x43, 0x46, 0x4D, 0x50
+};
+
+// Timer Command Characteristic UUID: 504D4643-0102-CAFE-FACE-DEAD00000000
+// Properties: Write
+constexpr uint8_t UUID_TIMER_COMMAND_CHAR[16] = {
+    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
+    0xFE, 0xCA, 0x02, 0x01, 0x43, 0x46, 0x4D, 0x50
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// Goal Service (0002)
+// ══════════════════════════════════════════════════════════════════════
+
+// Goal Service UUID: 504D4643-0002-CAFE-FACE-DEAD00000000
+constexpr uint8_t UUID_GOAL_SERVICE[16] = {
+    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
+    0xFE, 0xCA, 0x02, 0x00, 0x43, 0x46, 0x4D, 0x50
+};
+
+// Goal List Characteristic UUID: 504D4643-0201-CAFE-FACE-DEAD00000000
+// Properties: Write
+constexpr uint8_t UUID_GOAL_LIST_CHAR[16] = {
+    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
+    0xFE, 0xCA, 0x01, 0x02, 0x43, 0x46, 0x4D, 0x50
+};
+
+// Selected Goal Characteristic UUID: 504D4643-0202-CAFE-FACE-DEAD00000000
+// Properties: Read, Notify
+constexpr uint8_t UUID_GOAL_SELECTED_CHAR[16] = {
+    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
+    0xFE, 0xCA, 0x02, 0x02, 0x43, 0x46, 0x4D, 0x50
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// Session Sync Service (0003)
+// ══════════════════════════════════════════════════════════════════════
+
+// Session Sync Service UUID: 504D4643-0003-CAFE-FACE-DEAD00000000
+constexpr uint8_t UUID_SESSION_SYNC_SERVICE[16] = {
+    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
+    0xFE, 0xCA, 0x03, 0x00, 0x43, 0x46, 0x4D, 0x50
+};
+
+// Sync Status Characteristic UUID: 504D4643-0301-CAFE-FACE-DEAD00000000
+// Properties: Read, Notify
+constexpr uint8_t UUID_SYNC_STATUS_CHAR[16] = {
+    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
+    0xFE, 0xCA, 0x01, 0x03, 0x43, 0x46, 0x4D, 0x50
+};
+
+// Session Data Characteristic UUID: 504D4643-0302-CAFE-FACE-DEAD00000000
+// Properties: Notify (bulk TX — device streams sessions to phone)
+constexpr uint8_t UUID_SESSION_DATA_CHAR[16] = {
+    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
+    0xFE, 0xCA, 0x02, 0x03, 0x43, 0x46, 0x4D, 0x50
+};
+
+// Sync Control Characteristic UUID: 504D4643-0303-CAFE-FACE-DEAD00000000
+// Properties: Write (bulk RX — phone sends sync commands to device)
+constexpr uint8_t UUID_SYNC_CONTROL_CHAR[16] = {
+    0x00, 0x00, 0x00, 0x00, 0xAD, 0xDE, 0xCE, 0xFA,
+    0xFE, 0xCA, 0x03, 0x03, 0x43, 0x46, 0x4D, 0x50
+};
+
+#endif // POMOFOCUS_BLE_UUIDS_H


### PR DESCRIPTION
## Summary

- Defines all custom 128-bit UUIDs for the 3 GATT services (Timer, Goal, Session Sync) and their characteristics in a dedicated `ble_uuids.h` header
- Registers the services and characteristics with the nRF52840 SoftDevice in `ble_manager.cpp`
- Uses the UUID scheme from ADR-013: `504D4643-XXXX-CAFE-FACE-DEAD00000000`

Closes #231

## Test plan

- [ ] `pio run` compiles successfully
- [ ] Connect with nRF Connect and verify all custom UUIDs appear in service discovery
- [ ] Timer Service: `504D4643-0001-CAFE-FACE-DEAD00000000`
- [ ] Goal Service: `504D4643-0002-CAFE-FACE-DEAD00000000`
- [ ] Session Sync Service: `504D4643-0003-CAFE-FACE-DEAD00000000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)