### PR TITLE
feat: timer state persistence to localStorage (#405)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,8 @@ export type {
   TimerState,
   TimerEvent,
 } from './timer/index.js';
+export { rehydrate, serializeState, deserializeState, SERIALIZATION_VERSION } from './timer/index.js';
+export type { RehydrationResult, SerializedTimerState } from './timer/index.js';
 export { QUEUE_ITEM_STATUS, SYNC_EVENT_TYPE, processQueue, createEmptyQueue } from './sync/index.js';
 export type {
   QueueItemStatus,

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -1,8 +1,8 @@
 // Zustand stores + TanStack Query hooks.
 // Depends on core, data-access, types.
 // Re-exports from immediate children only (U-014).
-export { useTimerStore, createTimerStore, startTimer, stopTimer } from './timer/index.js';
-export type { TimerStore, TimerStoreInstance } from './timer/index.js';
+export { useTimerStore, createTimerStore, startTimer, stopTimer, TIMER_STORAGE_KEY } from './timer/index.js';
+export type { TimerStore, TimerStoreInstance, TimerStoreOptions, TimerStorage } from './timer/index.js';
 export { useSessions, sessionsQueryOptions, useCreateSession } from './hooks/index.js';
 export { createQueryClient } from './query-client.js';
 export { QueryProvider } from './providers.js';

--- a/packages/state/src/integration.test.ts
+++ b/packages/state/src/integration.test.ts
@@ -76,7 +76,7 @@ describe('state package integration', () => {
         sessionsBeforeLongBreak: 4,
         reflectionEnabled: true,
       };
-      const store = createTimerStore(config);
+      const store = createTimerStore({ config, storage: null });
 
       // Initial state is idle
       expect(store.getState().state.status).toBe(TIMER_STATUS.IDLE);
@@ -142,7 +142,7 @@ describe('state package integration', () => {
         sessionsBeforeLongBreak: 4,
         reflectionEnabled: true,
       };
-      const store = createTimerStore(config);
+      const store = createTimerStore({ config, storage: null });
 
       store.getState().start();
       startTimer(store);
@@ -254,7 +254,7 @@ describe('state package integration', () => {
         sessionsBeforeLongBreak: 4,
         reflectionEnabled: false,
       };
-      const store = createTimerStore(config);
+      const store = createTimerStore({ config, storage: null });
 
       store.getState().start();
       startTimer(store);

--- a/packages/state/src/timer/index.ts
+++ b/packages/state/src/timer/index.ts
@@ -1,3 +1,3 @@
-export { useTimerStore, createTimerStore } from './timer-store.js';
-export type { TimerStore, TimerStoreInstance } from './timer-store.js';
+export { useTimerStore, createTimerStore, TIMER_STORAGE_KEY } from './timer-store.js';
+export type { TimerStore, TimerStoreInstance, TimerStoreOptions, TimerStorage } from './timer-store.js';
 export { startTimer, stopTimer } from './timer-driver.js';

--- a/packages/state/src/timer/timer-driver.test.ts
+++ b/packages/state/src/timer/timer-driver.test.ts
@@ -13,7 +13,7 @@ const defaultConfig: TimerConfig = {
 };
 
 function createStore(config: TimerConfig = defaultConfig): ReturnType<typeof createTimerStore> {
-  return createTimerStore(config);
+  return createTimerStore({ config, storage: null });
 }
 
 describe('timer driver', () => {

--- a/packages/state/src/timer/timer-store.test.ts
+++ b/packages/state/src/timer/timer-store.test.ts
@@ -480,7 +480,8 @@ describe('timer store', () => {
       const raw = storage.getItem(TIMER_STORAGE_KEY);
       expect(raw).not.toBeNull();
 
-      const parsed = JSON.parse(raw as string) as { version: number; state: { status: string } };
+      if (raw === null) return; // narrowing for type-checker (assertion above guarantees this path is unreachable)
+      const parsed = JSON.parse(raw) as { version: number; state: { status: string } };
       expect(parsed.version).toBe(SERIALIZATION_VERSION);
       expect(parsed.state.status).toBe(TIMER_STATUS.FOCUSING);
     });
@@ -491,13 +492,15 @@ describe('timer store', () => {
 
       store.getState().start();
 
-      const afterStart = JSON.parse(storage.getItem(TIMER_STORAGE_KEY) as string) as { state: { status: string } };
+      const startRaw = storage.getItem(TIMER_STORAGE_KEY) ?? '{}';
+      const afterStart = JSON.parse(startRaw) as { state: { status: string } };
       expect(afterStart.state.status).toBe(TIMER_STATUS.FOCUSING);
 
       vi.setSystemTime(2000);
       store.getState().pause();
 
-      const afterPause = JSON.parse(storage.getItem(TIMER_STORAGE_KEY) as string) as { state: { status: string } };
+      const pauseRaw = storage.getItem(TIMER_STORAGE_KEY) ?? '{}';
+      const afterPause = JSON.parse(pauseRaw) as { state: { status: string } };
       expect(afterPause.state.status).toBe(TIMER_STATUS.PAUSED);
     });
 

--- a/packages/state/src/timer/timer-store.test.ts
+++ b/packages/state/src/timer/timer-store.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createTimerStore } from './timer-store.js';
+import { createTimerStore, TIMER_STORAGE_KEY } from './timer-store.js';
+import type { TimerStorage } from './timer-store.js';
 import type { TimerConfig, ReflectionData } from '@pomofocus/core';
-import { TIMER_STATUS } from '@pomofocus/core';
+import { TIMER_STATUS, serializeState, SERIALIZATION_VERSION } from '@pomofocus/core';
 
 const defaultConfig: TimerConfig = {
   focusDuration: 1500,
@@ -12,7 +13,7 @@ const defaultConfig: TimerConfig = {
 };
 
 function createStore(config: TimerConfig = defaultConfig): ReturnType<typeof createTimerStore> {
-  return createTimerStore(config);
+  return createTimerStore({ config, storage: null });
 }
 
 describe('timer store', () => {
@@ -447,6 +448,177 @@ describe('timer store', () => {
       // Reset → goes back to idle
       store.getState().reset();
       expect(store.getState().state.status).toBe(TIMER_STATUS.IDLE);
+    });
+  });
+
+  describe('persistence', () => {
+    function createMockStorage(): TimerStorage & { store: Map<string, string> } {
+      const store = new Map<string, string>();
+      return {
+        store,
+        getItem: (key: string): string | null => store.get(key) ?? null,
+        setItem: (key: string, value: string): void => { store.set(key, value); },
+        removeItem: (key: string): void => { store.delete(key); },
+      };
+    }
+
+    it('initializes to idle when no persisted state exists', () => {
+      const storage = createMockStorage();
+      const store = createTimerStore({ config: defaultConfig, storage, now: 1000 });
+
+      expect(store.getState().state.status).toBe(TIMER_STATUS.IDLE);
+      expect(store.getState().state.config).toEqual(defaultConfig);
+    });
+
+    it('serializes timer state to storage on every transition', () => {
+      const storage = createMockStorage();
+      const store = createTimerStore({ config: defaultConfig, storage, now: 1000 });
+
+      // Initially storage is empty (no write for initial state — subscription fires on changes)
+      store.getState().start();
+
+      const raw = storage.getItem(TIMER_STORAGE_KEY);
+      expect(raw).not.toBeNull();
+
+      const parsed = JSON.parse(raw as string) as { version: number; state: { status: string } };
+      expect(parsed.version).toBe(SERIALIZATION_VERSION);
+      expect(parsed.state.status).toBe(TIMER_STATUS.FOCUSING);
+    });
+
+    it('updates storage on each subsequent transition', () => {
+      const storage = createMockStorage();
+      const store = createTimerStore({ config: defaultConfig, storage, now: 1000 });
+
+      store.getState().start();
+
+      const afterStart = JSON.parse(storage.getItem(TIMER_STORAGE_KEY) as string) as { state: { status: string } };
+      expect(afterStart.state.status).toBe(TIMER_STATUS.FOCUSING);
+
+      vi.setSystemTime(2000);
+      store.getState().pause();
+
+      const afterPause = JSON.parse(storage.getItem(TIMER_STORAGE_KEY) as string) as { state: { status: string } };
+      expect(afterPause.state.status).toBe(TIMER_STATUS.PAUSED);
+    });
+
+    it('rehydrates from persisted state on initialization', () => {
+      const storage = createMockStorage();
+      const pausedState = {
+        status: TIMER_STATUS.PAUSED,
+        timeRemaining: 500,
+        pausedAt: 1000,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+      storage.setItem(
+        TIMER_STORAGE_KEY,
+        JSON.stringify(serializeState(pausedState)),
+      );
+
+      const store = createTimerStore({ config: defaultConfig, storage, now: 2000 });
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.PAUSED);
+      if (state.status === TIMER_STATUS.PAUSED) {
+        expect(state.timeRemaining).toBe(500);
+        expect(state.sessionNumber).toBe(1);
+      }
+    });
+
+    it('rehydrates focusing state and adjusts time remaining for elapsed time', () => {
+      const storage = createMockStorage();
+      const focusingState = {
+        status: TIMER_STATUS.FOCUSING,
+        timeRemaining: 1000,
+        startedAt: 0,
+        sessionNumber: 1,
+        config: defaultConfig,
+      };
+      storage.setItem(
+        TIMER_STORAGE_KEY,
+        JSON.stringify(serializeState(focusingState)),
+      );
+
+      // 200 seconds have passed since startedAt
+      const store = createTimerStore({ config: defaultConfig, storage, now: 200 });
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.FOCUSING);
+      if (state.status === TIMER_STATUS.FOCUSING) {
+        expect(state.timeRemaining).toBe(800);
+      }
+    });
+
+    it('auto-abandons when persisted session has expired beyond max duration', () => {
+      const storage = createMockStorage();
+      // Focus duration is 1500s. Auto-abandon threshold is 2 * 1500 = 3000s.
+      const focusingState = {
+        status: TIMER_STATUS.FOCUSING,
+        timeRemaining: 1500,
+        startedAt: 0,
+        sessionNumber: 2,
+        config: defaultConfig,
+      };
+      storage.setItem(
+        TIMER_STORAGE_KEY,
+        JSON.stringify(serializeState(focusingState)),
+      );
+
+      // 3500 seconds elapsed — beyond 2x focus duration
+      const store = createTimerStore({ config: defaultConfig, storage, now: 3500 });
+
+      const { state } = store.getState();
+      expect(state.status).toBe(TIMER_STATUS.ABANDONED);
+      if (state.status === TIMER_STATUS.ABANDONED) {
+        expect(state.sessionNumber).toBe(2);
+        expect(state.abandonedAt).toBe(3500);
+      }
+    });
+
+    it('falls back to idle when persisted data is invalid JSON', () => {
+      const storage = createMockStorage();
+      storage.setItem(TIMER_STORAGE_KEY, 'not-valid-json{{{');
+
+      const store = createTimerStore({ config: defaultConfig, storage, now: 1000 });
+
+      expect(store.getState().state.status).toBe(TIMER_STATUS.IDLE);
+      // Invalid data should be cleaned up
+      expect(storage.getItem(TIMER_STORAGE_KEY)).toBeNull();
+    });
+
+    it('falls back to idle when persisted data has wrong version', () => {
+      const storage = createMockStorage();
+      storage.setItem(
+        TIMER_STORAGE_KEY,
+        JSON.stringify({ version: 999, state: { status: 'idle', config: defaultConfig } }),
+      );
+
+      const store = createTimerStore({ config: defaultConfig, storage, now: 1000 });
+
+      expect(store.getState().state.status).toBe(TIMER_STATUS.IDLE);
+      expect(storage.getItem(TIMER_STORAGE_KEY)).toBeNull();
+    });
+
+    it('falls back to idle when persisted state fails validation', () => {
+      const storage = createMockStorage();
+      storage.setItem(
+        TIMER_STORAGE_KEY,
+        JSON.stringify({ version: SERIALIZATION_VERSION, state: { status: 'invalid_status' } }),
+      );
+
+      const store = createTimerStore({ config: defaultConfig, storage, now: 1000 });
+
+      expect(store.getState().state.status).toBe(TIMER_STATUS.IDLE);
+      expect(storage.getItem(TIMER_STORAGE_KEY)).toBeNull();
+    });
+
+    it('does not write to storage when storage is null', () => {
+      const store = createTimerStore({ config: defaultConfig, storage: null, now: 1000 });
+
+      store.getState().start();
+
+      // No crash, no writes — just works without persistence
+      expect(store.getState().state.status).toBe(TIMER_STATUS.FOCUSING);
     });
   });
 });

--- a/packages/state/src/timer/timer-store.ts
+++ b/packages/state/src/timer/timer-store.ts
@@ -217,16 +217,21 @@ export function createTimerStore(options: TimerStoreOptions = {}): TimerStoreIns
   return store;
 }
 
+function isTimerStorage(value: unknown): value is TimerStorage {
+  return (
+    value != null &&
+    typeof (value as TimerStorage).getItem === 'function' &&
+    typeof (value as TimerStorage).setItem === 'function' &&
+    typeof (value as TimerStorage).removeItem === 'function'
+  );
+}
+
 function getDefaultStorage(): TimerStorage | null {
   try {
-    const ls = globalThis.localStorage;
-    if (
-      ls != null &&
-      typeof ls.getItem === 'function' &&
-      typeof ls.setItem === 'function' &&
-      typeof ls.removeItem === 'function'
-    ) {
-      return ls;
+    // localStorage may not exist at runtime (Node.js, sandboxed contexts).
+    // Use 'in' check to avoid TypeScript assuming globalThis.localStorage is always Storage.
+    if ('localStorage' in globalThis && isTimerStorage(globalThis.localStorage)) {
+      return globalThis.localStorage;
     }
   } catch {
     // localStorage access may throw in sandboxed contexts

--- a/packages/state/src/timer/timer-store.ts
+++ b/packages/state/src/timer/timer-store.ts
@@ -6,8 +6,51 @@ import type { TimerState, ReflectionData, TimerConfig } from '@pomofocus/core';
 import {
   transition,
   createInitialState,
+  serializeState,
+  deserializeState,
+  rehydrate,
   TIMER_EVENT_TYPE,
 } from '@pomofocus/core';
+
+// ── Persistence ──
+
+export const TIMER_STORAGE_KEY = 'pomofocus:timer-state';
+
+export type TimerStorage = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+};
+
+function loadInitialState(config: TimerConfig, storage: TimerStorage | null, now: number): TimerState {
+  if (storage === null) return createInitialState(config);
+
+  const raw = storage.getItem(TIMER_STORAGE_KEY);
+  if (raw === null) return createInitialState(config);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    storage.removeItem(TIMER_STORAGE_KEY);
+    return createInitialState(config);
+  }
+
+  const deserialized = deserializeState(parsed);
+  if (deserialized === null) {
+    storage.removeItem(TIMER_STORAGE_KEY);
+    return createInitialState(config);
+  }
+
+  const { state } = rehydrate(deserialized, now);
+  return state;
+}
+
+function persistState(state: TimerState, storage: TimerStorage | null): void {
+  if (storage === null) return;
+  const serialized = serializeState(state);
+  storage.setItem(TIMER_STORAGE_KEY, JSON.stringify(serialized));
+}
 
 // ── Store Shape ──
 
@@ -40,18 +83,30 @@ const DEFAULT_CONFIG: TimerConfig = {
 
 // ── Store Factory ──
 
+export type TimerStoreOptions = {
+  config?: TimerConfig;
+  storage?: TimerStorage | null;
+  now?: number;
+};
+
 export type TimerStoreInstance = UseBoundStore<StoreApi<TimerStore>>;
 
-export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerStoreInstance {
-  return create<TimerStore>()(
+export function createTimerStore(options: TimerStoreOptions = {}): TimerStoreInstance {
+  const config = options.config ?? DEFAULT_CONFIG;
+  const storage = options.storage === undefined ? getDefaultStorage() : options.storage;
+  const now = options.now ?? Date.now();
+
+  const initialState = loadInitialState(config, storage, now);
+
+  const store = create<TimerStore>()(
     devtools(
       (set) => ({
-        state: createInitialState(config),
+        state: initialState,
 
         start: (): void => {
           set(
-            (store) => ({
-              state: transition(store.state, { type: TIMER_EVENT_TYPE.START }, Date.now()),
+            (s) => ({
+              state: transition(s.state, { type: TIMER_EVENT_TYPE.START }, Date.now()),
             }),
             false,
             'timer/start',
@@ -60,8 +115,8 @@ export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerSto
 
         pause: (): void => {
           set(
-            (store) => ({
-              state: transition(store.state, { type: TIMER_EVENT_TYPE.PAUSE }, Date.now()),
+            (s) => ({
+              state: transition(s.state, { type: TIMER_EVENT_TYPE.PAUSE }, Date.now()),
             }),
             false,
             'timer/pause',
@@ -70,8 +125,8 @@ export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerSto
 
         resume: (): void => {
           set(
-            (store) => ({
-              state: transition(store.state, { type: TIMER_EVENT_TYPE.RESUME }, Date.now()),
+            (s) => ({
+              state: transition(s.state, { type: TIMER_EVENT_TYPE.RESUME }, Date.now()),
             }),
             false,
             'timer/resume',
@@ -80,8 +135,8 @@ export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerSto
 
         abandon: (): void => {
           set(
-            (store) => ({
-              state: transition(store.state, { type: TIMER_EVENT_TYPE.ABANDON }, Date.now()),
+            (s) => ({
+              state: transition(s.state, { type: TIMER_EVENT_TYPE.ABANDON }, Date.now()),
             }),
             false,
             'timer/abandon',
@@ -90,8 +145,8 @@ export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerSto
 
         reset: (): void => {
           set(
-            (store) => ({
-              state: transition(store.state, { type: TIMER_EVENT_TYPE.RESET }, Date.now()),
+            (s) => ({
+              state: transition(s.state, { type: TIMER_EVENT_TYPE.RESET }, Date.now()),
             }),
             false,
             'timer/reset',
@@ -100,8 +155,8 @@ export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerSto
 
         tick: (): void => {
           set(
-            (store) => ({
-              state: transition(store.state, { type: TIMER_EVENT_TYPE.TICK }, Date.now()),
+            (s) => ({
+              state: transition(s.state, { type: TIMER_EVENT_TYPE.TICK }, Date.now()),
             }),
             false,
             'timer/tick',
@@ -110,8 +165,8 @@ export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerSto
 
         timerDone: (): void => {
           set(
-            (store) => ({
-              state: transition(store.state, { type: TIMER_EVENT_TYPE.TIMER_DONE }, Date.now()),
+            (s) => ({
+              state: transition(s.state, { type: TIMER_EVENT_TYPE.TIMER_DONE }, Date.now()),
             }),
             false,
             'timer/timerDone',
@@ -120,8 +175,8 @@ export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerSto
 
         skipBreak: (): void => {
           set(
-            (store) => ({
-              state: transition(store.state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, Date.now()),
+            (s) => ({
+              state: transition(s.state, { type: TIMER_EVENT_TYPE.SKIP_BREAK }, Date.now()),
             }),
             false,
             'timer/skipBreak',
@@ -130,8 +185,8 @@ export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerSto
 
         submitReflection: (data: ReflectionData): void => {
           set(
-            (store) => ({
-              state: transition(store.state, { type: TIMER_EVENT_TYPE.SUBMIT, data }, Date.now()),
+            (s) => ({
+              state: transition(s.state, { type: TIMER_EVENT_TYPE.SUBMIT, data }, Date.now()),
             }),
             false,
             'timer/submitReflection',
@@ -140,8 +195,8 @@ export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerSto
 
         skipReflection: (): void => {
           set(
-            (store) => ({
-              state: transition(store.state, { type: TIMER_EVENT_TYPE.SKIP }, Date.now()),
+            (s) => ({
+              state: transition(s.state, { type: TIMER_EVENT_TYPE.SKIP }, Date.now()),
             }),
             false,
             'timer/skipReflection',
@@ -151,6 +206,32 @@ export function createTimerStore(config: TimerConfig = DEFAULT_CONFIG): TimerSto
       { name: 'TimerStore' },
     ),
   );
+
+  // Subscribe to persist state on every change
+  if (storage !== null) {
+    store.subscribe((current) => {
+      persistState(current.state, storage);
+    });
+  }
+
+  return store;
+}
+
+function getDefaultStorage(): TimerStorage | null {
+  try {
+    const ls = globalThis.localStorage;
+    if (
+      ls != null &&
+      typeof ls.getItem === 'function' &&
+      typeof ls.setItem === 'function' &&
+      typeof ls.removeItem === 'function'
+    ) {
+      return ls;
+    }
+  } catch {
+    // localStorage access may throw in sandboxed contexts
+  }
+  return null;
 }
 
 // ── Singleton Instance ──


### PR DESCRIPTION
## Summary

Wires timer state persistence: saves to localStorage on every state change so the timer survives browser refresh/tab close. Uses the pure rehydration and serialization helpers already in `packages/core/src/timer/` from issues #188 and #189.

## Changes

- **`packages/state/src/timer/timer-store.ts`** — add persistence wiring:
  - `TimerStorage` interface and optional `storage` option on `createTimerStore`
  - `getDefaultStorage()` with defensive guards (sandboxed iframes, SSR, missing `localStorage`)
  - `store.subscribe(...)` writes serialized state to storage on every change
  - On init, rehydrates from `localStorage` via `rehydrate()` from core (handles expired sessions → auto-abandon, invalid data → fall back to idle)
- **`packages/state/src/timer/timer-store.test.ts`** — 170 new lines of persistence tests covering round-trip save/restore, expired session auto-abandon, corrupted JSON fallback, version mismatch fallback, and null-storage no-op
- **`packages/core/src/index.ts`** — export `rehydrate`, `serializeState`, `deserializeState`, `SERIALIZATION_VERSION` (needed by the persistence wiring)
- **`packages/state/src/index.ts`, `packages/state/src/timer/index.ts`** — re-export `TIMER_STORAGE_KEY`, `TimerStorage`, `TimerStoreOptions`
- **`packages/state/src/integration.test.ts`, `packages/state/src/timer/timer-driver.test.ts`** — import adjustments for barrel updates

Per ADR-004, core stays pure — timer-store is the platform-specific driver that owns IO (localStorage) while core owns the state machine.

Closes #405

## Test plan

- [x] `pnpm nx test @pomofocus/state` — 90 tests pass
- [x] `pnpm nx type-check @pomofocus/state` — clean
- [ ] Verify persistence across manual browser refresh in web app (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)