### PR TITLE
feat: add BLE connection state management and MTU negotiation (#244)

### DIFF
--- a/firmware/device/src/ble_manager.cpp
+++ b/firmware/device/src/ble_manager.cpp
@@ -22,9 +22,24 @@
 // Constructed from the 128-bit UUID byte array defined in ble_manager.h.
 static BLEUuid s_timerServiceUuid(TIMER_SERVICE_UUID);
 
+// ── Connection state ──
+
+// Current connection handle. Valid only when s_connected is true.
+static uint16_t s_connHandle = BLE_CONN_HANDLE_INVALID;
+
+// Whether a central is currently connected.
+static bool s_connected = false;
+
+// Effective MTU negotiated with the connected central.
+// Starts at BLE_DEFAULT_MTU (23) and updates after MTU exchange.
+static uint16_t s_effectiveMtu = BLE_DEFAULT_MTU;
+
 // ── Connection callbacks ──
 
 static void onConnect(uint16_t connHandle) {
+    s_connHandle = connHandle;
+    s_connected = true;
+
     BLEConnection* conn = Bluefruit.Connection(connHandle);
     char peerName[32 + 1] = {};
     conn->getPeerName(peerName, sizeof(peerName));
@@ -33,9 +48,28 @@ static void onConnect(uint16_t connHandle) {
     Serial.print(connHandle);
     Serial.print(" peer=");
     Serial.println(peerName);
+
+    // Request MTU exchange. The SoftDevice will negotiate with the central
+    // and the result is available via conn->getMtu() after the exchange.
+    // Bluefruit configures the SoftDevice to support BLE_MAX_MTU at init.
+    // The actual negotiated MTU depends on the central's capability.
+    // After requestMtu, the SoftDevice handles the L2CAP exchange;
+    // we read the result immediately as Bluefruit applies it synchronously
+    // for the Adafruit nRF52 stack.
+    conn->requestMtuExchange(BLE_MAX_MTU);
+    s_effectiveMtu = conn->getMtu();
+
+    Serial.print("[ble] effective MTU=");
+    Serial.print(s_effectiveMtu);
+    Serial.print(" chunk_payload=");
+    Serial.println(s_effectiveMtu - ATT_HEADER_SIZE - CHUNK_HEADER_SIZE);
 }
 
 static void onDisconnect(uint16_t connHandle, uint8_t reason) {
+    s_connHandle = BLE_CONN_HANDLE_INVALID;
+    s_connected = false;
+    s_effectiveMtu = BLE_DEFAULT_MTU;
+
     Serial.print("[ble] disconnected: handle=");
     Serial.print(connHandle);
     Serial.print(" reason=0x");
@@ -84,6 +118,13 @@ static void startAdvertising() {
 void ble_init() {
     Serial.println("[ble] initializing SoftDevice");
 
+    // Configure maximum MTU the SoftDevice will accept during negotiation.
+    // ADR-013: device supports up to 247 bytes. The central initiates the
+    // MTU exchange and the SoftDevice responds with min(central_mtu, our_max).
+    // Must be called BEFORE Bluefruit.begin() — it sets SoftDevice config
+    // params that begin() applies when enabling the SoftDevice.
+    Bluefruit.configPrphBandwidth(BANDWIDTH_MAX);
+
     // Initialize Bluefruit with max connections: 1 peripheral, 0 central.
     // PomoFocus device is a peripheral only — the phone is the central.
     Bluefruit.begin(1, 0);
@@ -94,6 +135,14 @@ void ble_init() {
     // Set TX power level.
     Bluefruit.setTxPower(ADV_TX_POWER);
 
+    // Set connection supervision timeout. This determines how long the BLE
+    // stack waits without receiving packets before declaring the connection
+    // lost. 10 seconds is long enough to keep idle connections alive
+    // indefinitely (the BLE stack sends empty PDUs as keep-alive within
+    // the supervision window). This ensures the connection survives 10+
+    // minutes idle as required by ADR-013.
+    Bluefruit.Periph.setConnSupervisionTimeout(CONN_SUPERVISION_TIMEOUT);
+
     // Register connection callbacks.
     Bluefruit.Periph.setConnectCallback(onConnect);
     Bluefruit.Periph.setDisconnectCallback(onDisconnect);
@@ -102,4 +151,16 @@ void ble_init() {
 
     // Configure and start advertising.
     startAdvertising();
+}
+
+bool ble_isConnected() {
+    return s_connected;
+}
+
+uint16_t ble_getEffectiveMtu() {
+    return s_effectiveMtu;
+}
+
+uint16_t ble_getChunkPayloadSize() {
+    return s_effectiveMtu - ATT_HEADER_SIZE - CHUNK_HEADER_SIZE;
 }

--- a/firmware/device/src/ble_manager.h
+++ b/firmware/device/src/ble_manager.h
@@ -36,11 +36,49 @@ constexpr uint16_t ADV_TIMEOUT_SEC = 0;
 // without excessive battery drain.
 constexpr int8_t ADV_TX_POWER = 0;
 
+// ── MTU parameters ──
+
+// Maximum MTU the device supports. ADR-013: adaptive MTU, device up to 247 bytes.
+// nRF52840 SoftDevice S140 supports up to 247 bytes.
+constexpr uint16_t BLE_MAX_MTU = 247;
+
+// BLE 4.0 default MTU before negotiation.
+constexpr uint16_t BLE_DEFAULT_MTU = 23;
+
+// ATT protocol header overhead (3 bytes: 1 opcode + 2 handle).
+constexpr uint16_t ATT_HEADER_SIZE = 3;
+
+// Application-level chunk header overhead (4 bytes: sequence + flags + length).
+// See ADR-013: chunk_payload_size = mtu - 3 ATT - 4 chunk header.
+constexpr uint16_t CHUNK_HEADER_SIZE = 4;
+
+// ── Connection parameters ──
+
+// Connection supervision timeout in units of 10ms.
+// 1000 * 10ms = 10 seconds. If no packets are exchanged within this window,
+// the connection is considered lost. The BLE stack handles keep-alive
+// automatically via empty PDUs within this window, so idle connections
+// survive indefinitely as long as both devices are in range.
+constexpr uint16_t CONN_SUPERVISION_TIMEOUT = 1000;
+
 // ── Public API ──
 
 // Initialize BLE SoftDevice, configure advertising, and start advertising.
 // Call once from setup() after Serial.begin().
 // Logs initialization progress and any errors to Serial.
 void ble_init();
+
+// Returns true if a central device is currently connected.
+bool ble_isConnected();
+
+// Returns the effective MTU negotiated with the connected central.
+// Returns BLE_DEFAULT_MTU (23) if no connection is active or MTU
+// has not been negotiated yet.
+uint16_t ble_getEffectiveMtu();
+
+// Returns the maximum chunk payload size for session sync transfers.
+// Calculated as: effective_mtu - ATT_HEADER_SIZE - CHUNK_HEADER_SIZE.
+// See ADR-013: chunk_payload_size = mtu - 3 - 4.
+uint16_t ble_getChunkPayloadSize();
 
 #endif // POMOFOCUS_BLE_MANAGER_H


### PR DESCRIPTION
## Summary

- Implements BLE connection lifecycle management for the nRF52840 firmware: connect/disconnect callbacks, connection handle tracking, and automatic advertising resume on disconnect
- Adds MTU negotiation (device supports up to 247 bytes) with effective MTU storage and chunk payload size calculation (`mtu - 3 ATT - 4 chunk header`)
- Provides `getEffectiveMtu()` and `getChunkPayloadSize()` accessors for session sync throughput optimization

Closes #244

## Test Plan

- [ ] `pio run` compiles cleanly
- [ ] nRF Connect: observe MTU negotiation on connect
- [ ] nRF Connect: verify disconnect resumes advertising
- [ ] Leave connected 10+ minutes idle — connection stays alive
- [ ] Verify `getEffectiveMtu()` returns negotiated value
- [ ] Verify `getChunkPayloadSize()` returns `mtu - 7`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)