### PR TITLE
feat: implement goal selection UI for pre-session flow (#385)

### DIFF
--- a/apps/web/app/components/goal-selector.test.tsx
+++ b/apps/web/app/components/goal-selector.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import type { ProcessGoal } from '@pomofocus/core';
+import { GoalSelector } from './goal-selector.js';
+
+function makeGoal(overrides: Partial<ProcessGoal> = {}): ProcessGoal {
+  return {
+    id: 'goal-1',
+    longTermGoalId: 'lt-1',
+    userId: 'user-1',
+    title: 'Study calculus',
+    targetSessionsPerDay: 3,
+    recurrence: 'daily',
+    status: 'active',
+    sortOrder: 0,
+    createdAt: '2026-03-17T10:00:00Z',
+    updatedAt: '2026-03-17T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('GoalSelector', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a list of process goals by title', () => {
+    const goals: readonly ProcessGoal[] = [
+      makeGoal({ id: 'goal-1', title: 'Study calculus' }),
+      makeGoal({ id: 'goal-2', title: 'Write essay' }),
+      makeGoal({ id: 'goal-3', title: 'Practice piano' }),
+    ];
+
+    render(
+      <GoalSelector goals={goals} selectedGoalId={null} onSelect={vi.fn()} />,
+    );
+
+    expect(screen.getByText('Study calculus')).toBeDefined();
+    expect(screen.getByText('Write essay')).toBeDefined();
+    expect(screen.getByText('Practice piano')).toBeDefined();
+  });
+
+  it('renders an empty state when no goals are provided', () => {
+    render(
+      <GoalSelector goals={[]} selectedGoalId={null} onSelect={vi.fn()} />,
+    );
+
+    expect(screen.getByText('No goals yet')).toBeDefined();
+  });
+
+  it('calls onSelect with the goal id when a goal is pressed', () => {
+    const onSelect = vi.fn();
+    const goals: readonly ProcessGoal[] = [
+      makeGoal({ id: 'goal-1', title: 'Study calculus' }),
+      makeGoal({ id: 'goal-2', title: 'Write essay' }),
+    ];
+
+    render(
+      <GoalSelector goals={goals} selectedGoalId={null} onSelect={onSelect} />,
+    );
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Write essay' }));
+
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith('goal-2');
+  });
+
+  it('marks only the selected goal as selected (radio-style, exactly one)', () => {
+    const goals: readonly ProcessGoal[] = [
+      makeGoal({ id: 'goal-1', title: 'Study calculus' }),
+      makeGoal({ id: 'goal-2', title: 'Write essay' }),
+      makeGoal({ id: 'goal-3', title: 'Practice piano' }),
+    ];
+
+    render(
+      <GoalSelector
+        goals={goals}
+        selectedGoalId="goal-2"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const radios = screen.getAllByRole('radio');
+    const selectedRadios = radios.filter(
+      (el) => el.getAttribute('aria-checked') === 'true',
+    );
+
+    expect(selectedRadios).toHaveLength(1);
+    expect(selectedRadios[0]?.getAttribute('aria-label')).toBe('Write essay');
+  });
+
+  it('renders no selected radio when selectedGoalId is null', () => {
+    const goals: readonly ProcessGoal[] = [
+      makeGoal({ id: 'goal-1', title: 'Study calculus' }),
+      makeGoal({ id: 'goal-2', title: 'Write essay' }),
+    ];
+
+    render(
+      <GoalSelector goals={goals} selectedGoalId={null} onSelect={vi.fn()} />,
+    );
+
+    const radios = screen.getAllByRole('radio');
+    const selectedRadios = radios.filter(
+      (el) => el.getAttribute('aria-checked') === 'true',
+    );
+
+    expect(selectedRadios).toHaveLength(0);
+  });
+
+  it('visually highlights the selected goal with different text styling', () => {
+    const goals: readonly ProcessGoal[] = [
+      makeGoal({ id: 'goal-1', title: 'Study calculus' }),
+      makeGoal({ id: 'goal-2', title: 'Write essay' }),
+    ];
+
+    const { rerender } = render(
+      <GoalSelector goals={goals} selectedGoalId="goal-1" onSelect={vi.fn()} />,
+    );
+
+    const selectedRadio = screen.getByRole('radio', { name: 'Study calculus' });
+    expect(selectedRadio.getAttribute('aria-checked')).toBe('true');
+
+    rerender(
+      <GoalSelector goals={goals} selectedGoalId="goal-2" onSelect={vi.fn()} />,
+    );
+
+    const newSelectedRadio = screen.getByRole('radio', { name: 'Write essay' });
+    expect(newSelectedRadio.getAttribute('aria-checked')).toBe('true');
+
+    const previouslySelected = screen.getByRole('radio', { name: 'Study calculus' });
+    expect(previouslySelected.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('assigns a testID for each goal option', () => {
+    const goals: readonly ProcessGoal[] = [
+      makeGoal({ id: 'goal-abc', title: 'Study calculus' }),
+    ];
+
+    render(
+      <GoalSelector goals={goals} selectedGoalId={null} onSelect={vi.fn()} />,
+    );
+
+    expect(screen.getByTestId('goal-option-goal-abc')).toBeDefined();
+  });
+});

--- a/apps/web/app/components/goal-selector.tsx
+++ b/apps/web/app/components/goal-selector.tsx
@@ -1,0 +1,90 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import type { ProcessGoal } from '@pomofocus/core';
+
+type GoalSelectorProps = {
+  readonly goals: readonly ProcessGoal[];
+  readonly selectedGoalId: string | null;
+  readonly onSelect: (goalId: string) => void;
+};
+
+function GoalSelector({
+  goals,
+  selectedGoalId,
+  onSelect,
+}: GoalSelectorProps): React.JSX.Element {
+  if (goals.length === 0) {
+    return (
+      <View testID="goal-selector" style={styles.container}>
+        <Text style={styles.heading}>Select a goal</Text>
+        <Text testID="goal-selector-empty">No goals yet</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      testID="goal-selector"
+      role="radiogroup"
+      accessibilityLabel="Select a goal"
+      style={styles.container}
+    >
+      <Text style={styles.heading}>Select a goal</Text>
+      {goals.map((goal) => {
+        const isSelected = goal.id === selectedGoalId;
+
+        return (
+          <Pressable
+            key={goal.id}
+            testID={`goal-option-${goal.id}`}
+            role="radio"
+            aria-checked={isSelected}
+            accessibilityLabel={goal.title}
+            onPress={() => {
+              onSelect(goal.id);
+            }}
+            style={[styles.option, isSelected && styles.optionSelected]}
+          >
+            <Text style={isSelected ? styles.optionTextSelected : styles.optionText}>
+              {goal.title}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 16,
+  },
+  heading: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  option: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  optionSelected: {
+    borderColor: '#2563eb',
+    backgroundColor: '#eff6ff',
+  },
+  optionText: {
+    fontSize: 14,
+    color: '#111827',
+  },
+  optionTextSelected: {
+    fontSize: 14,
+    color: '#1d4ed8',
+    fontWeight: '600',
+  },
+});
+
+export { GoalSelector };
+export type { GoalSelectorProps };

--- a/apps/web/app/index.tsx
+++ b/apps/web/app/index.tsx
@@ -1,21 +1,65 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { createApiClient } from '@pomofocus/data-access';
+import { useTimerStore } from '@pomofocus/state';
+import { TIMER_STATUS } from '@pomofocus/core';
+import type { ProcessGoal } from '@pomofocus/core';
 import { TimerDisplay } from './components/timer-display';
 import { TimerControls } from './components/timer-controls';
 import { SessionList } from './components/session-list';
+import { GoalSelector } from './components/goal-selector';
 
 const API_BASE_URL: string =
   process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8787';
 
+// Mocked goal data until Stream C delivers the goals state hooks.
+// See issue #385: "If not yet available, mock the data for now and wire later."
+const MOCK_GOALS: readonly ProcessGoal[] = [
+  {
+    id: 'mock-goal-1',
+    longTermGoalId: 'mock-lt-1',
+    userId: 'mock-user',
+    title: 'Deep work',
+    targetSessionsPerDay: 4,
+    recurrence: 'daily',
+    status: 'active',
+    sortOrder: 0,
+    createdAt: '2026-04-05T00:00:00Z',
+    updatedAt: '2026-04-05T00:00:00Z',
+  },
+  {
+    id: 'mock-goal-2',
+    longTermGoalId: 'mock-lt-1',
+    userId: 'mock-user',
+    title: 'Writing practice',
+    targetSessionsPerDay: 2,
+    recurrence: 'daily',
+    status: 'active',
+    sortOrder: 1,
+    createdAt: '2026-04-05T00:00:00Z',
+    updatedAt: '2026-04-05T00:00:00Z',
+  },
+];
+
 export default function HomeScreen(): React.JSX.Element {
   const client = useMemo(() => createApiClient(API_BASE_URL), []);
+  const timerStatus = useTimerStore((s) => s.state.status);
+  const [selectedGoalId, setSelectedGoalId] = useState<string | null>(null);
+
+  const isIdle = timerStatus === TIMER_STATUS.IDLE;
 
   return (
     <View style={styles.container}>
       <View style={styles.timerSection}>
         <Text style={styles.title}>PomoFocus</Text>
         <TimerDisplay />
+        {isIdle && (
+          <GoalSelector
+            goals={MOCK_GOALS}
+            selectedGoalId={selectedGoalId}
+            onSelect={setSelectedGoalId}
+          />
+        )}
         <TimerControls />
       </View>
       <View style={styles.sessionsSection}>


### PR DESCRIPTION
## Summary

- Adds `GoalSelector` component (`apps/web/app/components/goal-selector.tsx`) — a radio-style list of process goals with visual highlight on selection
- Integrates goal selector into home screen, visible only when timer is idle
- Mocks goal data until Stream C delivers goals state hooks from `packages/state/`

Closes #385

## Test plan

- [ ] `pnpm nx test @pomofocus/web` passes (6 tests in `goal-selector.test.tsx`)
- [ ] `pnpm nx type-check @pomofocus/web` exits clean
- [ ] Goal selector renders list of goals, allows single selection (radio behavior)
- [ ] Goal selector only appears when timer status is `idle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)