### PR TITLE
feat: add Device Info and Battery Level BLE services

### DIFF
--- a/firmware/device/src/ble_manager.cpp
+++ b/firmware/device/src/ble_manager.cpp
@@ -224,7 +224,7 @@ void ble_init() {
 
     Serial.println("[ble] SoftDevice initialized");
 
-    // Initialize GATT services before advertising starts.
+    // Initialize all GATT services before advertising starts.
     // Services must be registered before Bluefruit.Advertising.start().
     ble_services_init();
 

--- a/firmware/device/src/ble_services.cpp
+++ b/firmware/device/src/ble_services.cpp
@@ -11,6 +11,10 @@
 //   Session Data (0302): Notify — device-to-phone bulk transfer (chunked protocol in 7A.7)
 //   Sync Control (0303): Write — phone sends sync commands (START, ACK, etc.)
 //
+// Standard services:
+//   Device Information (0x180A): read-only, set once at boot.
+//   Battery (0x180F): Read + Notify. Placeholder (100%) until ADC in 7A.8.
+//
 // Encoding uses Nanopb (static buffers only, NAT-F01).
 // Notifications use BLE NOTIFY (not INDICATE) per NAT-F07.
 // Full chunked transfer protocol is deferred to issue 7A.7.
@@ -45,6 +49,11 @@ static BLEService       s_syncService(SESSION_SYNC_SERVICE_UUID);
 static BLECharacteristic s_syncStatusChar(SYNC_STATUS_CHAR_UUID);
 static BLECharacteristic s_sessionDataChar(SESSION_DATA_CHAR_UUID);
 static BLECharacteristic s_syncControlChar(SYNC_CONTROL_CHAR_UUID);
+
+// ── Standard service instances ──
+// Static module-level objects — zero dynamic allocation (NAT-F01).
+static BLEDis s_deviceInfo;
+static BLEBas s_battery;
 
 // ── Command callback ──
 static BleTimerCommandCallback s_commandCallback = nullptr;
@@ -206,6 +215,26 @@ static void onSyncControlWrite(uint16_t connHandle, BLECharacteristic* chr,
 // ── Public API ──
 
 void ble_services_init() {
+  // ── Device Information Service (0x180A) ──
+  // BLEDis::begin() registers the service with the SoftDevice.
+  // Characteristics are set before begin() — Bluefruit copies the strings.
+  s_deviceInfo.setManufacturer(DIS_MANUFACTURER_NAME);
+  s_deviceInfo.setModel(DIS_MODEL_NUMBER);
+  s_deviceInfo.setFirmwareRev(DIS_FIRMWARE_REVISION);
+  s_deviceInfo.begin();
+
+  Serial.println("[ble_svc] Device Info Service 0x180A registered");
+
+  // ── Battery Service (0x180F) ──
+  // BLEBas::begin() registers the service and Battery Level characteristic
+  // (0x2A19) with Read + Notify permissions.
+  s_battery.begin();
+
+  // Set initial battery level to 100% (placeholder until ADC in 7A.8).
+  s_battery.write(100);
+
+  Serial.println("[ble_svc] Battery Service 0x180F registered (level=100%)");
+
   // ── Timer Service ──
   // Begin the Timer Service
   s_timerService.begin();
@@ -313,4 +342,10 @@ void ble_services_update_sync_status(uint32_t pending, uint32_t total,
     // If a central is subscribed, Bluefruit sends a notification automatically
     // when the characteristic value is updated via write().
     // Explicit notify() call is not needed — Bluefruit handles CCCD internally.
+}
+
+void ble_services_set_battery_level(uint8_t level) {
+  uint8_t clamped = level > 100 ? 100 : level;
+  s_battery.write(clamped);
+  s_battery.notify(clamped);
 }

--- a/firmware/device/src/ble_services.h
+++ b/firmware/device/src/ble_services.h
@@ -2,6 +2,7 @@
 // Timer Service: Timer State (Read+Notify) and Timer Command (Write).
 // Session Sync Service: Sync Status (Read+Notify), Session Data (Notify),
 //   and Sync Control (Write).
+// Standard services: Device Information (0x180A) and Battery (0x180F).
 // Protobuf-encoded payloads per ADR-013 GATT protocol design.
 // See ADR-013 for UUIDs, properties, and behavior spec.
 
@@ -65,9 +66,15 @@ constexpr uint8_t SYNC_CONTROL_CHAR_UUID[16] = {
 // ble_timer_notify_state() after the transition.
 using BleTimerCommandCallback = void (*)(TimerEvent event);
 
+// ── Device identity strings ──
+
+constexpr const char* DIS_MANUFACTURER_NAME = "PomoFocus";
+constexpr const char* DIS_MODEL_NUMBER      = "PF-001";
+constexpr const char* DIS_FIRMWARE_REVISION  = "0.1.0";
+
 // ── Public API ──
 
-// Initialize all BLE GATT services (Timer Service, Session Sync Service)
+// Initialize all BLE GATT services (Timer, Session Sync, Device Info, Battery)
 // and register them with the Bluefruit SoftDevice. Must be called after
 // Bluefruit.begin() and before Bluefruit.Advertising.start().
 void ble_services_init();
@@ -90,5 +97,10 @@ void ble_timer_notify_state(const TimerState& state);
 // state: current SyncState enum value (from pomofocus.pb.h).
 void ble_services_update_sync_status(uint32_t pending, uint32_t total,
                                      uint8_t state);
+
+// Update the battery level characteristic (0x2A19).
+// level: 0-100 percent. Values >100 are clamped to 100.
+// Sends a BLE notification to connected clients if notify is enabled.
+void ble_services_set_battery_level(uint8_t level);
 
 #endif // POMOFOCUS_BLE_SERVICES_H


### PR DESCRIPTION
## Summary

- Adds standard BLE Device Info Service (0x180A) with Manufacturer Name, Model Number, and Firmware Revision characteristics
- Adds standard BLE Battery Service (0x180F) with Battery Level characteristic (Read + Notify), placeholder 100% until ADC integration in 7A.8
- Integrates both services into the existing BLE manager initialization

Closes #239

## Test plan

- [ ] `pio run` compiles successfully
- [ ] nRF Connect shows Device Info Service (0x180A) with readable characteristics
- [ ] nRF Connect shows Battery Service (0x180F) with Battery Level returning 100%
- [ ] Battery Level characteristic supports Read and Notify

🤖 Generated with [Claude Code](https://claude.com/claude-code)