### PR TITLE
feat: network connectivity detector for sync (#400)

### DIFF
--- a/packages/data-access/src/index.ts
+++ b/packages/data-access/src/index.ts
@@ -55,3 +55,5 @@ export {
   REFRESH_BUFFER_SECONDS,
 } from './auth/token-refresh';
 export type { TokenRefreshDeps } from './auth/token-refresh';
+export { isOnline, onNetworkAvailable } from './sync/network-detector';
+export type { NetworkCallback, Unsubscribe as NetworkUnsubscribe } from './sync/network-detector';

--- a/packages/data-access/src/sync/network-detector.test.ts
+++ b/packages/data-access/src/sync/network-detector.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isOnline, onNetworkAvailable } from './network-detector';
+
+describe('isOnline', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns true when navigator.onLine is true', () => {
+    vi.stubGlobal('navigator', { onLine: true });
+
+    expect(isOnline()).toBe(true);
+  });
+
+  it('returns false when navigator.onLine is false', () => {
+    vi.stubGlobal('navigator', { onLine: false });
+
+    expect(isOnline()).toBe(false);
+  });
+
+  it('returns true when navigator is undefined (non-browser environment)', () => {
+    vi.stubGlobal('navigator', undefined);
+
+    expect(isOnline()).toBe(true);
+  });
+});
+
+describe('onNetworkAvailable', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('registers an online event listener and fires callback on online event', () => {
+    const listeners: { type: string; callback: () => void }[] = [];
+
+    vi.stubGlobal(
+      'addEventListener',
+      vi.fn((type: string, callback: () => void) => {
+        listeners.push({ type, callback });
+      }),
+    );
+    vi.stubGlobal('removeEventListener', vi.fn());
+
+    const callback = vi.fn();
+    onNetworkAvailable(callback);
+
+    expect(globalThis.addEventListener).toHaveBeenCalledWith('online', callback);
+
+    const listener = listeners.find((l) => l.type === 'online');
+    expect(listener).toBeDefined();
+    listener?.callback();
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it('returns an unsubscribe function that removes the listener', () => {
+    vi.stubGlobal('addEventListener', vi.fn());
+    vi.stubGlobal('removeEventListener', vi.fn());
+
+    const callback = vi.fn();
+    const unsubscribe = onNetworkAvailable(callback);
+
+    unsubscribe();
+
+    expect(globalThis.removeEventListener).toHaveBeenCalledWith('online', callback);
+  });
+
+  it('returns a no-op unsubscribe when addEventListener is not available', () => {
+    vi.stubGlobal('addEventListener', undefined);
+
+    const callback = vi.fn();
+    const unsubscribe = onNetworkAvailable(callback);
+
+    // Should not throw
+    unsubscribe();
+
+    // Callback should never have been called
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('does not fire callback until online event occurs', () => {
+    vi.stubGlobal('addEventListener', vi.fn());
+    vi.stubGlobal('removeEventListener', vi.fn());
+
+    const callback = vi.fn();
+    onNetworkAvailable(callback);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('allows multiple callbacks to be registered independently', () => {
+    const listeners: { type: string; callback: () => void }[] = [];
+
+    vi.stubGlobal(
+      'addEventListener',
+      vi.fn((type: string, callback: () => void) => {
+        listeners.push({ type, callback });
+      }),
+    );
+    vi.stubGlobal('removeEventListener', vi.fn());
+
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+
+    onNetworkAvailable(callback1);
+    onNetworkAvailable(callback2);
+
+    expect(globalThis.addEventListener).toHaveBeenCalledTimes(2);
+
+    for (const listener of listeners) {
+      listener.callback();
+    }
+
+    expect(callback1).toHaveBeenCalledOnce();
+    expect(callback2).toHaveBeenCalledOnce();
+  });
+
+  it('unsubscribing one callback does not affect others', () => {
+    vi.stubGlobal('addEventListener', vi.fn());
+    vi.stubGlobal('removeEventListener', vi.fn());
+
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+
+    const unsubscribe1 = onNetworkAvailable(callback1);
+    onNetworkAvailable(callback2);
+
+    unsubscribe1();
+
+    expect(globalThis.removeEventListener).toHaveBeenCalledWith('online', callback1);
+    expect(globalThis.removeEventListener).not.toHaveBeenCalledWith('online', callback2);
+  });
+});

--- a/packages/data-access/src/sync/network-detector.test.ts
+++ b/packages/data-access/src/sync/network-detector.test.ts
@@ -33,18 +33,16 @@ describe('onNetworkAvailable', () => {
   it('registers an online event listener and fires callback on online event', () => {
     const listeners: { type: string; callback: () => void }[] = [];
 
-    vi.stubGlobal(
-      'addEventListener',
-      vi.fn((type: string, callback: () => void) => {
-        listeners.push({ type, callback });
-      }),
-    );
+    const addSpy = vi.fn((type: string, callback: () => void) => {
+      listeners.push({ type, callback });
+    });
+    vi.stubGlobal('addEventListener', addSpy);
     vi.stubGlobal('removeEventListener', vi.fn());
 
     const callback = vi.fn();
     onNetworkAvailable(callback);
 
-    expect(globalThis.addEventListener).toHaveBeenCalledWith('online', callback);
+    expect(addSpy).toHaveBeenCalledWith('online', callback);
 
     const listener = listeners.find((l) => l.type === 'online');
     expect(listener).toBeDefined();
@@ -53,15 +51,17 @@ describe('onNetworkAvailable', () => {
   });
 
   it('returns an unsubscribe function that removes the listener', () => {
-    vi.stubGlobal('addEventListener', vi.fn());
-    vi.stubGlobal('removeEventListener', vi.fn());
+    const addSpy = vi.fn();
+    const removeSpy = vi.fn();
+    vi.stubGlobal('addEventListener', addSpy);
+    vi.stubGlobal('removeEventListener', removeSpy);
 
     const callback = vi.fn();
     const unsubscribe = onNetworkAvailable(callback);
 
     unsubscribe();
 
-    expect(globalThis.removeEventListener).toHaveBeenCalledWith('online', callback);
+    expect(removeSpy).toHaveBeenCalledWith('online', callback);
   });
 
   it('returns a no-op unsubscribe when addEventListener is not available', () => {
@@ -90,12 +90,10 @@ describe('onNetworkAvailable', () => {
   it('allows multiple callbacks to be registered independently', () => {
     const listeners: { type: string; callback: () => void }[] = [];
 
-    vi.stubGlobal(
-      'addEventListener',
-      vi.fn((type: string, callback: () => void) => {
-        listeners.push({ type, callback });
-      }),
-    );
+    const addSpy = vi.fn((type: string, callback: () => void) => {
+      listeners.push({ type, callback });
+    });
+    vi.stubGlobal('addEventListener', addSpy);
     vi.stubGlobal('removeEventListener', vi.fn());
 
     const callback1 = vi.fn();
@@ -104,7 +102,7 @@ describe('onNetworkAvailable', () => {
     onNetworkAvailable(callback1);
     onNetworkAvailable(callback2);
 
-    expect(globalThis.addEventListener).toHaveBeenCalledTimes(2);
+    expect(addSpy).toHaveBeenCalledTimes(2);
 
     for (const listener of listeners) {
       listener.callback();
@@ -115,8 +113,10 @@ describe('onNetworkAvailable', () => {
   });
 
   it('unsubscribing one callback does not affect others', () => {
-    vi.stubGlobal('addEventListener', vi.fn());
-    vi.stubGlobal('removeEventListener', vi.fn());
+    const addSpy = vi.fn();
+    const removeSpy = vi.fn();
+    vi.stubGlobal('addEventListener', addSpy);
+    vi.stubGlobal('removeEventListener', removeSpy);
 
     const callback1 = vi.fn();
     const callback2 = vi.fn();
@@ -126,7 +126,7 @@ describe('onNetworkAvailable', () => {
 
     unsubscribe1();
 
-    expect(globalThis.removeEventListener).toHaveBeenCalledWith('online', callback1);
-    expect(globalThis.removeEventListener).not.toHaveBeenCalledWith('online', callback2);
+    expect(removeSpy).toHaveBeenCalledWith('online', callback1);
+    expect(removeSpy).not.toHaveBeenCalledWith('online', callback2);
   });
 });

--- a/packages/data-access/src/sync/network-detector.ts
+++ b/packages/data-access/src/sync/network-detector.ts
@@ -2,27 +2,25 @@
 // Uses navigator.onLine + online/offline events for web.
 // No React imports (PKG-D04).
 //
-// Minimal global augmentation for browser APIs used by this module.
-// The project uses lib: ["esnext"] without DOM, so navigator/addEventListener
-// are not typed on globalThis. These declarations cover only what we use.
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface Window {
-    navigator?: { readonly onLine: boolean };
-    addEventListener?(type: string, listener: () => void): void;
-    removeEventListener?(type: string, listener: () => void): void;
-  }
-
-  // Augment globalThis with the same shape
-  var navigator: { readonly onLine: boolean } | undefined;
-  function addEventListener(type: string, listener: () => void): void;
-  function removeEventListener(type: string, listener: () => void): void;
-}
+// Runtime feature-detection only — no `declare global` augmentation.
+// The data-access package uses lib: ["esnext"] without DOM types, but
+// downstream consumers (apps/web, packages/state) include DOM. A global
+// augmentation that narrows `navigator` to `{ readonly onLine: boolean }`
+// conflicts with the full `Navigator` type from lib.dom.d.ts, breaking
+// type-check in those packages. Instead we access browser globals through
+// `globalThis` cast to `unknown` and use runtime typeof guards.
 
 type NetworkCallback = () => void;
 
 type Unsubscribe = () => void;
+
+// Typed accessor for globalThis in environments that may or may not have DOM.
+// Cast through `unknown` avoids conflict with both DOM and non-DOM tsconfigs.
+const _global = globalThis as unknown as {
+  navigator?: { readonly onLine: boolean };
+  addEventListener?: (type: string, listener: () => void) => void;
+  removeEventListener?: (type: string, listener: () => void) => void;
+};
 
 /**
  * Synchronous check for current network connectivity.
@@ -30,11 +28,11 @@ type Unsubscribe = () => void;
  * (assumes online in non-browser environments like Node.js).
  */
 function isOnline(): boolean {
-  if (typeof navigator === 'undefined') {
+  if (typeof _global.navigator === 'undefined') {
     return true;
   }
 
-  return navigator.onLine;
+  return _global.navigator.onLine;
 }
 
 /**
@@ -46,15 +44,17 @@ function isOnline(): boolean {
  * Returns an unsubscribe function to remove the listener.
  */
 function onNetworkAvailable(callback: NetworkCallback): Unsubscribe {
-  if (typeof globalThis.addEventListener !== 'function') {
+  if (typeof _global.addEventListener !== 'function') {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     return () => {};
   }
 
-  globalThis.addEventListener('online', callback);
+  _global.addEventListener('online', callback);
 
   return () => {
-    globalThis.removeEventListener('online', callback);
+    if (typeof _global.removeEventListener === 'function') {
+      _global.removeEventListener('online', callback);
+    }
   };
 }
 

--- a/packages/data-access/src/sync/network-detector.ts
+++ b/packages/data-access/src/sync/network-detector.ts
@@ -1,0 +1,62 @@
+// Network connectivity detector for sync queue drain (ADR-006).
+// Uses navigator.onLine + online/offline events for web.
+// No React imports (PKG-D04).
+//
+// Minimal global augmentation for browser APIs used by this module.
+// The project uses lib: ["esnext"] without DOM, so navigator/addEventListener
+// are not typed on globalThis. These declarations cover only what we use.
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  interface Window {
+    navigator?: { readonly onLine: boolean };
+    addEventListener?(type: string, listener: () => void): void;
+    removeEventListener?(type: string, listener: () => void): void;
+  }
+
+  // Augment globalThis with the same shape
+  var navigator: { readonly onLine: boolean } | undefined;
+  function addEventListener(type: string, listener: () => void): void;
+  function removeEventListener(type: string, listener: () => void): void;
+}
+
+type NetworkCallback = () => void;
+
+type Unsubscribe = () => void;
+
+/**
+ * Synchronous check for current network connectivity.
+ * Returns true if navigator.onLine is true or navigator is unavailable
+ * (assumes online in non-browser environments like Node.js).
+ */
+function isOnline(): boolean {
+  if (typeof navigator === 'undefined') {
+    return true;
+  }
+
+  return navigator.onLine;
+}
+
+/**
+ * Registers a callback that fires when network connectivity is restored.
+ * Uses the browser `online` event. In non-browser environments (Node.js,
+ * tests), the callback is never automatically fired — callers must invoke
+ * it manually or use platform-specific detection.
+ *
+ * Returns an unsubscribe function to remove the listener.
+ */
+function onNetworkAvailable(callback: NetworkCallback): Unsubscribe {
+  if (typeof globalThis.addEventListener !== 'function') {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
+  }
+
+  globalThis.addEventListener('online', callback);
+
+  return () => {
+    globalThis.removeEventListener('online', callback);
+  };
+}
+
+export { isOnline, onNetworkAvailable };
+export type { NetworkCallback, Unsubscribe };


### PR DESCRIPTION
## Summary

Implements a network connectivity detector so the sync engine can drain the outbox queue when the device comes back online. Per ADR-006, this is the IO layer that complements the pure sync FSM in `packages/core/src/sync/`.

## Changes

- **`packages/data-access/src/sync/network-detector.ts`**:
  - `onNetworkAvailable(callback)` — subscribes via `window.addEventListener('online', ...)`; returns an unsubscribe handle
  - `isOnline()` — synchronous check against `navigator.onLine`
- **`packages/data-access/src/sync/network-detector.test.ts`** — tests covering online/offline transitions, subscribe/unsubscribe lifecycle, and safe teardown
- **`packages/data-access/src/index.ts`** — export the new detector

Web-only for v1. React Native NetInfo integration is deferred to Phase 4 per issue scope.

No React imports (PKG-D04).

Closes #400

## Test plan

- [x] `pnpm nx test @pomofocus/data-access` — 125 tests pass
- [x] `pnpm nx type-check @pomofocus/data-access` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)