### PR TITLE
feat: GET /v1/me/export for GDPR data portability (#418)

### DIFF
--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -3,7 +3,7 @@ import { OpenAPIHono } from '@hono/zod-openapi';
 import { authMiddleware } from '../middleware/auth.js';
 import type { AuthVariables } from '../middleware/auth.js';
 import type { SupabaseEnv } from '../lib/supabase.js';
-import { registerMeRoute, MeResponseSchema } from './me.js';
+import { registerMeRoute, MeResponseSchema, MeExportResponseSchema } from './me.js';
 
 /**
  * Mock the Supabase client factory so no real clients are created.
@@ -30,6 +30,31 @@ const FAKE_USER = {
   id: 'aaaa1111-0000-0000-0000-000000000001',
   email: 'alice@example.com',
   created_at: '2026-03-01T00:00:00.000Z',
+};
+
+const FAKE_PROFILE_ID = 'bbbb2222-0000-0000-0000-000000000001';
+
+const FAKE_PROFILE = {
+  id: FAKE_PROFILE_ID,
+  auth_user_id: FAKE_USER.id,
+  display_name: 'Alice',
+  username: 'alice',
+  avatar_url: null,
+  created_at: '2026-03-01T00:00:00.000Z',
+  updated_at: '2026-03-01T00:00:00.000Z',
+};
+
+const FAKE_PREFERENCES = {
+  id: 'cccc3333-0000-0000-0000-000000000001',
+  user_id: FAKE_PROFILE_ID,
+  work_duration_minutes: 25,
+  short_break_minutes: 5,
+  long_break_minutes: 15,
+  sessions_before_long_break: 4,
+  reflection_enabled: true,
+  timezone: 'UTC',
+  created_at: '2026-03-01T00:00:00.000Z',
+  updated_at: '2026-03-01T00:00:00.000Z',
 };
 
 function createTestApp(): OpenAPIHono<{ Bindings: SupabaseEnv; Variables: AuthVariables }> {
@@ -131,6 +156,330 @@ describe('GET /v1/me', () => {
     const app = createTestApp();
     const res = await app.request(
       '/v1/me',
+      { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
+
+    expect(res.headers.get('content-type')).toContain('application/json');
+  });
+});
+
+/**
+ * The export endpoint queries multiple tables with different patterns:
+ * - profiles: .eq('auth_user_id', ...).maybeSingle()
+ * - user_preferences: .eq('user_id', ...).maybeSingle()
+ * - user_id-scoped tables: .eq('user_id', ...) returning arrays
+ * - friend_requests: two queries (.eq('sender_id'), .eq('recipient_id'))
+ * - device_sync_log: .in('device_id', [...])
+ *
+ * We need a more flexible mock to handle these patterns.
+ */
+function createExportMockClientFull(options: {
+  profile?: unknown;
+  preferences?: unknown;
+  longTermGoals?: unknown[];
+  processGoals?: unknown[];
+  sessions?: unknown[];
+  breaks?: unknown[];
+  devices?: { id: string; [key: string]: unknown }[];
+  deviceSyncLog?: unknown[];
+  friendRequestsSent?: unknown[];
+  friendRequestsReceived?: unknown[];
+  friendships?: unknown[];
+  encouragementTaps?: unknown[];
+}): Record<string, unknown> {
+  const {
+    profile = null,
+    preferences = null,
+    longTermGoals = [],
+    processGoals = [],
+    sessions = [],
+    breaks = [],
+    devices = [],
+    deviceSyncLog = [],
+    friendRequestsSent = [],
+    friendRequestsReceived = [],
+    friendships = [],
+    encouragementTaps = [],
+  } = options;
+
+  // Track call counts for friend_requests to return sent vs received
+  let friendRequestCallCount = 0;
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'profiles') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({ data: profile, error: null }),
+            })),
+          })),
+        };
+      }
+      if (table === 'user_preferences') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({ data: preferences, error: null }),
+            })),
+          })),
+        };
+      }
+      if (table === 'friend_requests') {
+        friendRequestCallCount++;
+        const data = friendRequestCallCount % 2 === 1 ? friendRequestsSent : friendRequestsReceived;
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => Promise.resolve({ data, error: null })),
+          })),
+        };
+      }
+      if (table === 'device_sync_log') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn(() => Promise.resolve({ data: deviceSyncLog, error: null })),
+          })),
+        };
+      }
+
+      // All user_id-scoped tables
+      const tableMap: Record<string, unknown[]> = {
+        long_term_goals: longTermGoals,
+        process_goals: processGoals,
+        sessions,
+        breaks,
+        devices,
+        friendships,
+        encouragement_taps: encouragementTaps,
+      };
+
+      const data = tableMap[table] ?? [];
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => Promise.resolve({ data, error: null })),
+        })),
+      };
+    }),
+    auth: { getUser: mockGetUser },
+  };
+}
+
+describe('GET /v1/me/export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 without authorization header', async () => {
+    const app = createTestApp();
+    const res = await app.request('/v1/me/export', {}, FAKE_ENV);
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with all entity types in response', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    const mockClient = createExportMockClientFull({
+      profile: FAKE_PROFILE,
+      preferences: FAKE_PREFERENCES,
+    });
+
+    mockCreateUserClient.mockReturnValue(mockClient);
+
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/me/export',
+      { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const expectedKeys = [
+      'profile',
+      'preferences',
+      'long_term_goals',
+      'process_goals',
+      'sessions',
+      'breaks',
+      'devices',
+      'device_sync_log',
+      'friend_requests',
+      'friendships',
+      'encouragement_taps',
+    ];
+    expect(Object.keys(body).sort()).toEqual(expectedKeys.sort());
+  });
+
+  it('sets Content-Disposition header for file download', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    mockCreateUserClient.mockReturnValue(
+      createExportMockClientFull({ profile: FAKE_PROFILE }),
+    );
+
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/me/export',
+      { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-disposition')).toBe(
+      'attachment; filename="pomofocus-export.json"',
+    );
+  });
+
+  it('returns 200 with empty collections when user has no data', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    mockCreateUserClient.mockReturnValue(
+      createExportMockClientFull({}),
+    );
+
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/me/export',
+      { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.profile).toBeNull();
+    expect(body.preferences).toBeNull();
+    expect(body.long_term_goals).toEqual([]);
+    expect(body.process_goals).toEqual([]);
+    expect(body.sessions).toEqual([]);
+    expect(body.breaks).toEqual([]);
+    expect(body.devices).toEqual([]);
+    expect(body.device_sync_log).toEqual([]);
+    expect(body.friend_requests).toEqual([]);
+    expect(body.friendships).toEqual([]);
+    expect(body.encouragement_taps).toEqual([]);
+  });
+
+  it('includes profile and preferences when they exist', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    mockCreateUserClient.mockReturnValue(
+      createExportMockClientFull({
+        profile: FAKE_PROFILE,
+        preferences: FAKE_PREFERENCES,
+      }),
+    );
+
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/me/export',
+      { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.profile).toEqual(FAKE_PROFILE);
+    expect(body.preferences).toEqual(FAKE_PREFERENCES);
+  });
+
+  it('includes data from all entity tables', async () => {
+    const fakeSession = {
+      id: 'ssss0001-0000-0000-0000-000000000001',
+      user_id: FAKE_PROFILE_ID,
+      started_at: '2026-03-15T10:00:00.000Z',
+    };
+    const fakeDevice = {
+      id: 'dddd0001-0000-0000-0000-000000000001',
+      user_id: FAKE_PROFILE_ID,
+      device_name: 'My Device',
+    };
+    const fakeSyncLog = {
+      id: 'llll0001-0000-0000-0000-000000000001',
+      device_id: fakeDevice.id,
+      direction: 'upload',
+    };
+
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    mockCreateUserClient.mockReturnValue(
+      createExportMockClientFull({
+        profile: FAKE_PROFILE,
+        sessions: [fakeSession],
+        devices: [fakeDevice],
+        deviceSyncLog: [fakeSyncLog],
+      }),
+    );
+
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/me/export',
+      { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.sessions).toEqual([fakeSession]);
+    expect(body.devices).toEqual([fakeDevice]);
+    expect(body.device_sync_log).toEqual([fakeSyncLog]);
+  });
+
+  it('validates response against MeExportResponseSchema', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    mockCreateUserClient.mockReturnValue(
+      createExportMockClientFull({ profile: FAKE_PROFILE }),
+    );
+
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/me/export',
+      { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
+      FAKE_ENV,
+    );
+
+    const body = await res.json();
+    const result = MeExportResponseSchema.safeParse(body);
+    expect(result.success).toBe(true);
+  });
+
+  it('returns content-type application/json', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: FAKE_USER },
+      error: null,
+    });
+
+    mockCreateUserClient.mockReturnValue(
+      createExportMockClientFull({ profile: FAKE_PROFILE }),
+    );
+
+    const app = createTestApp();
+    const res = await app.request(
+      '/v1/me/export',
       { headers: { Authorization: `Bearer ${FAKE_JWT}` } },
       FAKE_ENV,
     );

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -3,6 +3,12 @@ import type { OpenAPIHono } from '@hono/zod-openapi';
 import type { AppEnv } from '../types.js';
 
 /**
+ * Row type used throughout the export response.
+ * Matches what Supabase returns: objects with string keys and JSON-serializable values.
+ */
+type Row = Record<string, unknown>;
+
+/**
  * Zod schema for the GET /v1/me response.
  * Returns the authenticated user's profile.
  */
@@ -10,6 +16,25 @@ export const MeResponseSchema = z.object({
   id: z.string(),
   email: z.string().nullable(),
   created_at: z.string(),
+});
+
+/**
+ * Zod schema for the GET /v1/me/export response.
+ * Returns all user data grouped by entity type for GDPR data portability (ADR-012).
+ * Uses z.record() for row objects since Supabase returns typed rows with varying shapes.
+ */
+export const MeExportResponseSchema = z.object({
+  profile: z.record(z.string(), z.unknown()).nullable(),
+  preferences: z.record(z.string(), z.unknown()).nullable(),
+  long_term_goals: z.array(z.record(z.string(), z.unknown())),
+  process_goals: z.array(z.record(z.string(), z.unknown())),
+  sessions: z.array(z.record(z.string(), z.unknown())),
+  breaks: z.array(z.record(z.string(), z.unknown())),
+  devices: z.array(z.record(z.string(), z.unknown())),
+  device_sync_log: z.array(z.record(z.string(), z.unknown())),
+  friend_requests: z.array(z.record(z.string(), z.unknown())),
+  friendships: z.array(z.record(z.string(), z.unknown())),
+  encouragement_taps: z.array(z.record(z.string(), z.unknown())),
 });
 
 /**
@@ -43,10 +68,62 @@ export const meRoute = createRoute({
 });
 
 /**
- * Registers the GET /v1/me route on the given OpenAPIHono app.
+ * OpenAPI route definition for GET /v1/me/export.
+ * Returns all user data as a JSON download for GDPR data portability.
+ */
+export const meExportRoute = createRoute({
+  method: 'get',
+  path: '/v1/me/export',
+  security: [{ Bearer: [] }],
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: MeExportResponseSchema,
+        },
+      },
+      description: 'Full user data export (GDPR Art. 20)',
+      headers: z.object({
+        'Content-Disposition': z.string(),
+      }),
+    },
+    401: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: z.string(),
+            status: z.number(),
+          }),
+        },
+      },
+      description: 'Missing or invalid authorization token',
+    },
+  },
+});
+
+/**
+ * Table names scoped by user_id for the data export.
+ * Each entry maps to a Supabase table where the user's data lives.
+ */
+const USER_TABLES = [
+  'long_term_goals',
+  'process_goals',
+  'sessions',
+  'breaks',
+  'devices',
+  'device_sync_log',
+  'friendships',
+  'encouragement_taps',
+] as const;
+
+/**
+ * Registers the GET /v1/me and GET /v1/me/export routes on the given OpenAPIHono app.
  *
- * Uses the user-scoped Supabase client from auth middleware to resolve
- * the authenticated user's identity from the JWT.
+ * GET /v1/me: Returns the authenticated user's identity from the JWT.
+ *
+ * GET /v1/me/export: Returns all user data as a JSON download.
+ * Uses the user-scoped Supabase client so RLS filters to own data only.
+ * Queries all 11 application tables and returns a nested structure.
  */
 export function registerMeRoute(app: OpenAPIHono<AppEnv>): void {
   app.openapi(meRoute, async (c) => {
@@ -65,5 +142,129 @@ export function registerMeRoute(app: OpenAPIHono<AppEnv>): void {
       },
       200,
     );
+  });
+
+  app.openapi(meExportRoute, async (c) => {
+    const supabase = c.get('supabase');
+
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError) {
+      throw userError;
+    }
+
+    const userId = userData.user.id;
+
+    // Fetch profile (single row via auth_user_id)
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('*')
+      .eq('auth_user_id', userId)
+      .maybeSingle();
+
+    if (profileError) {
+      throw profileError;
+    }
+
+    // Fetch preferences (single row via user_id -> profiles.id)
+    let preferences: Row | null = null;
+    if (profile) {
+      const { data: prefs, error: prefsError } = await supabase
+        .from('user_preferences')
+        .select('*')
+        .eq('user_id', profile.id)
+        .maybeSingle();
+
+      if (prefsError) {
+        throw prefsError;
+      }
+
+      preferences = prefs;
+    }
+
+    // Fetch friend_requests where user is sender or recipient (uses profile.id)
+    let friendRequests: Row[] = [];
+    if (profile) {
+      const { data: sentRequests, error: sentError } = await supabase
+        .from('friend_requests')
+        .select('*')
+        .eq('sender_id', profile.id);
+
+      if (sentError) {
+        throw sentError;
+      }
+
+      const { data: receivedRequests, error: receivedError } = await supabase
+        .from('friend_requests')
+        .select('*')
+        .eq('recipient_id', profile.id);
+
+      if (receivedError) {
+        throw receivedError;
+      }
+
+      friendRequests = [...sentRequests, ...receivedRequests];
+    }
+
+    // Fetch all user_id-scoped tables in parallel.
+    // RLS ensures only the user's own rows are returned.
+    // device_sync_log is scoped via device_id, so we fetch it after devices.
+    const profileId = profile?.id;
+    const tableResults = await Promise.all(
+      USER_TABLES.filter((t) => t !== 'device_sync_log').map(async (table) => {
+        if (!profileId) {
+          return { table, data: [] as Row[] };
+        }
+        const { data: rows, error: tableError } = await supabase
+          .from(table)
+          .select('*')
+          .eq('user_id', profileId);
+
+        if (tableError) {
+          throw tableError;
+        }
+
+        return { table, data: rows as Row[] };
+      }),
+    );
+
+    const tableData: Record<string, Row[]> = {};
+    for (const result of tableResults) {
+      tableData[result.table] = result.data;
+    }
+
+    // Fetch device_sync_log scoped by the user's device IDs
+    let deviceSyncLog: Row[] = [];
+    const devices = tableData['devices'] as { id: string }[] | undefined;
+    if (devices && devices.length > 0) {
+      const deviceIds = devices.map((d) => d.id);
+      const { data: syncRows, error: syncError } = await supabase
+        .from('device_sync_log')
+        .select('*')
+        .in('device_id', deviceIds);
+
+      if (syncError) {
+        throw syncError;
+      }
+
+      deviceSyncLog = syncRows;
+    }
+
+    const exportData = {
+      profile,
+      preferences,
+      long_term_goals: tableData['long_term_goals'] ?? [],
+      process_goals: tableData['process_goals'] ?? [],
+      sessions: tableData['sessions'] ?? [],
+      breaks: tableData['breaks'] ?? [],
+      devices: tableData['devices'] ?? [],
+      device_sync_log: deviceSyncLog,
+      friend_requests: friendRequests,
+      friendships: tableData['friendships'] ?? [],
+      encouragement_taps: tableData['encouragement_taps'] ?? [],
+    };
+
+    c.header('Content-Disposition', 'attachment; filename="pomofocus-export.json"');
+
+    return c.json(exportData, 200);
   });
 }


### PR DESCRIPTION
## Summary

Implements `GET /v1/me/export` returning all user data as a JSON download for GDPR Art. 20 (Right to data portability) per ADR-012.

## Changes

- **`apps/api/src/routes/me.ts`** — add `GET /v1/me/export` handler that queries all 11 application tables (profile, preferences, long-term and process goals, sessions, breaks, devices, friendships, friend requests, encouragement taps) via the user's JWT (RLS filters to own data only), then returns a human-readable JSON nested by entity type
- **`apps/api/src/routes/me.test.ts`** — tests covering happy path, empty-data case (200 with empty collections), auth enforcement, and Content-Disposition header

Sets `Content-Disposition: attachment; filename=\"pomofocus-export.json\"` so browsers trigger a download.

Closes #418

## Test plan

- [x] `pnpm nx test @pomofocus/api` — 116 tests pass
- [x] `pnpm nx type-check @pomofocus/api` — clean
- [ ] Manual verification of download in browser (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)