### PR TITLE
feat: GET /v1/analytics/glanceable Tier 1 endpoint (#407)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@hono/zod-openapi": "^0.19.6",
+    "@pomofocus/analytics": "workspace:*",
+    "@pomofocus/core": "workspace:*",
     "@pomofocus/types": "workspace:*",
     "@supabase/supabase-js": "^2.49.8",
     "hono": "^4.7.11",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import { errorHandler } from './middleware/error-handler.js';
 import { registerHealthRoute } from './routes/health.js';
 import { registerMeRoute } from './routes/me.js';
 import { registerSessionsRoute } from './routes/sessions.js';
+import { registerAnalyticsRoute } from './routes/analytics.js';
 import type { AppEnv } from './types.js';
 
 const app = new OpenAPIHono<AppEnv>({
@@ -25,6 +26,7 @@ app.use('/v1/*', authMiddleware);
 registerHealthRoute(app);
 registerMeRoute(app);
 registerSessionsRoute(app);
+registerAnalyticsRoute(app);
 
 app.doc('/openapi.json', {
   openapi: '3.1.0',

--- a/apps/api/src/routes/analytics.test.ts
+++ b/apps/api/src/routes/analytics.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { authMiddleware } from '../middleware/auth.js';
+import type { AuthVariables } from '../middleware/auth.js';
+import type { SupabaseEnv } from '../lib/supabase.js';
+import { registerAnalyticsRoute, GlanceableResponseSchema } from './analytics.js';
+
+/**
+ * Mock the Supabase client factory so no real network calls are made.
+ */
+const { mockCreateUserClient, mockGetUser } = vi.hoisted(() => ({
+  mockCreateUserClient: vi.fn(),
+  mockGetUser: vi.fn(),
+}));
+
+vi.mock('../lib/supabase.js', () => ({
+  createUserClient: mockCreateUserClient,
+}));
+
+/**
+ * Mock tierOneMetrics so we test the route wiring, not the analytics computation.
+ * Analytics functions are thoroughly tested in packages/analytics/.
+ */
+const { mockTierOneMetrics } = vi.hoisted(() => ({
+  mockTierOneMetrics: vi.fn(),
+}));
+
+vi.mock('@pomofocus/analytics', () => ({
+  tierOneMetrics: mockTierOneMetrics,
+}));
+
+const FAKE_ENV: SupabaseEnv = {
+  SUPABASE_URL: 'https://fake.supabase.co',
+  SUPABASE_ANON_KEY: 'fake-anon-key',
+  SUPABASE_SERVICE_ROLE_KEY: 'fake-service-role-key',
+};
+
+const FAKE_JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTEyMyJ9.fake';
+
+const FAKE_USER_ID = 'aaaa1111-0000-0000-0000-000000000001';
+
+const FAKE_USER = {
+  id: FAKE_USER_ID,
+  email: 'alice@example.com',
+  created_at: '2026-03-01T00:00:00.000Z',
+};
+
+const FAKE_TIER_ONE_RESULT = {
+  goalProgress: [
+    { goalId: 'goal-1', goalTitle: 'Study', completedToday: 2, targetToday: 3 },
+  ],
+  weeklyDots: [true, true, false, true, false, false, false] as [boolean, boolean, boolean, boolean, boolean, boolean, boolean],
+  currentStreak: 4,
+};
+
+const FAKE_SESSION_ROW = {
+  id: '11111111-1111-1111-1111-111111111111',
+  user_id: FAKE_USER_ID,
+  process_goal_id: 'eeee0001-0000-0000-0000-000000000001',
+  intention_text: null,
+  started_at: '2026-03-17T10:00:00.000Z',
+  ended_at: '2026-03-17T10:25:00.000Z',
+  completed: true,
+  abandonment_reason: null,
+  focus_quality: null,
+  distraction_type: null,
+  device_id: null,
+  created_at: '2026-03-17T10:25:01.000Z',
+};
+
+const FAKE_GOAL_ROW = {
+  id: 'eeee0001-0000-0000-0000-000000000001',
+  long_term_goal_id: 'dddd0001-0000-0000-0000-000000000001',
+  user_id: FAKE_USER_ID,
+  title: 'Study',
+  target_sessions_per_day: 3,
+  recurrence: 'daily',
+  status: 'active',
+  sort_order: 0,
+  created_at: '2026-03-01T00:00:00.000Z',
+  updated_at: '2026-03-01T00:00:00.000Z',
+};
+
+function authHeaders(): Record<string, string> {
+  return { Authorization: `Bearer ${FAKE_JWT}` };
+}
+
+function createTestApp(): OpenAPIHono<{ Bindings: SupabaseEnv; Variables: AuthVariables }> {
+  const app = new OpenAPIHono<{ Bindings: SupabaseEnv; Variables: AuthVariables }>({
+    defaultHook: (result, c) => {
+      if (!result.success) {
+        return c.json(
+          { error: 'Validation failed', details: result.error.flatten() },
+          422,
+        );
+      }
+    },
+  });
+  app.use('/v1/*', authMiddleware);
+  registerAnalyticsRoute(app);
+  return app;
+}
+
+/**
+ * Builds a mock Supabase client with configurable query results.
+ *
+ * Each table (user_preferences, sessions, process_goals) gets its own
+ * chainable query mock matching the Supabase SDK pattern.
+ */
+function createMockSupabase(overrides: {
+  prefs?: { data: unknown; error: unknown };
+  sessions?: { data: unknown; error: unknown };
+  goals?: { data: unknown; error: unknown };
+} = {}): unknown {
+  const defaultPrefs = { data: { timezone: 'America/New_York' }, error: null };
+  const defaultSessions = { data: [FAKE_SESSION_ROW], error: null };
+  const defaultGoals = { data: [FAKE_GOAL_ROW], error: null };
+
+  const prefs = overrides.prefs ?? defaultPrefs;
+  const sessions = overrides.sessions ?? defaultSessions;
+  const goals = overrides.goals ?? defaultGoals;
+
+  return {
+    auth: { getUser: mockGetUser },
+    from: vi.fn((table: string) => {
+      if (table === 'user_preferences') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue(prefs),
+            })),
+          })),
+        };
+      }
+      if (table === 'sessions') {
+        return {
+          select: vi.fn(() => ({
+            order: vi.fn().mockResolvedValue(sessions),
+          })),
+        };
+      }
+      if (table === 'process_goals') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue(goals),
+          })),
+        };
+      }
+      return {};
+    }),
+  };
+}
+
+describe('GET /v1/analytics/glanceable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    mockGetUser.mockResolvedValue({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    mockTierOneMetrics.mockReturnValue(FAKE_TIER_ONE_RESULT);
+    mockCreateUserClient.mockReturnValue(createMockSupabase());
+  });
+
+  it('returns 401 without authorization header', async () => {
+    const app = createTestApp();
+    const res = await app.request('/v1/analytics/glanceable', { method: 'GET' }, FAKE_ENV);
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with glanceable analytics for authenticated user', async () => {
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/analytics/glanceable',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = GlanceableResponseSchema.parse(await res.json());
+    expect(body.goalProgress).toHaveLength(1);
+    expect(body.goalProgress[0]?.goalTitle).toBe('Study');
+    expect(body.weeklyDots).toHaveLength(7);
+    expect(body.currentStreak).toBe(4);
+  });
+
+  it('calls tierOneMetrics with converted session and goal data', async () => {
+    const app = createTestApp();
+    await app.request(
+      '/v1/analytics/glanceable',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
+
+    expect(mockTierOneMetrics).toHaveBeenCalledTimes(1);
+
+    const [sessions, goals, timezone] = mockTierOneMetrics.mock.calls[0] as [unknown[], unknown[], string, number];
+
+    // Sessions should be transformed to camelCase SessionData
+    expect(sessions).toHaveLength(1);
+    expect((sessions[0] as Record<string, unknown>).startedAt).toBe(FAKE_SESSION_ROW.started_at);
+    expect((sessions[0] as Record<string, unknown>).processGoalId).toBe(FAKE_SESSION_ROW.process_goal_id);
+
+    // Goals should be transformed to camelCase ProcessGoal
+    expect(goals).toHaveLength(1);
+    expect((goals[0] as Record<string, unknown>).targetSessionsPerDay).toBe(FAKE_GOAL_ROW.target_sessions_per_day);
+
+    // Timezone from user preferences
+    expect(timezone).toBe('America/New_York');
+  });
+
+  it('defaults timezone to UTC when no user preferences exist', async () => {
+    mockCreateUserClient.mockReturnValue(
+      createMockSupabase({ prefs: { data: null, error: null } }),
+    );
+
+    const app = createTestApp();
+    await app.request(
+      '/v1/analytics/glanceable',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
+
+    const [, , timezone] = mockTierOneMetrics.mock.calls[0] as [unknown, unknown, string, number];
+    expect(timezone).toBe('UTC');
+  });
+
+  it('returns valid response with no sessions and no goals', async () => {
+    const emptyResult = {
+      goalProgress: [],
+      weeklyDots: [false, false, false, false, false, false, false] as [boolean, boolean, boolean, boolean, boolean, boolean, boolean],
+      currentStreak: 0,
+    };
+    mockTierOneMetrics.mockReturnValue(emptyResult);
+    mockCreateUserClient.mockReturnValue(
+      createMockSupabase({
+        sessions: { data: [], error: null },
+        goals: { data: [], error: null },
+      }),
+    );
+
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/analytics/glanceable',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = GlanceableResponseSchema.parse(await res.json());
+    expect(body.goalProgress).toEqual([]);
+    expect(body.weeklyDots).toEqual([false, false, false, false, false, false, false]);
+    expect(body.currentStreak).toBe(0);
+  });
+
+  it('returns 500 when sessions query fails', async () => {
+    mockCreateUserClient.mockReturnValue(
+      createMockSupabase({
+        sessions: { data: null, error: new Error('sessions query failed') },
+      }),
+    );
+
+    const app = createTestApp();
+    app.onError((_err, c) => {
+      return c.json({ error: 'Internal server error', status: 500 }, 500);
+    });
+
+    const res = await app.request(
+      '/v1/analytics/glanceable',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 500 when goals query fails', async () => {
+    mockCreateUserClient.mockReturnValue(
+      createMockSupabase({
+        goals: { data: null, error: new Error('goals query failed') },
+      }),
+    );
+
+    const app = createTestApp();
+    app.onError((_err, c) => {
+      return c.json({ error: 'Internal server error', status: 500 }, 500);
+    });
+
+    const res = await app.request(
+      '/v1/analytics/glanceable',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 500 when user preferences query fails', async () => {
+    mockCreateUserClient.mockReturnValue(
+      createMockSupabase({
+        prefs: { data: null, error: new Error('prefs query failed') },
+      }),
+    );
+
+    const app = createTestApp();
+    app.onError((_err, c) => {
+      return c.json({ error: 'Internal server error', status: 500 }, 500);
+    });
+
+    const res = await app.request(
+      '/v1/analytics/glanceable',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(500);
+  });
+
+  it('returns correct content-type header', async () => {
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/analytics/glanceable',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
+
+    expect(res.headers.get('content-type')).toContain('application/json');
+  });
+
+  it('response validates against GlanceableResponseSchema', async () => {
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/analytics/glanceable',
+      { method: 'GET', headers: authHeaders() },
+      FAKE_ENV,
+    );
+
+    const body = await res.json();
+    const parsed = GlanceableResponseSchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -1,0 +1,169 @@
+import { createRoute, z } from '@hono/zod-openapi';
+import type { OpenAPIHono } from '@hono/zod-openapi';
+import { tierOneMetrics } from '@pomofocus/analytics';
+import type { SessionData } from '@pomofocus/core';
+import type { ProcessGoal } from '@pomofocus/core';
+import type { Session, ProcessGoal as DBProcessGoal } from '@pomofocus/types';
+import type { AppEnv } from '../types.js';
+
+/**
+ * Zod schema for a single goal progress entry.
+ */
+export const GoalProgressSchema = z.object({
+  goalId: z.string(),
+  goalTitle: z.string(),
+  completedToday: z.number(),
+  targetToday: z.number(),
+});
+
+/**
+ * Zod schema for the GET /v1/analytics/glanceable response.
+ * Matches TierOneResult from @pomofocus/analytics.
+ */
+export const GlanceableResponseSchema = z.object({
+  goalProgress: z.array(GoalProgressSchema),
+  weeklyDots: z.tuple([
+    z.boolean(),
+    z.boolean(),
+    z.boolean(),
+    z.boolean(),
+    z.boolean(),
+    z.boolean(),
+    z.boolean(),
+  ]),
+  currentStreak: z.number(),
+});
+
+/**
+ * OpenAPI route definition for GET /v1/analytics/glanceable.
+ */
+export const glanceableRoute = createRoute({
+  method: 'get',
+  path: '/v1/analytics/glanceable',
+  security: [{ Bearer: [] }],
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: GlanceableResponseSchema,
+        },
+      },
+      description: 'Tier 1 glanceable analytics: goal progress, weekly dots, streak',
+    },
+    401: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: z.string(),
+            status: z.number(),
+          }),
+        },
+      },
+      description: 'Missing or invalid authorization token',
+    },
+  },
+});
+
+/**
+ * Converts a Supabase session row (snake_case) to the domain SessionData type (camelCase).
+ */
+function toSessionData(row: Session): SessionData {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    processGoalId: row.process_goal_id,
+    intentionText: row.intention_text,
+    startedAt: row.started_at,
+    endedAt: row.ended_at,
+    completed: row.completed,
+    abandonmentReason: row.abandonment_reason,
+    deviceId: row.device_id,
+  };
+}
+
+/**
+ * Converts a Supabase process_goals row (snake_case) to the domain ProcessGoal type (camelCase).
+ */
+function toProcessGoal(row: DBProcessGoal): ProcessGoal {
+  return {
+    id: row.id,
+    longTermGoalId: row.long_term_goal_id,
+    userId: row.user_id,
+    title: row.title,
+    targetSessionsPerDay: row.target_sessions_per_day,
+    recurrence: row.recurrence,
+    status: row.status,
+    sortOrder: row.sort_order,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * Registers the GET /v1/analytics/glanceable route on the given OpenAPIHono app.
+ *
+ * Queries the user's sessions, process goals, and timezone preference via the
+ * user-scoped Supabase client, then delegates to tierOneMetrics() from
+ * @pomofocus/analytics for pure computation. RLS scopes all queries to the
+ * authenticated user.
+ */
+export function registerAnalyticsRoute(app: OpenAPIHono<AppEnv>): void {
+  app.openapi(glanceableRoute, async (c) => {
+    const supabase = c.get('supabase');
+
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError) {
+      throw userError;
+    }
+
+    const userId = userData.user.id;
+
+    // Fetch user timezone (defaults to UTC if no preference row exists)
+    const { data: prefs, error: prefsError } = await supabase
+      .from('user_preferences')
+      .select('timezone')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (prefsError) {
+      throw prefsError;
+    }
+
+    const timezone = prefs?.timezone ?? 'UTC';
+
+    // Fetch all user sessions (RLS scopes to current user)
+    const { data: sessionRows, error: sessionsError } = await supabase
+      .from('sessions')
+      .select('*')
+      .order('started_at', { ascending: false });
+
+    if (sessionsError) {
+      throw sessionsError;
+    }
+
+    // Fetch active process goals (RLS scopes to current user)
+    const { data: goalRows, error: goalsError } = await supabase
+      .from('process_goals')
+      .select('*')
+      .eq('status', 'active');
+
+    if (goalsError) {
+      throw goalsError;
+    }
+
+    const sessions = sessionRows.map(toSessionData);
+    const goals = goalRows.map(toProcessGoal);
+    const now = Date.now();
+
+    const result = tierOneMetrics(sessions, goals, timezone, now);
+
+    return c.json(
+      {
+        goalProgress: result.goalProgress.map((g) => ({ ...g })),
+        weeklyDots: [...result.weeklyDots],
+        currentStreak: result.currentStreak,
+      },
+      200,
+    );
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,12 @@ importers:
       '@hono/zod-openapi':
         specifier: ^0.19.6
         version: 0.19.10(hono@4.12.7)(zod@3.25.76)
+      '@pomofocus/analytics':
+        specifier: workspace:*
+        version: link:../../packages/analytics
+      '@pomofocus/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@pomofocus/types':
         specifier: workspace:*
         version: link:../../packages/types


### PR DESCRIPTION
## Summary

Adds `GET /v1/analytics/glanceable` API endpoint returning Tier 1 metrics (goal progress, weekly dots, current streak) by wiring the existing pure analytics functions from `packages/analytics/` to a Hono route.

## Changes

- `apps/api/src/routes/analytics.ts` — new route file with `GET /v1/analytics/glanceable`
- `apps/api/src/routes/analytics.test.ts` — route tests
- `apps/api/src/index.ts` — register analytics routes

Uses `@hono/zod-openapi` for request/response schemas, calls `tierOneMetrics()` from `@pomofocus/analytics`, and enforces auth via the existing middleware.

Closes #407

## Test plan

- [x] `pnpm nx test @pomofocus/api` passes locally
- [ ] Response shape matches `GlanceableResponse` spec
- [ ] Auth middleware enforced
- [ ] Queries filter by authenticated user via forwarded JWT

🤖 Generated with [Claude Code](https://claude.com/claude-code)