### PR TITLE
feat: outbox queue management FIFO with flash backing

### DIFF
--- a/firmware/device/platformio.ini
+++ b/firmware/device/platformio.ini
@@ -8,6 +8,9 @@
 ; variant since the PlatformIO registry BSP predates XIAO support.
 ; Pin mapping differences are handled in firmware code.
 
+[platformio]
+default_envs = seeed_xiao_nrf52840
+
 [env:seeed_xiao_nrf52840]
 platform = nordicnrf52
 board = seeed_xiao_nrf52840
@@ -44,6 +47,8 @@ monitor_speed = 115200
 ; ── Native test environment ──
 ; Runs unit tests on the host machine (no MCU required).
 ; Usage: pio test -e native
+; Note: default_envs above excludes this from `pio run` since it requires
+; test files (test/) to provide main(). Use `pio test -e native` instead.
 [env:native]
 platform = native
 test_framework = unity

--- a/firmware/device/src/ble_manager.cpp
+++ b/firmware/device/src/ble_manager.cpp
@@ -26,6 +26,7 @@
 #include "ble_manager.h"
 #include "ble_services.h"
 #include "display.h"
+#include "outbox.h"
 
 #include <bluefruit.h>
 
@@ -139,6 +140,11 @@ static void onDisconnect(uint16_t connHandle, uint8_t reason) {
     s_connHandle = BLE_CONN_HANDLE_INVALID;
     s_connected = false;
     s_effectiveMtu = BLE_DEFAULT_MTU;
+
+    // Clean up any in-flight BLE transfer so stale state doesn't persist
+    // across reconnections. Without this, the poll loop would keep trying
+    // to notify a disconnected client.
+    Outbox::transferAbort();
 
     Serial.print("[ble] disconnected: handle=");
     Serial.print(connHandle);

--- a/firmware/device/src/ble_services.cpp
+++ b/firmware/device/src/ble_services.cpp
@@ -26,12 +26,14 @@
 
 #include "ble_services.h"
 #include "ble_manager.h"
+#include "outbox.h"
 #include "timer.h"
 #include "display.h"
 
 #include <bluefruit.h>
 #include <pb_encode.h>
 #include <pb_decode.h>
+#include <cstring>
 #include "pomofocus.pb.h"
 
 // ── Static encode buffers ──
@@ -319,9 +321,15 @@ static void updateSelectedGoalValue() {
 // Session Sync Service helpers
 // ══════════════════════════════════════════════════════════════════════
 
+// ── Session Sync transfer state ──
+// Chunk buffer for BLE notifications. Max = MTU - ATT header = 244 bytes.
+static uint8_t s_chunkBuf[BLE_MAX_MTU - ATT_HEADER_SIZE];
+static bool s_chunkPendingRetry = false;
+static uint16_t s_pendingChunkLen = 0;
+
 // ── Sync Control write callback ──
 // Called when the phone writes a SyncControl Protobuf to characteristic 0303.
-// Decodes the command and logs it. Full command handling deferred to 7A.7.
+// Dispatches START/ACK/NACK/ABORT/CURSOR_UPDATE to the outbox transfer API.
 
 static void onSyncControlWrite(uint16_t connHandle, BLECharacteristic* chr,
                                uint8_t* data, uint16_t len) {
@@ -337,10 +345,69 @@ static void onSyncControlWrite(uint16_t connHandle, BLECharacteristic* chr,
         return;
     }
 
-    Serial.print("[sync] control cmd=");
+    Serial.print("[sync] cmd=");
     Serial.print(static_cast<int>(ctrl.command));
     Serial.print(" ack_count=");
     Serial.println(ctrl.ack_count);
+
+    switch (ctrl.command) {
+        case pomofocus_ble_SyncCommand_SYNC_COMMAND_START: {
+            s_chunkPendingRetry = false;
+            uint16_t chunkPayload = ble_getChunkPayloadSize();
+            uint32_t count = Outbox::transferStart(chunkPayload);
+            if (count > 0) {
+                ble_services_update_sync_status(
+                    count, Outbox::getRecordCount(),
+                    static_cast<uint8_t>(
+                        pomofocus_ble_SyncState_SYNC_STATE_TRANSFERRING));
+            } else {
+                ble_services_update_sync_status(
+                    0, Outbox::getRecordCount(),
+                    static_cast<uint8_t>(
+                        pomofocus_ble_SyncState_SYNC_STATE_IDLE));
+            }
+            break;
+        }
+
+        case pomofocus_ble_SyncCommand_SYNC_COMMAND_ACK:
+            Outbox::transferAck(ctrl.ack_count);
+            ble_services_update_sync_status(
+                Outbox::getPendingCount(), Outbox::getRecordCount(),
+                static_cast<uint8_t>(
+                    pomofocus_ble_SyncState_SYNC_STATE_COMPLETE));
+            break;
+
+        case pomofocus_ble_SyncCommand_SYNC_COMMAND_NACK:
+            s_chunkPendingRetry = false;
+            Outbox::transferNack(ctrl.ack_count);
+            ble_services_update_sync_status(
+                Outbox::getPendingCount(), Outbox::getRecordCount(),
+                static_cast<uint8_t>(
+                    pomofocus_ble_SyncState_SYNC_STATE_TRANSFERRING));
+            break;
+
+        case pomofocus_ble_SyncCommand_SYNC_COMMAND_ABORT:
+            s_chunkPendingRetry = false;
+            Outbox::transferAbort();
+            ble_services_update_sync_status(
+                Outbox::getPendingCount(), Outbox::getRecordCount(),
+                static_cast<uint8_t>(
+                    pomofocus_ble_SyncState_SYNC_STATE_IDLE));
+            break;
+
+        case pomofocus_ble_SyncCommand_SYNC_COMMAND_CURSOR_UPDATE:
+            Outbox::transferCursorUpdate(ctrl.ack_count);
+            ble_services_update_sync_status(
+                Outbox::getPendingCount(), Outbox::getRecordCount(),
+                static_cast<uint8_t>(
+                    pomofocus_ble_SyncState_SYNC_STATE_IDLE));
+            break;
+
+        default:
+            Serial.print("[sync] unknown cmd: ");
+            Serial.println(static_cast<int>(ctrl.command));
+            break;
+    }
 }
 
 // ══════════════════════════════════════════════════════════════════════
@@ -437,11 +504,11 @@ void ble_services_init() {
       static_cast<uint8_t>(pomofocus_ble_SyncState_SYNC_STATE_IDLE));
 
   // Session Data (0302): Notify only.
-  // Device sends session records to phone during bulk transfer.
-  // No read property — data is streamed via notifications only.
+  // Device streams chunked session data to phone via notifications.
+  // Max notification payload = MTU - ATT header = 244 bytes.
   s_sessionDataChar.setProperties(CHR_PROPS_NOTIFY);
   s_sessionDataChar.setPermission(SECMODE_ENC_NO_MITM, SECMODE_NO_ACCESS);
-  s_sessionDataChar.setMaxLen(pomofocus_ble_SessionRecord_size);
+  s_sessionDataChar.setMaxLen(BLE_MAX_MTU - ATT_HEADER_SIZE);
   s_sessionDataChar.begin();
 
   // Sync Control (0303): Write.
@@ -544,4 +611,43 @@ bool goal_service_goals_dirty() {
     bool dirty = s_goalsDirty;
     s_goalsDirty = false;
     return dirty;
+}
+
+// ── Chunked transfer polling ──
+
+void ble_services_poll_transfer() {
+    if (!Outbox::transferIsActive() || Outbox::transferIsAwaitingAck()) {
+        return;
+    }
+
+    uint16_t chunkLen;
+
+    if (s_chunkPendingRetry) {
+        // Retry the chunk that failed to send last time.
+        chunkLen = s_pendingChunkLen;
+    } else {
+        chunkLen = Outbox::transferNextChunk(s_chunkBuf, sizeof(s_chunkBuf));
+        if (chunkLen == 0) {
+            return;
+        }
+    }
+
+    // Send chunk via Session Data (0302) notification.
+    uint16_t sent = s_sessionDataChar.notify(s_chunkBuf, chunkLen);
+    if (sent == 0) {
+        // TX buffer full — save for retry on next poll.
+        s_chunkPendingRetry = true;
+        s_pendingChunkLen = chunkLen;
+        return;
+    }
+
+    s_chunkPendingRetry = false;
+
+    // If all chunks sent, update sync status to COMPLETE.
+    if (Outbox::transferIsAwaitingAck()) {
+        ble_services_update_sync_status(
+            Outbox::getPendingCount(), Outbox::getRecordCount(),
+            static_cast<uint8_t>(
+                pomofocus_ble_SyncState_SYNC_STATE_COMPLETE));
+    }
 }

--- a/firmware/device/src/ble_services.h
+++ b/firmware/device/src/ble_services.h
@@ -88,4 +88,9 @@ void goal_service_set_selected(uint8_t index);
 // when in GOAL_SELECT mode without the BLE callback controlling the display.
 bool goal_service_goals_dirty();
 
+// Poll the chunked transfer state machine. If a transfer is active,
+// prepares and sends the next chunk via Session Data (0302) notification.
+// Call once per loop() iteration. Safe to call when no transfer is active.
+void ble_services_poll_transfer();
+
 #endif // POMOFOCUS_BLE_SERVICES_H

--- a/firmware/device/src/main.cpp
+++ b/firmware/device/src/main.cpp
@@ -5,6 +5,8 @@
 #include <Arduino.h>
 #include "ble_manager.h"
 #include "ble_services.h"
+#include "flash_storage.h"
+#include "outbox.h"
 #include "display.h"
 #include "input.h"
 #include "timer.h"
@@ -236,6 +238,10 @@ void setup() {
   // Register BLE timer command handler — receives events from phone.
   ble_set_timer_command_callback(onBleTimerCommand);
 
+  // Initialize flash storage and session outbox (for BLE session sync).
+  FlashStorage::init();
+  Outbox::init();
+
   // Initialize e-ink display and show idle screen.
   Display::init();
 
@@ -277,6 +283,9 @@ void loop() {
       }
     }
   }
+
+  // Poll BLE chunked transfer — sends next chunk if transfer is active.
+  ble_services_poll_transfer();
 
   // Check if the goal list was updated via BLE. Mark display dirty so
   // refreshDisplay() re-renders (it decides WHAT to show based on g_screenMode).

--- a/firmware/device/src/outbox.cpp
+++ b/firmware/device/src/outbox.cpp
@@ -69,6 +69,55 @@ uint8_t g_decodeBuffer[Outbox::ENCODE_BUFFER_SIZE];
 // Current metadata entry index within the metadata page.
 uint32_t g_metaEntryIndex = 0;
 
+// ── Transfer state (chunked bulk transfer, ADR-013) ──
+
+enum class TransferPhase : uint8_t {
+    IDLE,          // No active transfer
+    SENDING,       // Streaming chunks to phone
+    AWAITING_ACK,  // All chunks sent, waiting for phone ACK
+};
+
+TransferPhase g_transferPhase = TransferPhase::IDLE;
+uint16_t g_chunkPayloadSize = 0;      // Max Protobuf bytes per chunk
+uint32_t g_totalToTransfer = 0;       // Sessions to transfer this batch
+uint32_t g_transferSessionIdx = 0;    // 0-based session within transfer
+uint32_t g_chunkIdx = 0;              // 0-based chunk within current session
+uint32_t g_totalChunks = 0;           // Total chunks for current session
+uint32_t g_currentEncodedSize = 0;    // Encoded bytes of current session
+uint32_t g_currentReadOffset = 0;     // Flash offset of current session
+
+// Load the session at g_transferSessionIdx from flash into g_decodeBuffer.
+// Sets g_currentEncodedSize, g_totalChunks, g_chunkIdx.
+// Returns true on success.
+bool loadTransferSession() {
+    uint32_t outLen = 0;
+    FlashStorage::FlashResult result =
+        FlashStorage::readRecord(g_currentReadOffset, g_decodeBuffer,
+                                 sizeof(g_decodeBuffer), outLen);
+    if (result != FlashStorage::FlashResult::OK) {
+        Serial.print("[outbox] transfer read failed at offset ");
+        Serial.println(g_currentReadOffset);
+        return false;
+    }
+
+    g_currentEncodedSize = outLen;
+    g_totalChunks = (outLen + g_chunkPayloadSize - 1) / g_chunkPayloadSize;
+    if (g_totalChunks == 0) {
+        g_totalChunks = 1;
+    }
+    g_chunkIdx = 0;
+
+    Serial.print("[outbox] loaded session ");
+    Serial.print(g_transferSessionIdx);
+    Serial.print(": ");
+    Serial.print(outLen);
+    Serial.print("B, ");
+    Serial.print(g_totalChunks);
+    Serial.println(" chunks");
+
+    return true;
+}
+
 // ── Metadata checksum ──
 
 uint32_t computeChecksum(const MetaEntry& entry) {
@@ -637,6 +686,184 @@ uint32_t getCapacityRemaining() {
 
 QueueMeta getQueueMeta() {
     return g_meta;
+}
+
+// ── Chunked transfer protocol ──
+
+uint32_t transferStart(uint16_t chunkPayloadSize) {
+    if (chunkPayloadSize == 0) {
+        return 0;
+    }
+
+    uint32_t pending = getPendingCount();
+    if (pending == 0) {
+        return 0;
+    }
+
+    g_chunkPayloadSize = chunkPayloadSize;
+    g_totalToTransfer = pending;
+    g_transferSessionIdx = 0;
+
+    // Walk to the first pending session (skip synced records).
+    g_currentReadOffset = walkToRecord(g_meta.head, g_meta.syncedCount);
+
+    if (!loadTransferSession()) {
+        return 0;
+    }
+
+    g_transferPhase = TransferPhase::SENDING;
+
+    Serial.print("[outbox] transfer started: ");
+    Serial.print(pending);
+    Serial.println(" sessions");
+
+    return pending;
+}
+
+uint16_t transferNextChunk(uint8_t* buf, uint16_t bufSize) {
+    if (g_transferPhase != TransferPhase::SENDING) {
+        return 0;
+    }
+
+    constexpr uint16_t HDR_SIZE = 4;
+    if (bufSize < HDR_SIZE + 1) {
+        return 0;
+    }
+
+    // Build 4-byte chunk header: SeqNum, Total, Flags, Reserved.
+    uint8_t flags = 0;
+    if (g_chunkIdx == 0) {
+        flags |= CHUNK_FLAG_FIRST;
+    }
+    bool lastChunk = (g_chunkIdx == g_totalChunks - 1);
+    if (lastChunk) {
+        flags |= CHUNK_FLAG_LAST;
+    }
+    bool lastSession = (g_transferSessionIdx == g_totalToTransfer - 1);
+    if (lastChunk && lastSession) {
+        flags |= CHUNK_FLAG_FINAL;
+    }
+
+    buf[0] = static_cast<uint8_t>(g_chunkIdx);    // SeqNum
+    buf[1] = static_cast<uint8_t>(g_totalChunks);  // Total
+    buf[2] = flags;
+    buf[3] = 0x00;                                  // Reserved
+
+    // Copy payload slice from the encoded session in g_decodeBuffer.
+    uint32_t payloadOffset = g_chunkIdx * g_chunkPayloadSize;
+    uint32_t remaining = g_currentEncodedSize - payloadOffset;
+    uint16_t payloadLen = (remaining < g_chunkPayloadSize)
+                          ? static_cast<uint16_t>(remaining)
+                          : g_chunkPayloadSize;
+
+    if (HDR_SIZE + payloadLen > bufSize) {
+        payloadLen = bufSize - HDR_SIZE;
+    }
+
+    memcpy(buf + HDR_SIZE, g_decodeBuffer + payloadOffset, payloadLen);
+
+    uint16_t totalLen = HDR_SIZE + payloadLen;
+
+    // Advance state.
+    g_chunkIdx++;
+    if (g_chunkIdx >= g_totalChunks) {
+        // Current session fully chunked — move to next.
+        g_transferSessionIdx++;
+        if (g_transferSessionIdx >= g_totalToTransfer) {
+            g_transferPhase = TransferPhase::AWAITING_ACK;
+            Serial.println("[outbox] all chunks sent, awaiting ACK");
+        } else {
+            // Advance flash read offset to next record.
+            uint32_t recSize = recordSizeAt(g_currentReadOffset);
+            g_currentReadOffset += recSize;
+            if (g_currentReadOffset >= DATA_REGION_SIZE) {
+                g_currentReadOffset = 0;
+            }
+
+            if (!loadTransferSession()) {
+                g_transferPhase = TransferPhase::IDLE;
+                return 0;
+            }
+        }
+    }
+
+    return totalLen;
+}
+
+void transferAck(uint32_t ackCount) {
+    (void)ackCount;
+    g_transferPhase = TransferPhase::IDLE;
+
+    Serial.print("[outbox] ACK ");
+    Serial.print(ackCount);
+    Serial.println(" sessions");
+}
+
+void transferNack(uint32_t position) {
+    if (g_transferPhase != TransferPhase::SENDING &&
+        g_transferPhase != TransferPhase::AWAITING_ACK) {
+        Serial.println("[outbox] NACK ignored: no active transfer");
+        return;
+    }
+
+    if (position >= g_totalToTransfer) {
+        position = 0;
+    }
+
+    g_transferSessionIdx = position;
+    g_currentReadOffset =
+        walkToRecord(g_meta.head, g_meta.syncedCount + position);
+
+    if (!loadTransferSession()) {
+        g_transferPhase = TransferPhase::IDLE;
+        return;
+    }
+
+    g_transferPhase = TransferPhase::SENDING;
+
+    Serial.print("[outbox] NACK: retransmit from session ");
+    Serial.println(position);
+}
+
+void transferAbort() {
+    g_transferPhase = TransferPhase::IDLE;
+    Serial.println("[outbox] transfer aborted");
+}
+
+void transferCursorUpdate(uint32_t count) {
+    if (g_transferPhase == TransferPhase::IDLE) {
+        Serial.println("[outbox] cursor update ignored: no active transfer");
+        return;
+    }
+
+    uint32_t pending = getPendingCount();
+    if (count > pending) {
+        Serial.print("[outbox] cursor update clamped from ");
+        Serial.print(count);
+        Serial.print(" to ");
+        Serial.println(pending);
+        count = pending;
+    }
+
+    for (uint32_t i = 0; i < count; i++) {
+        if (getPendingCount() == 0) {
+            break;
+        }
+        markSynced();
+    }
+    g_transferPhase = TransferPhase::IDLE;
+
+    Serial.print("[outbox] cursor update: ");
+    Serial.print(count);
+    Serial.println(" sessions permanently synced");
+}
+
+bool transferIsActive() {
+    return g_transferPhase != TransferPhase::IDLE;
+}
+
+bool transferIsAwaitingAck() {
+    return g_transferPhase == TransferPhase::AWAITING_ACK;
 }
 
 } // namespace Outbox

--- a/firmware/device/src/outbox.h
+++ b/firmware/device/src/outbox.h
@@ -116,6 +116,48 @@ uint32_t getCapacityRemaining();
 // Return a copy of the current queue metadata (for BLE sync status).
 QueueMeta getQueueMeta();
 
+// ── Chunked transfer protocol (ADR-013) ──
+// Bulk transfer of pending sessions to phone via BLE notifications.
+// Phone controls the flow: START initiates, ACK confirms receipt,
+// NACK requests retransmission, ABORT cancels, CURSOR_UPDATE marks synced.
+// Each chunk has a 4-byte header: SeqNum(1) Total(1) Flags(1) Reserved(1).
+
+// Chunk header flag bits.
+constexpr uint8_t CHUNK_FLAG_FIRST = 0x01; // Bit 0: first chunk of session
+constexpr uint8_t CHUNK_FLAG_LAST  = 0x02; // Bit 1: last chunk of session
+constexpr uint8_t CHUNK_FLAG_FINAL = 0x04; // Bit 2: last session in batch
+
+// Begin bulk transfer of all pending sessions.
+// chunkPayloadSize: max Protobuf payload per chunk (effective_mtu - 3 - 4).
+// Returns the number of sessions to transfer, or 0 if none pending.
+uint32_t transferStart(uint16_t chunkPayloadSize);
+
+// Prepare the next chunk for BLE transmission.
+// Writes 4-byte chunk header + payload into buf.
+// bufSize: available bytes in buf (must be >= 4 + chunkPayloadSize).
+// Returns total bytes written (header + payload), or 0 if transfer done.
+uint16_t transferNextChunk(uint8_t* buf, uint16_t bufSize);
+
+// Phone acknowledged receipt of ackCount sessions.
+// Does not modify flash — sessions remain pending until CURSOR_UPDATE.
+void transferAck(uint32_t ackCount);
+
+// Phone requests retransmission starting from session index position.
+void transferNack(uint32_t position);
+
+// Cancel the current transfer. Resets to idle.
+void transferAbort();
+
+// Permanently mark count sessions as synced in flash.
+// Called when the phone has uploaded sessions to the cloud.
+void transferCursorUpdate(uint32_t count);
+
+// Returns true if a bulk transfer is in progress (sending or awaiting ACK).
+bool transferIsActive();
+
+// Returns true if all chunks have been sent and device awaits phone ACK.
+bool transferIsAwaitingAck();
+
 } // namespace Outbox
 
 #endif // POMOFOCUS_OUTBOX_H


### PR DESCRIPTION
## Summary

- Implements a FIFO queue with circular buffer semantics on top of the existing flash storage layer for session outbox management on the nRF52840 device
- Queue metadata (head, tail, count, synced count) is persisted in a dedicated metadata flash page using log-structured entries with magic number and XOR checksum validation
- New APIs: `getPendingCount`, `getNextPending` (reads + decodes Protobuf), `markSynced` (advances sync cursor), `getCapacityRemaining`, `getQueueMeta`
- Synced pages are reclaimed on demand when space runs out; metadata survives power cycles via flash persistence with scan-based fallback

## Test plan

- [ ] `pio run` compiles successfully
- [ ] Manual: store 3 sessions, verify count, mark synced, power cycle, verify persistence

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)