### PR TITLE
feat: sync upload driver for outbox entries (#396)

### DIFF
--- a/packages/data-access/src/index.ts
+++ b/packages/data-access/src/index.ts
@@ -55,3 +55,11 @@ export {
   REFRESH_BUFFER_SECONDS,
 } from './auth/token-refresh';
 export type { TokenRefreshDeps } from './auth/token-refresh';
+export { uploadEntry, isRetryableStatus, getSupportedEntityTypes } from './sync';
+export type {
+  UploadResult,
+  UploadSuccess,
+  UploadFailure,
+  EntityPayload,
+  SessionPayload,
+} from './sync';

--- a/packages/data-access/src/sync/index.ts
+++ b/packages/data-access/src/sync/index.ts
@@ -1,0 +1,8 @@
+export { uploadEntry, isRetryableStatus, getSupportedEntityTypes } from './upload-driver';
+export type {
+  UploadResult,
+  UploadSuccess,
+  UploadFailure,
+  EntityPayload,
+  SessionPayload,
+} from './upload-driver';

--- a/packages/data-access/src/sync/upload-driver.test.ts
+++ b/packages/data-access/src/sync/upload-driver.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createApiClient } from '../client';
+import { uploadEntry, isRetryableStatus, getSupportedEntityTypes } from './upload-driver';
+import type { UploadResult, SessionPayload } from './upload-driver';
+import type { OutboxEntry } from '@pomofocus/core';
+
+type StubResponse = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: { get: (key: string) => string | null };
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+  clone: () => StubResponse;
+};
+
+function stubFetch(status: number, body: unknown): void {
+  const response: StubResponse = {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: statusTextFor(status),
+    headers: { get: (key: string) => key === 'content-type' ? 'application/json' : null },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    clone: () => response,
+  };
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+}
+
+function statusTextFor(status: number): string {
+  const texts: Record<number, string> = {
+    200: 'OK',
+    201: 'Created',
+    400: 'Bad Request',
+    401: 'Unauthorized',
+    409: 'Conflict',
+    422: 'Unprocessable Entity',
+    429: 'Too Many Requests',
+    500: 'Internal Server Error',
+    503: 'Service Unavailable',
+  };
+  return texts[status] ?? '';
+}
+
+function makeSessionEntry(overrides?: Partial<OutboxEntry>): OutboxEntry {
+  return {
+    id: 'outbox-entry-1',
+    entityType: 'sessions',
+    entityId: '550e8400-e29b-41d4-a716-446655440000',
+    state: { type: 'uploading' },
+    retryCount: 0,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeSessionPayload(): SessionPayload {
+  return {
+    started_at: '2026-03-17T10:00:00Z',
+    ended_at: '2026-03-17T10:25:00Z',
+    focus_quality: 'locked_in',
+  };
+}
+
+describe('uploadEntry', () => {
+  const baseUrl = 'https://api.example.com';
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns success for a 201 session creation', async () => {
+    const responseBody = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      user_id: 'user-1',
+      process_goal_id: 'goal-1',
+      intention_text: null,
+      started_at: '2026-03-17T10:00:00Z',
+      ended_at: '2026-03-17T10:25:00Z',
+      completed: true,
+      abandonment_reason: null,
+      focus_quality: 'locked_in',
+      distraction_type: null,
+      device_id: null,
+      created_at: '2026-03-17T10:25:00Z',
+    };
+
+    stubFetch(201, responseBody);
+
+    const client = createApiClient(baseUrl);
+    const entry = makeSessionEntry();
+    const payload = makeSessionPayload();
+
+    const result: UploadResult = await uploadEntry(client, entry, payload);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('treats 409 (duplicate UUID) as success', async () => {
+    stubFetch(409, { error: 'Duplicate entry' });
+
+    const client = createApiClient(baseUrl);
+    const entry = makeSessionEntry();
+    const payload = makeSessionPayload();
+
+    const result = await uploadEntry(client, entry, payload);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns retryable failure for 500 server error', async () => {
+    stubFetch(500, { error: 'Internal server error' });
+
+    const client = createApiClient(baseUrl);
+    const entry = makeSessionEntry();
+    const payload = makeSessionPayload();
+
+    const result = await uploadEntry(client, entry, payload);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(500);
+      expect(result.message).toBe('Internal server error');
+      expect(result.retryable).toBe(true);
+    }
+  });
+
+  it('returns retryable failure for 503 service unavailable', async () => {
+    stubFetch(503, { error: 'Service unavailable' });
+
+    const client = createApiClient(baseUrl);
+    const entry = makeSessionEntry();
+    const payload = makeSessionPayload();
+
+    const result = await uploadEntry(client, entry, payload);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(503);
+      expect(result.retryable).toBe(true);
+    }
+  });
+
+  it('returns retryable failure for 429 too many requests', async () => {
+    stubFetch(429, { error: 'Rate limited' });
+
+    const client = createApiClient(baseUrl);
+    const entry = makeSessionEntry();
+    const payload = makeSessionPayload();
+
+    const result = await uploadEntry(client, entry, payload);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(429);
+      expect(result.retryable).toBe(true);
+    }
+  });
+
+  it('returns non-retryable failure for 422 validation error', async () => {
+    stubFetch(422, { error: 'Validation failed' });
+
+    const client = createApiClient(baseUrl);
+    const entry = makeSessionEntry();
+    const payload = makeSessionPayload();
+
+    const result = await uploadEntry(client, entry, payload);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(422);
+      expect(result.message).toBe('Validation failed');
+      expect(result.retryable).toBe(false);
+    }
+  });
+
+  it('returns non-retryable failure for 401 unauthorized', async () => {
+    stubFetch(401, { error: 'Unauthorized' });
+
+    const client = createApiClient(baseUrl);
+    const entry = makeSessionEntry();
+    const payload = makeSessionPayload();
+
+    const result = await uploadEntry(client, entry, payload);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.retryable).toBe(false);
+    }
+  });
+
+  it('returns non-retryable failure for 400 bad request', async () => {
+    stubFetch(400, { error: 'Bad request' });
+
+    const client = createApiClient(baseUrl);
+    const entry = makeSessionEntry();
+    const payload = makeSessionPayload();
+
+    const result = await uploadEntry(client, entry, payload);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.retryable).toBe(false);
+    }
+  });
+
+  it('uses statusText when error body has no error field', async () => {
+    stubFetch(500, {});
+
+    const client = createApiClient(baseUrl);
+    const entry = makeSessionEntry();
+    const payload = makeSessionPayload();
+
+    const result = await uploadEntry(client, entry, payload);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe('Internal Server Error');
+    }
+  });
+
+  it('uses fallback message when error body is empty and no statusText', async () => {
+    const response: StubResponse = {
+      ok: false,
+      status: 500,
+      statusText: '',
+      headers: { get: (key: string) => key === 'content-type' ? 'application/json' : null },
+      json: () => Promise.resolve({}),
+      text: () => Promise.resolve('{}'),
+      clone: () => response,
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+
+    const client = createApiClient(baseUrl);
+    const entry = makeSessionEntry();
+    const payload = makeSessionPayload();
+
+    const result = await uploadEntry(client, entry, payload);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe('Upload failed');
+    }
+  });
+
+  it('returns not-implemented failure for unsupported entity types', async () => {
+    const client = createApiClient(baseUrl);
+    const payload = makeSessionPayload();
+
+    const unsupportedTypes = [
+      'breaks',
+      'encouragement_taps',
+      'user_preferences',
+      'long_term_goals',
+      'process_goals',
+    ] as const;
+
+    for (const entityType of unsupportedTypes) {
+      const entry = makeSessionEntry({ entityType });
+      const result = await uploadEntry(client, entry, payload);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(0);
+        expect(result.message).toContain(entityType);
+        expect(result.retryable).toBe(false);
+      }
+    }
+  });
+
+  it('sends minimal session payload (no optional fields)', async () => {
+    const responseBody = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      user_id: 'user-1',
+      process_goal_id: 'goal-1',
+      intention_text: null,
+      started_at: '2026-03-17T10:00:00Z',
+      ended_at: '2026-03-17T10:25:00Z',
+      completed: true,
+      abandonment_reason: null,
+      focus_quality: null,
+      distraction_type: null,
+      device_id: null,
+      created_at: '2026-03-17T10:25:00Z',
+    };
+
+    stubFetch(201, responseBody);
+
+    const client = createApiClient(baseUrl);
+    const entry = makeSessionEntry();
+    const payload: SessionPayload = {
+      started_at: '2026-03-17T10:00:00Z',
+      ended_at: '2026-03-17T10:25:00Z',
+    };
+
+    const result = await uploadEntry(client, entry, payload);
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('isRetryableStatus', () => {
+  it('returns true for 408 Request Timeout', () => {
+    expect(isRetryableStatus(408)).toBe(true);
+  });
+
+  it('returns true for 429 Too Many Requests', () => {
+    expect(isRetryableStatus(429)).toBe(true);
+  });
+
+  it('returns true for 500 Internal Server Error', () => {
+    expect(isRetryableStatus(500)).toBe(true);
+  });
+
+  it('returns true for 502 Bad Gateway', () => {
+    expect(isRetryableStatus(502)).toBe(true);
+  });
+
+  it('returns true for 503 Service Unavailable', () => {
+    expect(isRetryableStatus(503)).toBe(true);
+  });
+
+  it('returns false for 200 OK', () => {
+    expect(isRetryableStatus(200)).toBe(false);
+  });
+
+  it('returns false for 400 Bad Request', () => {
+    expect(isRetryableStatus(400)).toBe(false);
+  });
+
+  it('returns false for 401 Unauthorized', () => {
+    expect(isRetryableStatus(401)).toBe(false);
+  });
+
+  it('returns false for 404 Not Found', () => {
+    expect(isRetryableStatus(404)).toBe(false);
+  });
+
+  it('returns false for 422 Unprocessable Entity', () => {
+    expect(isRetryableStatus(422)).toBe(false);
+  });
+});
+
+describe('getSupportedEntityTypes', () => {
+  it('returns sessions as a supported entity type', () => {
+    const supported = getSupportedEntityTypes();
+    expect(supported).toContain('sessions');
+  });
+
+  it('returns a frozen array', () => {
+    const supported = getSupportedEntityTypes();
+    expect(Array.isArray(supported)).toBe(true);
+  });
+});

--- a/packages/data-access/src/sync/upload-driver.ts
+++ b/packages/data-access/src/sync/upload-driver.ts
@@ -28,6 +28,17 @@ type SessionPayload =
 
 type EntityPayload = SessionPayload;
 
+// ── Minimal Response Shape ──
+// openapi-fetch returns `Response` (DOM type) which is unresolvable without
+// "dom" in tsconfig lib. This package intentionally omits "dom" (it runs in
+// Node/CF Workers). We define only the fields we read so the compiler can
+// verify access without pulling in the DOM lib.
+
+type MinimalResponse = {
+  readonly status: number;
+  readonly statusText: string;
+};
+
 // ── Upload Logic ──
 
 /**
@@ -44,7 +55,7 @@ async function uploadEntry(
 ): Promise<UploadResult> {
   switch (entry.entityType) {
     case 'sessions':
-      return uploadSession(client, payload as SessionPayload);
+      return uploadSession(client, payload);
     case 'breaks':
     case 'encouragement_taps':
     case 'user_preferences':
@@ -67,14 +78,17 @@ async function uploadSession(
   client: ApiClient,
   payload: SessionPayload,
 ): Promise<UploadResult> {
-  const { data, error, response } = await client.POST('/v1/sessions', {
+  const result = await client.POST('/v1/sessions', {
     body: payload,
   });
 
-  if (data !== undefined) {
+  if (result.data !== undefined) {
     return { ok: true };
   }
 
+  // Cast to minimal shape — openapi-fetch response is always a standard
+  // Response at runtime; the DOM type is just unresolvable in our tsconfig.
+  const response = result.response as unknown as MinimalResponse;
   const status = response.status;
 
   // Server returns 409 for duplicate UUID — treat as success (idempotent write)
@@ -82,7 +96,8 @@ async function uploadSession(
     return { ok: true };
   }
 
-  const message = extractErrorMessage(error) ?? (response.statusText || 'Upload failed');
+  const message =
+    extractErrorMessage(result.error) ?? (response.statusText !== '' ? response.statusText : 'Upload failed');
 
   return {
     ok: false,

--- a/packages/data-access/src/sync/upload-driver.ts
+++ b/packages/data-access/src/sync/upload-driver.ts
@@ -1,0 +1,123 @@
+// Sync upload driver — sends outbox entries to the Hono API via openapi-fetch (ADR-006, ADR-007).
+// IO driver only. Pure sync FSM lives in packages/core/sync/.
+// No direct Supabase imports (PKG-D02). No React imports (PKG-D04).
+
+import type { ApiClient } from '../client';
+import type { OutboxEntry, SyncableEntityType } from '@pomofocus/core';
+import type { paths } from '../generated/api-types';
+
+// ── Result Types ──
+
+type UploadSuccess = {
+  readonly ok: true;
+};
+
+type UploadFailure = {
+  readonly ok: false;
+  readonly status: number;
+  readonly message: string;
+  readonly retryable: boolean;
+};
+
+type UploadResult = UploadSuccess | UploadFailure;
+
+// ── Payload Types ──
+
+type SessionPayload =
+  paths['/v1/sessions']['post']['requestBody']['content']['application/json'];
+
+type EntityPayload = SessionPayload;
+
+// ── Upload Logic ──
+
+/**
+ * Uploads a single outbox entry to the API.
+ *
+ * Routes to the correct endpoint based on `entry.entityType`.
+ * Returns a result object — never throws for expected failures.
+ * Duplicate UUIDs (409) are treated as success (idempotent writes per ADR-007).
+ */
+async function uploadEntry(
+  client: ApiClient,
+  entry: OutboxEntry,
+  payload: EntityPayload,
+): Promise<UploadResult> {
+  switch (entry.entityType) {
+    case 'sessions':
+      return uploadSession(client, payload as SessionPayload);
+    case 'breaks':
+    case 'encouragement_taps':
+    case 'user_preferences':
+    case 'long_term_goals':
+    case 'process_goals':
+      return {
+        ok: false,
+        status: 0,
+        message: `Upload not yet implemented for entity type: ${entry.entityType}`,
+        retryable: false,
+      };
+    default: {
+      const _exhaustive: never = entry.entityType;
+      return _exhaustive;
+    }
+  }
+}
+
+async function uploadSession(
+  client: ApiClient,
+  payload: SessionPayload,
+): Promise<UploadResult> {
+  const { data, error, response } = await client.POST('/v1/sessions', {
+    body: payload,
+  });
+
+  if (data !== undefined) {
+    return { ok: true };
+  }
+
+  const status = response.status;
+
+  // Server returns 409 for duplicate UUID — treat as success (idempotent write)
+  if (status === 409) {
+    return { ok: true };
+  }
+
+  const message = extractErrorMessage(error) ?? (response.statusText || 'Upload failed');
+
+  return {
+    ok: false,
+    status,
+    message,
+    retryable: isRetryableStatus(status),
+  };
+}
+
+// ── Helpers ──
+
+function extractErrorMessage(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+
+  if ('error' in error && typeof error.error === 'string' && error.error.length > 0) {
+    return error.error;
+  }
+
+  return undefined;
+}
+
+function isRetryableStatus(status: number): boolean {
+  // 408 Request Timeout, 429 Too Many Requests, 5xx Server Errors
+  if (status === 408 || status === 429) {
+    return true;
+  }
+  return status >= 500;
+}
+
+/** Returns the set of entity types that have upload implementations. */
+function getSupportedEntityTypes(): readonly SyncableEntityType[] {
+  return ['sessions'] as const;
+}
+
+export { uploadEntry, isRetryableStatus, getSupportedEntityTypes };
+export type { UploadResult, UploadSuccess, UploadFailure, EntityPayload, SessionPayload };


### PR DESCRIPTION
## Summary

Implements the IO driver that uploads outbox entries from the sync queue to the Hono API. Wires the pure sync FSM in `packages/core/src/sync/` to the network layer per ADR-006 and ADR-007.

## Changes

- **`packages/data-access/src/sync/upload-driver.ts`** — new driver:
  - `uploadEntry(entry)` sends session data via openapi-fetch (uses the existing auth token refresh interceptor)
  - Returns a result object (`{ ok, status, message, retryable }`) rather than throwing on expected failures
  - Treats 409 (duplicate UUID) as success for idempotency — server uses `ON CONFLICT (id) DO NOTHING`
- **`packages/data-access/src/sync/upload-driver.test.ts`** — tests covering success, duplicate UUID, 4xx/5xx failures, retryable flag logic
- **`packages/data-access/src/sync/index.ts`** — sync barrel
- **`packages/data-access/src/index.ts`** — re-export the new sync surface

No direct Supabase imports (PKG-D02). No React imports (PKG-D04). The pure sync FSM in `packages/core/src/sync/` is untouched.

Closes #396

## Test plan

- [x] `pnpm nx test @pomofocus/data-access` — 140 tests pass
- [x] `pnpm nx type-check @pomofocus/data-access` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)